### PR TITLE
Add private /jasiu/ subpage with Granada study notes

### DIFF
--- a/jasiu/granada/osteoarticular-sistemicas/index.html
+++ b/jasiu/granada/osteoarticular-sistemicas/index.html
@@ -1,0 +1,6621 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skrypt — Patología Osteoarticular y Enfermedades Sistémicas</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="hero">
+  <h1>📚 Patología Osteoarticular y Enfermedades Sistémicas</h1>
+  <div class="subtitle">Apuntes integrales · Universidad de Granada · 5º Grado en Medicina</div>
+  <div class="hero-meta">
+    <span class="chip">🎓 Para: Jan Fedak</span>
+    <span class="chip">📅 Convocatoria mayo–junio 2026</span>
+    <span class="chip">📖 Bloque A1 · Sistémicas</span>
+    <span class="chip">🦴 Bloque A2 · Reumatología</span>
+    <span class="chip">🩹 Bloque B · Traumatología</span>
+    <span class="chip">❓ +200 preguntas resueltas</span>
+  </div>
+</header>
+
+<div class="wrap">
+
+<!-- ===================== SIDEBAR ===================== -->
+<nav class="sidebar" id="toc">
+  <h3>Índice general</h3>
+  <div class="toc-search"><input id="tocSearch" type="text" placeholder="Buscar tema..." aria-label="Buscar tema"></div>
+  <ol id="tocList">
+    <li class="group-title">Bloque A1 · Sistémicas</li>
+    <li><a href="#t1">1. Aspectos generales EAS</a></li>
+    <li><a href="#t2">2. Acrosíndromes</a></li>
+    <li><a href="#t3">3. LES</a></li>
+    <li><a href="#t4">4. SAF</a></li>
+    <li><a href="#t5">5. Sjögren</a></li>
+    <li><a href="#t6">6. Esclerodermia</a></li>
+    <li><a href="#t7">7. Miopatías inflamatorias</a></li>
+    <li><a href="#t8">8. EMTC y CTI</a></li>
+    <li><a href="#t9">9. Vasculitis sistémicas</a></li>
+    <li><a href="#t10">10. Sarcoidosis</a></li>
+    <li class="group-title">Bloque A2 · Reumatología</li>
+    <li><a href="#t11">11. Generales y semiología</a></li>
+    <li><a href="#t12">12. AR y AIJ</a></li>
+    <li><a href="#t13">13. Espondiloartritis</a></li>
+    <li><a href="#t14">14. Artrosis</a></li>
+    <li><a href="#t15">15. Microcristalinas</a></li>
+    <li><a href="#t16">16. Autoinflamatorios</a></li>
+    <li><a href="#t17">17. Metabolismo óseo</a></li>
+    <li><a href="#t18">18. Reumáticas vasculares</a></li>
+    <li><a href="#t19">19. Locorregionales</a></li>
+    <li><a href="#t20">20. Fibromialgia</a></li>
+    <li><a href="#t21">21. Embarazo</a></li>
+    <li class="group-title">Bloque B · Traumatología</li>
+    <li><a href="#t22">22. Fracturas — generalidades</a></li>
+    <li><a href="#t23">23. Tratamiento y complicaciones</a></li>
+    <li><a href="#t24">24. Fisiopatología articular</a></li>
+    <li><a href="#t25">25. Traumatismos articulares</a></li>
+    <li><a href="#t26">26. Cirugía articular</a></li>
+    <li><a href="#t27">27. Pelvis</a></li>
+    <li><a href="#t28">28. Luxación cadera</a></li>
+    <li><a href="#t29">29. Fractura cadera</a></li>
+    <li><a href="#t30">30. Cadera dolorosa</a></li>
+    <li><a href="#t31">31. Muslo, rodilla, pierna</a></li>
+    <li><a href="#t32">32. Tobillo y pie</a></li>
+    <li><a href="#t33">33. Inmovilizaciones</a></li>
+    <li class="group-title">Final</li>
+    <li><a href="#final">⭐ Consejos finales</a></li>
+  </ol>
+</nav>
+
+<main>
+
+<!-- ============================================================ -->
+<!-- BLOQUE A1 -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-a1">
+  <h2>🧬 BLOQUE A1 · Enfermedades Autoinmunes Sistémicas</h2>
+  <div class="b-sub">10 temas · LES, SAF, Sjögren, esclerodermia, miopatías, EMTC, vasculitis, sarcoidosis…</div>
+</div>
+
+<!-- =============== TEMA 1: Aspectos generales =============== -->
+<section class="card" id="t1">
+<h2 class="section-title"><span class="num">1</span>Aspectos generales de las enfermedades autoinmunes sistémicas</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés — lo que cae sí o sí</div>
+  <ul>
+    <li><strong>Concepto:</strong> respuesta inmune aberrante frente a constituyentes propios → inflamación + daño tisular.</li>
+    <li><strong>Autoinmunidad ≠ enfermedad autoinmune.</strong> La autoinmunidad existe en todos y aumenta con la edad.</li>
+    <li><strong>Clasificación:</strong> organoespecíficas (Hashimoto, PTI, AHAI, pénfigo) vs <em>sistémicas (EAS)</em>: LES, Sjögren, esclerodermia, EMTC, miopatías, vasculitis.</li>
+    <li><strong>Predominio femenino</strong> (LES 9-10:1; ES 4:1; AR 3:1), excepto DM tipo 1, EA y CBP.</li>
+    <li><strong>Etiopatogenia multifactorial:</strong> genética (poligénica) + sexo femenino + ambiente + alteración Treg (FOXP3).</li>
+    <li><strong>Curso progresivo</strong> (no explosivo), con solapamiento y agregación familiar.</li>
+    <li><strong>Los criterios clasificatorios NO son diagnósticos</strong> — son para investigación.</li>
+  </ul>
+</div>
+
+<h3>1.1 Mecanismos de autoinmunidad asociada a infecciones</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Mimetismo molecular</span><span class="v">Antígenos microbianos similares a propios → reactividad cruzada. <em>Ej.: estreptococo β-hemolítico A → fiebre reumática.</em></span></div>
+  <div class="kv"><span class="k">Diseminación del epítopo</span><span class="v">Infección persistente → daño tisular → exposición de antígenos propios.</span></div>
+  <div class="kv"><span class="k">Antígenos crípticos</span><span class="v">El daño libera autoantígenos previamente ocultos.</span></div>
+  <div class="kv"><span class="k">Activación del espectador</span><span class="v">Superantígeno activa policlonalmente linfocitos T y B.</span></div>
+</div>
+
+<h3>1.2 Asociaciones HLA con valor práctico</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>HLA</th><th>Enfermedad</th></tr></thead>
+<tbody>
+<tr><td><strong>HLA-B27</strong></td><td>Espondiloartritis</td></tr>
+<tr><td><strong>HLA-B51</strong></td><td>Enfermedad de Behçet</td></tr>
+<tr><td><strong>HLA-A29</strong></td><td>Coroidopatía en perdigonada (birdshot)</td></tr>
+<tr><td><strong>HLA-DQ2 / DQ8</strong></td><td>Enfermedad celíaca</td></tr>
+<tr><td><strong>HLA-DR3 / B8</strong></td><td>Predisposición a LES</td></tr>
+<tr><td><strong>HLA-DR4</strong> (epítopo compartido)</td><td>Artritis reumatoide</td></tr>
+</tbody></table></div>
+
+<h3>1.3 Autoanticuerpos — la chuleta que vale por mil</h3>
+
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🧪</span>Técnicas y orden del laboratorio</div>
+  <p style="margin:6px 0"><strong>ELISA/CLIA genérico</strong> → si (+) <strong>IFI sobre HEp-2</strong> (gold standard por sensibilidad; positivo si título ≥ 1/80) → si (+) <strong>ELISA específico</strong>.</p>
+</div>
+
+<h4>Patrones de IFI sobre HEp-2</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Patrón</th><th>Antígenos</th><th>Asociación clínica</th></tr></thead>
+<tbody>
+<tr><td><strong>Homogéneo</strong></td><td>DNA nativo, histonas</td><td>LES, LES inducido por fármacos</td></tr>
+<tr><td><strong>Moteado</strong></td><td>U1-RNP, SSA/Ro, SSB/La, Sm, Scl-70, Mi-2</td><td>LES, Sjögren, EMTC, miopatías</td></tr>
+<tr><td><strong>Centromérico</strong></td><td>CENP-B</td><td>Esclerodermia limitada, CBP</td></tr>
+<tr><td><strong>Nucleolar</strong></td><td>PM/Scl, RNA pol I, U3-RNP, Ku</td><td>Esclerodermia (sobre todo difusa), miopatías</td></tr>
+<tr><td><strong>Citoplásmico</strong></td><td>P-ribosomal, Jo-1, RNA-sintetasas, SRP</td><td>LES (SNC), miopatías inflamatorias, CBP</td></tr>
+</tbody></table></div>
+
+<h4>Autoanticuerpos clave (memorizar)</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Anticuerpo</th><th>Asociación</th><th>Significado</th></tr></thead>
+<tbody>
+<tr><td><strong>Anti-DNAn (ds-DNA)</strong></td><td>LES (70-80 %)</td><td>Muy específico a títulos altos · correlaciona con <em>actividad y nefritis</em></td></tr>
+<tr><td><strong>Anti-Sm</strong></td><td>LES (20-30 %)</td><td>Muy específico</td></tr>
+<tr><td><strong>Anti-RNP</strong></td><td>LES (30-40 %); EMTC a títulos altos</td><td>Obligatorio para criterios de EMTC</td></tr>
+<tr><td><strong>Anti-histona</strong></td><td>Lupus inducido por fármacos</td><td>Procainamida, hidralacina, isoniazida, anti-TNF, minociclina, anticonvulsivantes</td></tr>
+<tr><td><strong>Anti-P ribosomal</strong></td><td>LES (10-20 %, muy específico)</td><td>Asociado a <em>psicosis lúpica / SNC</em></td></tr>
+<tr><td><strong>Anti-Ro/SSA</strong></td><td>Sjögren, LES (40 %), LE cutáneo subagudo</td><td><em>Lupus neonatal · bloqueo AV congénito</em></td></tr>
+<tr><td><strong>Anti-La/SSB</strong></td><td>Sjögren, LES (10-15 %)</td><td>Lupus neonatal; con Ro protege riñón en LES</td></tr>
+<tr><td><strong>Anti-Scl-70</strong></td><td>ES difusa (~20 %)</td><td>Larga evolución · fibrosis pulmonar</td></tr>
+<tr><td><strong>Anti-centrómero</strong></td><td>ES limitada / CREST (40 %)</td><td>También Hashimoto, CBP</td></tr>
+<tr><td><strong>Anti-RNA pol III</strong></td><td>ES difusa</td><td><em>Crisis renal esclerodérmica</em> · neoplasias</td></tr>
+<tr><td><strong>Anti-PM/Scl</strong></td><td>Solapamiento ES + miositis</td><td>—</td></tr>
+<tr><td><strong>Anti-Mi-2</strong></td><td>Dermatomiositis</td><td>95 % específico</td></tr>
+<tr><td><strong>Anti-Jo-1 / RNA-sintetasas</strong></td><td>Síndrome antisintetasa</td><td>Miositis + EPI + Raynaud + artritis + manos de mecánico + fiebre</td></tr>
+<tr><td><strong>Anti-SRP</strong></td><td>Miopatía necrosante</td><td>CK muy altas, cardiopatía</td></tr>
+<tr><td><strong>Anti-HMGCR</strong></td><td>Miopatía necrosante por estatinas</td><td>—</td></tr>
+<tr><td><strong>Anti-MDA5</strong></td><td>DM amiopática</td><td>EPI rápidamente progresiva</td></tr>
+<tr><td><strong>Anti-TIF1γ / NXP-2</strong></td><td>DM paraneoplásica</td><td>¡buscar tumor!</td></tr>
+<tr><td><strong>c-ANCA / PR3</strong></td><td>GPA (Wegener)</td><td>—</td></tr>
+<tr><td><strong>p-ANCA / MPO</strong></td><td>PAM, GEPA (Churg-Strauss)</td><td>—</td></tr>
+<tr><td><strong>aFL</strong> (AL, aCL, anti-β2GPI)</td><td>SAF</td><td>Persistencia ≥ 12 semanas</td></tr>
+</tbody></table></div>
+
+<h3>1.4 Cómo diagnosticar una EAS</h3>
+<ol>
+  <li><strong>Anamnesis:</strong> mujer joven, afectación multiorgánica, antecedentes personales o familiares de AI.</li>
+  <li><strong>Exploración:</strong> lesiones mucocutáneas, sinovitis, <em>capilaroscopia</em>.</li>
+  <li><strong>Laboratorio:</strong> citopenias, VSG/PCR, hipergammaglobulinemia policlonal, sedimento, proteinuria, <em>autoanticuerpos</em>.</li>
+  <li>Imagen y genética cuando proceda.</li>
+</ol>
+
+<div class="box box-mnemo">
+  <div class="box-title"><span class="icon">💡</span>Regla del prof. Ortego</div>
+  <p style="margin:0"><em>«No se diagnostica lo que no se conoce.»</em> Las EAS son frecuentes pero infradiagnosticadas. <strong>Fiebre en EAS bajo inmunosupresor → pensar primero en infección.</strong></p>
+</div>
+
+<h3>1.5 Preguntas de examen — Aspectos generales</h3>
+
+<details class="qa"><summary>1. (Parc 2018/2020) Sobre los criterios clasificatorios</summary>
+<div class="qa-body">
+<p>Respecto a los criterios clasificatorios de las enfermedades autoinmunes sistémicas, ¿qué considera cierto?</p>
+<ol type="a">
+<li><strong>Se han desarrollado fundamentalmente con fines de investigación. Aunque no son diagnósticos, con frecuencia se utilizan como tales</strong></li>
+<li>No son útiles en absoluto para el diagnóstico de las EAS</li>
+<li>Nadie los utiliza en la práctica clínica. Solo sirven para hacer registros</li>
+<li>Solo se puede diagnosticar a los enfermos de una EAS si cumplen los criterios clasificatorios</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Los criterios (ACR, EULAR, SLICC, Sapporo…) se diseñaron para estudios e investigación, con alta especificidad. Útiles como guía pero NO equivalen al diagnóstico clínico (que requiere experiencia, contexto, evolución).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Parc 2018) Sobre la herencia en las EAS</summary>
+<div class="qa-body">
+<p>Sobre la herencia en las EAS, ¿cuál es la respuesta correcta?</p>
+<ol type="a">
+<li>No participa ningún tipo de herencia</li>
+<li>Se trata de una herencia autosómica recesiva</li>
+<li><strong>Se trata de una herencia poligénica en la que muchos genes aportan una pequeña cantidad de riesgo</strong></li>
+<li>Se trata de una herencia autosómica dominante. Por eso, el riesgo de que los hijos de una enferma padezcan la misma enfermedad es elevado</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> EAS son poligénicas: HLA (DR3, DR4, B27 según enfermedad) + decenas/cientos de variantes no-HLA. Cada una aporta un pequeño riesgo. No siguen patrón mendeliano. El riesgo en hijos es bajo pero superior a la población general.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Parc 2018) Sobre los ANA</summary>
+<div class="qa-body">
+<p>Sobre los anticuerpos antinucleares, ¿qué considera cierto?</p>
+<ol type="a">
+<li>Aparecen siempre en las EAS</li>
+<li>No tienen ninguna utilidad en el diagnóstico de las EAS</li>
+<li>La presencia de ANA, aunque sean a títulos bajos, nos deben hacer pensar en una EAS</li>
+<li><strong>Pueden aparecer en muchas enfermedades y no son exclusivos de las EAS</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> ANA aparecen en hasta el 13 % de la población sana, en enfermedades organoespecíficas (tiroiditis), infecciones, fármacos, edad avanzada. Cuanto más alto el título, más probabilidad de EAS, pero no es exclusivo.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Parc 2018) Curso y epidemiología de las EAS</summary>
+<div class="qa-body">
+<p>¿Cuál es el curso y el perfil epidemiológico más habitual en las EAS?</p>
+<ol type="a">
+<li>Normalmente afectan a mujeres jóvenes y suelen tener un curso explosivo, con instauración aguda</li>
+<li><strong>Suelen ser de instauración progresiva, con aparición progresiva de síntomas. Afectan preferentemente a mujeres jóvenes</strong></li>
+<li>Cuando afectan a varones son de instauración progresiva y si afectan a mujeres de instauración súbita</li>
+<li>Son enfermedades que tienden a aparecer en los extremos de la vida</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Mujer joven con cuadro <em>progresivo</em> con adición de síntomas. El curso explosivo (a) es minoritario. Solapamiento y agregación familiar son comunes.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Parc 2019) ANA con valor 12,9 U/mL (VN &lt; 0,99)</summary>
+<div class="qa-body">
+<p>Solicitamos una determinación de anticuerpos antinucleares para el estudio de un paciente que sospechamos tiene una EAS. Recibimos un resultado que dice que tiene unos anticuerpos con un valor de 12,9 U/mL (VN &lt; 0,99 U/mL). ¿Cómo lo interpretamos?</p>
+<ol type="a">
+<li>Es una determinación positiva por inmunofluorescencia indirecta (IFI)</li>
+<li>Son indeterminados, pues tienen un valor próximo a la normalidad</li>
+<li>Es una determinación negativa de ELISA</li>
+<li><strong>Es una determinación positiva y se ha realizado mediante ELISA o técnica similar no IFI</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Los resultados <em>numéricos en U/mL</em> son de ELISA / quimioluminiscencia (cuantitativos). La IFI da <em>títulos en diluciones</em> (1/80, 1/160, 1/320…). 12,9 con VN &lt; 0,99 es muy positivo.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2019) Criterios clasificatorios — cómo aplicarlos</summary>
+<div class="qa-body">
+<p>¿Qué opina respecto a los criterios clasificatorios de las EAS?</p>
+<ol type="a">
+<li>Solo sirven para el diagnóstico de las enfermedades</li>
+<li>Se aplican en un momento dado y solo cuentan los datos obtenidos en ese momento</li>
+<li><strong>Para aplicarlos se consideran todos los datos disponibles, tanto en el momento de evaluación como previamente</strong></li>
+<li>La mayoría de las EAS no tienen criterios clasificatorios</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los criterios se aplican considerando todo el historial: si en algún momento el paciente cumplió un criterio (por ejemplo, tuvo proteinuria documentada que ya remitió), sigue contando. Esto es clave en LES donde las manifestaciones son fluctuantes.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 2: Acrosíndromes =============== -->
+<section class="card" id="t2">
+<h2 class="section-title"><span class="num">2</span>Acrosíndromes (Raynaud y otros)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Fenómeno de Raynaud:</strong> vasoconstricción episódica con <em>palidez → cianosis → rubor</em> tras frío o estrés.</li>
+    <li><strong>Capilaroscopia</strong> = prueba clave para diferenciar <em>primario</em> (normal) de <em>secundario</em> (megacapilares, áreas avasculares).</li>
+    <li><strong>Tratamiento de 1ª línea farmacológica:</strong> calcioantagonistas dihidropiridínicos (<em>nifedipino, amlodipino</em>).</li>
+    <li><strong>Bosentán</strong> previene nuevas úlceras digitales en esclerodermia.</li>
+    <li><strong>¡Evitar β-bloqueantes!</strong></li>
+  </ul>
+</div>
+
+<h3>2.1 Fenómeno de Raynaud — primario vs secundario</h3>
+<div class="compare">
+  <div>
+    <h4>🟢 Primario (E. Raynaud)</h4>
+    <ul>
+      <li>Mujer joven &lt; 30 años</li>
+      <li>Crisis <em>simétricas</em></li>
+      <li><strong>Sin úlceras / necrosis</strong></li>
+      <li>ANA negativos, VSG normal</li>
+      <li><strong>Capilaroscopia normal</strong></li>
+      <li>Sin enfermedad de base</li>
+    </ul>
+  </div>
+  <div>
+    <h4>🔴 Secundario</h4>
+    <ul>
+      <li>Cualquier edad, también varones</li>
+      <li>Asimétrico, <em>úlceras / pitting scars</em></li>
+      <li>ANA (+), autoanticuerpos específicos</li>
+      <li><strong>Capilaroscopia anormal</strong> (megacapilares, áreas avasculares)</li>
+      <li>Asociado a: <strong>esclerodermia (&gt; 90 %)</strong>, LES, EMTC, Sjögren, miopatías, SAF, vibración, β-bloqueantes, ergotamina, cocaína, crioglobulinemia, neoplasia</li>
+    </ul>
+  </div>
+</div>
+
+<h4>Patrones capilaroscópicos (pliegue ungueal)</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Normal</span><span class="v">Asas regulares, sin megacapilares</span></div>
+  <div class="kv"><span class="k">Early</span><span class="v">Megacapilares aislados</span></div>
+  <div class="kv"><span class="k">Active</span><span class="v">Megacapilares + hemorragias + alguna área avascular</span></div>
+  <div class="kv"><span class="k">Late</span><span class="v">Áreas avasculares + neoangiogénesis + arquitectura desorganizada</span></div>
+</div>
+
+<h3>2.2 Tratamiento del Raynaud</h3>
+<ol>
+  <li><strong>Medidas generales</strong> (lo más importante): evitar frío, guantes, no fumar, reducir estrés, retirar β-bloqueantes y descongestionantes.</li>
+  <li><strong>Calcioantagonistas DHP</strong> — primera línea farmacológica.</li>
+  <li>Inhibidores PDE-5 (sildenafilo, tadalafilo).</li>
+  <li><strong>Bosentán</strong> (ARE) para prevenir nuevas úlceras digitales en ES.</li>
+  <li><strong>Análogos de prostaciclina (iloprost iv)</strong> para crisis isquémicas / úlceras refractarias.</li>
+  <li>Nitroglicerina tópica.</li>
+  <li>Simpatectomía digital (casos extremos).</li>
+</ol>
+
+<h3>2.3 Otros acrosíndromes</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Acrocianosis</span><span class="v">Cianosis persistente, simétrica, indolora. <em>Benigna</em>.</span></div>
+  <div class="kv"><span class="k">Eritermalgia</span><span class="v">Eritema + calor + dolor con el <em>calor</em>; alivio con frío. Primaria (SCN9A) o secundaria (trombocitemia → tratar con AAS).</span></div>
+  <div class="kv"><span class="k">Livedo reticularis</span><span class="v">Reticular, reversible con calor → benigna.</span></div>
+  <div class="kv"><span class="k">Livedo racemosa</span><span class="v">Irregular, persistente → <em>SAF, vasculitis, Sneddon</em>.</span></div>
+  <div class="kv"><span class="k">Pernio (sabañones)</span><span class="v">Lesiones violáceas tras frío húmedo. Chilblain lupus si LES.</span></div>
+</div>
+</section>
+
+<!-- =============== TEMA 3: LES =============== -->
+<section class="card" id="t3">
+<h2 class="section-title"><span class="num">3</span>Lupus Eritematoso Sistémico (LES)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Prototipo de EAS:</strong> mediada por inmunocomplejos, con múltiples autoanticuerpos, brotes y remisiones.</li>
+    <li><strong>Mujer 15-45 años, 9-10:1</strong>; más grave en raza negra / hispanos.</li>
+    <li>Predisposición: <em>HLA-DR3, DR2, B8</em>; déficit de C1q (LES en &gt; 90 %).</li>
+    <li><strong>Desencadenantes:</strong> luz UV, infecciones (VEB), estrés, embarazo, estrógenos a altas dosis.</li>
+    <li><strong>Tratamiento base: hidroxicloroquina a TODO paciente con LES.</strong></li>
+    <li><strong>Principal causa de muerte tardía: enfermedad cardiovascular</strong> (aterosclerosis acelerada).</li>
+  </ul>
+</div>
+
+<h3>3.1 Manifestaciones clínicas por sistema</h3>
+
+<h4>🩸 Lesiones cutáneas — específicas vs inespecíficas</h4>
+<div class="compare">
+  <div>
+    <h4>Específicas (biopsia: dermatitis de interfase)</h4>
+    <ul>
+      <li><strong>Lupus cutáneo agudo:</strong> eritema malar en alas de mariposa (respeta surcos nasogenianos), eritema generalizado, ampollas.</li>
+      <li><strong>Lupus cutáneo subagudo:</strong> lesiones anulares policíclicas o psoriasiformes en zonas fotoexpuestas. <em>Anti-Ro/SSA (+)</em>.</li>
+      <li><strong>Lupus cutáneo crónico discoide:</strong> placas con tapón folicular, atrofia y alopecia cicatricial.</li>
+    </ul>
+  </div>
+  <div>
+    <h4>Inespecíficas</h4>
+    <ul>
+      <li>Alopecia no cicatricial</li>
+      <li><strong>Úlceras orales/nasales indoloras</strong> (paladar duro)</li>
+      <li>Fenómeno de Raynaud</li>
+      <li>Livedo, vasculitis cutánea</li>
+      <li>Telangiectasias periungueales</li>
+      <li>Fotosensibilidad</li>
+    </ul>
+  </div>
+</div>
+
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🔬</span>Dermatitis de interfase</div>
+  <p style="margin:0">Es <strong>característica del lupus pero NO patognomónica</strong> (también en DM y otras conectivopatías). Aparece en TODAS las lesiones específicas.</p>
+</div>
+
+<h4>🦴 Musculoesquelético</h4>
+<ul>
+  <li><strong>Artralgias / artritis simétricas no erosivas</strong> de pequeñas articulaciones (carpos, MCF, IFP, rodillas).</li>
+  <li><strong>Artropatía de Jaccoud:</strong> deformidades <em>reductibles, no erosivas</em>, por afectación periarticular. Relacionada con corticoides y anti-Ro/La.</li>
+  <li><strong>Osteonecrosis aséptica</strong> (cabeza femoral, húmero) por corticoides + vasculopatía.</li>
+</ul>
+
+<h4>🩸 Hematológicas — citopenias muy frecuentes</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Anemia</span><span class="v">De trastornos crónicos &gt; AHAI (Coombs +)</span></div>
+  <div class="kv"><span class="k">Leucopenia / Linfopenia</span><span class="v">Típica · refleja actividad</span></div>
+  <div class="kv"><span class="k">Trombocitopenia</span><span class="v">Autoinmune</span></div>
+</div>
+
+<h4>🫁 Pulmonares</h4>
+<ul>
+  <li><strong>Pleuritis</strong> (muy frecuente; dolor que aumenta con tos e inspiración profunda).</li>
+  <li>Neumonitis lúpica aguda, hemorragia alveolar (grave), EPI crónica, shrinking lung, HAP.</li>
+</ul>
+
+<h4>❤️ Cardíacas</h4>
+<ul>
+  <li>Pericarditis, miocarditis.</li>
+  <li><strong>Endocarditis de Libman-Sacks</strong> (verrugosa, no infecciosa; asociada a aFL).</li>
+  <li>Aterosclerosis acelerada.</li>
+</ul>
+
+<h4>🫘 Renales — Nefritis lúpica (NL)</h4>
+<p>Afecta a 30-40 %, suele aparecer en los primeros 5 años. <strong>Biopsia renal OBLIGATORIA</strong>.</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Clase ISN/RPS</th><th>Descripción</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Mesangial mínima</td><td>HCQ ± corticoide bajo</td></tr>
+<tr><td>II</td><td>Proliferativa mesangial</td><td>HCQ ± corticoide bajo</td></tr>
+<tr><td><strong>III</strong></td><td>Proliferativa <em>focal</em> (&lt; 50 % glomérulos)</td><td><strong>Corticoides + MMF o ciclofosfamida iv</strong></td></tr>
+<tr><td><strong>IV</strong></td><td>Proliferativa <em>difusa</em> (≥ 50 %) — <em>asas de alambre</em>, semilunas. La más frecuente y grave.</td><td><strong>Corticoides + MMF o CFM iv</strong> ± belimumab/voclosporina</td></tr>
+<tr><td>V</td><td>Membranosa</td><td>HCQ + IECA + corticoide ± MMF</td></tr>
+<tr><td>VI</td><td>Esclerosis avanzada</td><td>Sintomático · TRS</td></tr>
+</tbody></table></div>
+
+<h4>🧠 Neurológicas (NPSLE)</h4>
+<p>19 síndromes (cefalea, convulsiones, ictus, psicosis, mielopatía, polineuropatía, déficit cognitivo). Dos mecanismos: <em>inflamatorio</em> o <em>isquémico</em> (frecuente con aFL). <strong>Anti-P ribosomales → psicosis.</strong></p>
+
+<h4>🤢 Digestivas — ¡cuidado!</h4>
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">⚠</span>Dolor abdominal en LES activo</div>
+  <p style="margin:0">Mientras no se demuestre lo contrario, <strong>VASCULITIS INTESTINAL</strong>. Pedir TAC. Mortalidad alta si se infravalora.</p>
+</div>
+
+<h3>3.2 Diagnóstico</h3>
+<p>Criterios <strong>EULAR/ACR 2019</strong>: entrada con <em>ANA ≥ 1/80</em> + suma de dominios con peso (≥ 10 puntos clasifica).</p>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🔍</span>Laboratorio típico</div>
+  <ul style="margin:6px 0">
+    <li>Citopenias</li>
+    <li>↑ VSG con <strong>PCR normal o sólo levemente ↑</strong> (PCR muy alta en LES → pensar infección o serositis)</li>
+    <li><strong>C3 y C4 bajos</strong> en actividad</li>
+    <li><strong>Anti-dsDNA ↑</strong> en brote</li>
+  </ul>
+</div>
+
+<h3>3.3 Tratamiento</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Base (siempre)</span><span class="v"><strong>Hidroxicloroquina 5 mg/kg/día</strong> + fotoprotección estricta</span></div>
+  <div class="kv"><span class="k">Articular / piel</span><span class="v">AINE · MTX · belimumab · anifrolumab</span></div>
+  <div class="kv"><span class="k">Nefritis III/IV</span><span class="v">Corticoides altas dosis + <strong>MMF o ciclofosfamida iv</strong> · belimumab · voclosporina</span></div>
+  <div class="kv"><span class="k">SNC / vasculitis grave</span><span class="v">Corticoides + ciclofosfamida iv (pulsos)</span></div>
+  <div class="kv"><span class="k">Citopenias autoinmunes</span><span class="v">Corticoides · <strong>rituximab</strong></span></div>
+  <div class="kv"><span class="k">Biológicos</span><span class="v">Belimumab (anti-BLyS) · Anifrolumab (anti-IFN-I-R) · Rituximab (anti-CD20)</span></div>
+</div>
+
+<h3>3.4 Lupus inducido por fármacos</h3>
+<div class="box box-mnemo">
+  <div class="box-title"><span class="icon">💊</span>Memorizar</div>
+  <p style="margin:4px 0"><strong>Fármacos:</strong> procainamida · hidralacina · isoniacida · metildopa · clorpromazina · quinidina · <em>minociclina</em> · <em>anti-TNF</em> · <em>anticonvulsivantes</em> (fenitoína, carbamacepina) · interferón.</p>
+  <p style="margin:4px 0"><strong>Anti-histona (+)</strong> · anti-DNAn habitualmente negativos · complemento normal.</p>
+  <p style="margin:4px 0"><strong>Riñón y SNC excepcionales</strong> · resuelve al suspender el fármaco.</p>
+</div>
+
+<h3>3.5 Lupus neonatal</h3>
+<p>Hijo de madre con <strong>anti-Ro/SSA (± anti-La/SSB)</strong>. <em>Bloqueo AV congénito</em> (irreversible, puede requerir marcapasos), lesiones cutáneas anulares transitorias, citopenias, hepatitis.</p>
+
+<h3>3.6 Preguntas — LES (haz clic en cada pregunta para verla y comprobar la respuesta)</h3>
+
+<details class="qa"><summary>1. (Jun 2018) Lesiones específicas del LES</summary>
+<div class="qa-body">
+<p>Sobre las lesiones específicas del lupus eritematoso sistémico:</p>
+<ol type="a">
+<li>Solo aparecen en los enfermos al principio de la enfermedad</li>
+<li>Son más graves que las inespecíficas</li>
+<li>Se caracterizan porque la biopsia muestra una dermatitis de interfase, que es patognomónica del lupus eritematoso</li>
+<li><strong>Se caracterizan porque la biopsia muestra una dermatitis de interfase, que, aunque es muy característica del lupus, no es patognomónica</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La dermatitis de interfase aparece en TODAS las lesiones específicas del LES (agudo, subagudo, discoide), pero no es patognomónica — también aparece en dermatomiositis, eritema multiforme y reacciones farmacológicas.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Parc 2018) Manifestaciones hematológicas del LES</summary>
+<div class="qa-body">
+<p>Sobre las manifestaciones hematológicas del lupus eritematoso sistémico:</p>
+<ol type="a">
+<li>La trombocitopenia suele ser de moderada intensidad</li>
+<li>La trombocitopenia es infrecuente (&lt; 10 %) y solo aparece en pacientes con enfermedad muy activa</li>
+<li>Siempre que hay anticuerpos dirigidos contra las plaquetas se produce trombocitopenia</li>
+<li><strong>La linfopenia aparece casi siempre y no se relaciona con la actividad de la enfermedad</strong> (en realidad la linfopenia SÍ refleja actividad — pero entre las opciones del banco, la "a" es la más correcta: la trombopenia suele ser moderada)</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La trombocitopenia en LES suele ser leve-moderada, no severa. La opción d es problemática (la linfopenia SÍ correlaciona con actividad), por lo que la respuesta más correcta es la <strong>a</strong>.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Parc 2018) Afectación cutánea del lupus eritematoso</summary>
+<div class="qa-body">
+<p>Sobre la afectación cutánea del lupus eritematoso:</p>
+<ol type="a">
+<li>Hay lesiones específicas e inespecíficas. Las inespecíficas suelen ser más benignas</li>
+<li>Las lesiones específicas son: lupus subagudo y lupus agudo</li>
+<li>No requieren tratamiento sistémico. El tratamiento tópico es suficiente</li>
+<li><strong>Las lesiones específicas se caracterizan por tener dermatitis de interfase en la biopsia cutánea</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Las lesiones específicas son tres: agudo, subagudo y crónico discoide (no dos como dice b). Las inespecíficas NO siempre son más benignas (a falso). Algunas requieren tratamiento sistémico (c falso).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Parc 2018/2020) Fármaco fundamental en el tratamiento del LES</summary>
+<div class="qa-body">
+<p>¿Qué fármaco se considera fundamental en el tratamiento del lupus?</p>
+<ol type="a">
+<li><strong>Los antipalúdicos (hidroxicloroquina)</strong></li>
+<li>Los antiinflamatorios no esteroideos</li>
+<li>Los corticoides</li>
+<li>Los inmunodepresores</li>
+<li>Los biológicos</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La HCQ debe darse a TODO paciente con LES salvo contraindicación: mejora supervivencia, previene brotes, daño orgánico y trombosis. Los corticoides son necesarios en brotes pero no son la base del tratamiento crónico.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Parc 2018) Lesiones cutáneas del LES</summary>
+<div class="qa-body">
+<p>Las lesiones cutáneas del lupus eritematoso sistémico:</p>
+<ol type="a">
+<li>Están presentes en el 100 % de los pacientes</li>
+<li><strong>Suelen ser fotosensibles</strong></li>
+<li>Nunca preceden a las manifestaciones sistémicas</li>
+<li>Tienden a aparecer en los miembros inferiores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La fotosensibilidad es característica del LES. No están en el 100 % (a falso). Pueden preceder a la enfermedad sistémica (c falso). Aparecen en zonas fotoexpuestas, no en MMII (d falso).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Parc 2018) Hematológicas — citopenias</summary>
+<div class="qa-body">
+<p>Sobre las manifestaciones hematológicas del LES:</p>
+<ol type="a">
+<li>La anemia es muy rara. Solo aparece en enfermos graves</li>
+<li>No suele cursar con trombocitopenia</li>
+<li>La leucopenia solo afecta a linfocitos B</li>
+<li><strong>Son muy frecuentes las citopenias en general, que pueden afectar a hematíes, leucocitos y plaquetas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Las citopenias son frecuentes y pueden afectar a las tres series. La leucopenia afecta sobre todo a <em>linfocitos T</em> (no B).</div>
+</div></details>
+
+<details class="qa"><summary>7. (Parc 2018) Mujer con LES y fiebre bajo HCQ y corticoide</summary>
+<div class="qa-body">
+<p>Una enferma diagnosticada de LES, en tratamiento con dolquine (HCQ 200 mg/día) y prednisona (7,5 mg/día), consulta por fiebre elevada. No refiere tos, expectoración ni molestias al orinar. Exploración: rash malar, ACR normal. Analítica básica: discreta leucocitosis; PCR 7 mg/L; sedimento de orina normal. ¿Qué actitud le parece más adecuada?</p>
+<ol type="a">
+<li><strong>Mientras no se demuestre lo contrario, se trata de una infección que debo descartar</strong></li>
+<li>Seguro que la fiebre es de la enfermedad. Le subiré la dosis de corticoides y espero que mejore</li>
+<li>Voy a pedir una radiografía de tórax. Si es normal, subiré la dosis de corticoides</li>
+<li>El lupus no produce fiebre si no existe una infección</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Regla clave: <em>fiebre en EAS bajo inmunosupresor → pensar PRIMERO en infección</em>, sobre todo si hay leucocitosis y PCR elevada (en LES la PCR suele ser normal). El LES sí puede producir fiebre (d falso), pero la infección debe descartarse siempre antes de aumentar la inmunosupresión.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Jun 2019/Parc 2020) Luisa, LES activa, dolor abdominal</summary>
+<div class="qa-body">
+<p>Luisa tiene 42 años y está diagnosticada de LES desde hace 4 años. Está tratada con antipalúdicos, azatioprina y prednisona (20 mg/día). En la última visita, unas semanas antes, tenía moderada linfopenia (950 linf/µL), anti-DNA nativo (+) a título elevado y niveles bajos de C4. Acude a urgencias por dolor abdominal de instauración subaguda. Se indica sueroterapia y un analgésico, con lo que la enferma mejora. ¿Qué actitud le parece más adecuada?</p>
+<ol type="a">
+<li><strong>A pesar de la buena evolución clínica creo que es imperativo descartar una vasculitis intestinal. Una TAC puede ayudar al diagnóstico</strong></li>
+<li>Dada la buena evolución, la enferma puede irse de alta puesto que la mayoría de los dolores abdominales en los pacientes con lupus son intrascendentes</li>
+<li>Es posible que se trate de una úlcera gastroduodenal favorecida por el uso de glucocorticoides y el diagnóstico se debe hacer con una endoscopia digestiva alta</li>
+<li>Lo primero es descartar una colelitiasis mediante una ecografía abdominal. Si es normal podremos dar de alta a la enferma y revisarla en consulta en unos días</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> <em>Dolor abdominal en LES activo (anti-DNAn alto, C4 bajo, linfopenia) → VASCULITIS INTESTINAL mientras no se demuestre lo contrario.</em> Tiene alta mortalidad si se infravalora; aunque la paciente mejore con analgesia y fluidos, debe descartarse con TAC con contraste.</div>
+</div></details>
+
+<details class="qa"><summary>9. Marcador más asociado a riesgo de nefritis lúpica</summary>
+<div class="qa-body">
+<p>El marcador más asociado a riesgo de nefritis lúpica es:</p>
+<ol type="a">
+<li><strong>Anticuerpo anti-DNA nativo</strong></li>
+<li>Anticuerpo anti-Sm</li>
+<li>Niveles de complemento</li>
+<li>Hematuria</li>
+<li>Cualquiera de los anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Los anti-DNAn a títulos altos predicen nefritis. El consumo de complemento (C3, C4 bajos) y la hematuria son marcadores de actividad/daño establecido, no de riesgo. Anti-Sm es específico de LES pero no se relaciona con nefritis.</div>
+</div></details>
+
+<details class="qa"><summary>10. Mujer con LES cutáneo-articular y dolor abdominal</summary>
+<div class="qa-body">
+<p>Mujer de 28 años con lupus cutáneo-articular, en tratamiento habitual con hidroxicloroquina y AINE por temporadas. Presenta dolor abdominal desde hace 15 días, coincidiendo con brote de actividad. ¿Qué sugiere?</p>
+<ol type="a">
+<li>Pancreatitis</li>
+<li><strong>Vasculitis intestinal</strong></li>
+<li>Hepatitis</li>
+<li>Gastroduodenitis por AINE</li>
+<li>Embarazo ectópico</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Mismo razonamiento que la anterior: dolor abdominal subagudo en LES activo → sospechar vasculitis intestinal. La gastroduodenitis por AINE es plausible pero el contexto de brote orienta a vasculitis.</div>
+</div></details>
+
+<details class="qa"><summary>11. Mujer con rash malar, anti-Sm +, tos seca y dolor de costado</summary>
+<div class="qa-body">
+<p>Mujer de 31 años con rash malar fotosensible, artritis de interfalángicas de manos, plaquetopenia y ANA + y anti-Sm +. En los últimos días tiene tos seca y dolor de costado. Lo más probable es que presente:</p>
+<ol type="a">
+<li>Neumonitis</li>
+<li>TBC pulmonar</li>
+<li><strong>Pleuritis</strong></li>
+<li>Pericarditis</li>
+<li>Hemorragia pulmonar</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La <em>pleuritis es la afectación pulmonar más frecuente del LES</em>. Cursa con dolor pleurítico (aumenta con tos e inspiración profunda), tos seca, a veces derrame. La neumonitis y hemorragia alveolar son raras y graves.</div>
+</div></details>
+
+<details class="qa"><summary>12. Anticuerpo anti-Ro/SSA y sus asociaciones</summary>
+<div class="qa-body">
+<p>El anticuerpo anti-Ro/SSA se relaciona con:</p>
+<ol type="a">
+<li>Lupus subagudo</li>
+<li>Síndrome de Sjögren</li>
+<li>Abortos</li>
+<li>Lupus neonatal</li>
+<li><strong>Todos los anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Anti-Ro/SSA se asocia clásicamente a: lupus cutáneo subagudo, síndrome de Sjögren primario y secundario, lupus neonatal (bloqueo AV congénito) y morbilidad obstétrica (abortos, en contexto de SAF asociado).</div>
+</div></details>
+
+<details class="qa"><summary>13. Mujer con rash + antiepilépticos — anticuerpo a investigar</summary>
+<div class="qa-body">
+<p>Mujer de 33 años, con rash malar, artralgias, ANA + y antecedentes de tratamiento antiepiléptico. ¿Qué anticuerpo se debe investigar?</p>
+<ol type="a">
+<li>Anticuerpos anticentrómero</li>
+<li><strong>Anticuerpos antihistona</strong></li>
+<li>Anticuerpos anti-Scl-70</li>
+<li>Anticuerpos anti-RNP</li>
+<li>Anticuerpos anti-SSB/La</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Sospecha de lupus inducido por fármacos (antiepilépticos como fenitoína, carbamacepina). Los anti-histona aparecen en &gt; 90 % de los lupus inducidos por fármacos. Los anti-DNAn suelen ser negativos y el complemento normal.</div>
+</div></details>
+
+<details class="qa"><summary>14. LES con fiebre, expectoración y malestar bajo tratamiento</summary>
+<div class="qa-body">
+<p>La causa más frecuente de fiebre, expectoración y malestar general en una enferma de lupus en tratamiento con antipalúdicos, corticoides y metotrexato es:</p>
+<ol type="a">
+<li>Neumonitis</li>
+<li>Hemorragia pulmonar</li>
+<li>Distrés respiratorio</li>
+<li><strong>Infección respiratoria</strong></li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Paciente inmunodeprimida con clínica respiratoria febril → primero descartar infección. La neumonitis lúpica es rara; la hemorragia alveolar cursa con hemoptisis y caída de hemoglobina; el distrés es agudo y muy grave.</div>
+</div></details>
+
+<details class="qa"><summary>15. Tratamiento del LES — verdadero</summary>
+<div class="qa-body">
+<p>¿Qué es cierto en relación con el tratamiento de los enfermos de LES?</p>
+<ol type="a">
+<li>La hidroxicloroquina no es tratamiento frecuentemente prescrito</li>
+<li>Los corticoides se deben evitar en casos de vasculitis asociada</li>
+<li><strong>Los tratamientos biológicos recientemente introducidos (anti-CD20 — rituximab) se deben aplicar cuando han fracasado los tratamientos clásicos</strong></li>
+<li>Los AINE son imprescindibles</li>
+<li>Los inmunosupresores son necesarios para controlar la artritis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los biológicos (rituximab, belimumab, anifrolumab) se reservan para refractarios. La HCQ se prescribe siempre (a falso). Los corticoides son esenciales en vasculitis (b falso). Los AINE son útiles pero no imprescindibles. La artritis lúpica suele controlarse con HCQ ± MTX, no requiere de entrada inmunosupresores.</div>
+</div></details>
+
+<details class="qa"><summary>16. Varón joven con crisis epiléptica + rash + anti-DNAn ↑</summary>
+<div class="qa-body">
+<p>Varón de 19 años con crisis epilépticas de reciente aparición, rash malar y anticuerpos anti-DNAn (+) elevados:</p>
+<ol type="a">
+<li><strong>Tiene clínicamente un LES, aunque no reúna criterios de clasificación de la ACR</strong></li>
+<li>Tiene una enfermedad indeterminada del tejido conectivo</li>
+<li>Tiene una colagenosis</li>
+<li>Hay que hacer biopsia de piel</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El diagnóstico clínico no equivale al cumplimiento de criterios clasificatorios. Con afectación neuropsiquiátrica + cutánea + anti-DNAn (+), clínicamente es un LES con NPSLE aunque los criterios clasificatorios formales no se completen.</div>
+</div></details>
+
+<details class="qa"><summary>17. (Jun 2019) María con lesiones anulares fotoexpuestas y dermatitis de interfase</summary>
+<div class="qa-body">
+<p>María tiene 32 años, consulta por lesiones cutáneas anulares en zonas fotoexpuestas y sensación de cansancio exagerado. Las lesiones se acompañan de prurito discreto. No hay otros datos de interés. El hemograma, la bioquímica elemental y el sedimento urinario son normales, sin proteinuria. La determinación de ANA y ENAs es negativa. Los niveles de C3 y C4 son normales. Anticuerpos antifosfolípido y Coombs negativos. Biopsia: dermatitis de interfase compatible con lupus eritematoso. ¿Qué opina?</p>
+<ol type="a">
+<li>Parece claro que padece un lupus sistémico dado el tipo de lesiones y la clínica general</li>
+<li><strong>Creo que puede tener un lupus cutáneo, posiblemente un lupus subagudo. En el momento actual no hay datos de lupus sistémico, pero me quedaría más tranquilo haciendo un seguimiento</strong></li>
+<li>Parece tratarse de una dermatomiositis por el tipo de lesiones y el cansancio exagerado</li>
+<li>Creo que las lesiones que refiere son inespecíficas puesto que los autoanticuerpos son negativos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Lesiones anulares fotoexpuestas + dermatitis de interfase = <em>lupus cutáneo subagudo</em>. La negatividad de ANA no excluye el diagnóstico (a veces requiere ELISA específico para anti-Ro). Sin afectación sistémica, no se diagnostica LES. Seguimiento periódico es lo prudente.</div>
+</div></details>
+
+<details class="qa"><summary>18. (Jun 2019) Manifestaciones neuropsiquiátricas del LES — FALSO</summary>
+<div class="qa-body">
+<p>Respecto a las manifestaciones neuropsiquiátricas en el LES, ¿qué considera FALSO?</p>
+<ol type="a">
+<li>La mayoría de las veces aparecen en los primeros años desde el inicio y con frecuencia en fases de actividad</li>
+<li>En ocasiones se deben a mecanismos inflamatorios, pero con mucha frecuencia se deben a eventos isquémicos en el contexto de anticuerpos antifosfolípido</li>
+<li>Los factores de riesgo son: actividad o daño sistémico y títulos elevados de anticuerpos antifosfolípido</li>
+<li><strong>La cefalea tiene unas características diferenciales típicas y se debe tratar con dosis elevadas de corticoides</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d (FALSA).</strong> La "cefalea lúpica" como entidad específica está cuestionada y NO se trata con corticoides altas dosis. Las cefaleas en LES suelen ser comunes (migrañas, tensionales) y se manejan como en la población general.</div>
+</div></details>
+
+<details class="qa"><summary>19. (Jun 2017) Manifestaciones respiratorias del LES</summary>
+<div class="qa-body">
+<p>En cuanto a las manifestaciones del aparato respiratorio de los pacientes con lupus, ¿qué considera cierto?</p>
+<ol type="a">
+<li>La hipertensión arterial pulmonar es una manifestación frecuente y precoz</li>
+<li>Los infiltrados eosinofílicos bilaterales son la norma en fases de actividad</li>
+<li>La pleuritis es muy frecuente y a veces cursa de forma asintomática</li>
+<li><strong>La pleuritis es muy frecuente y cursa con dolor que aumenta con la tos y la respiración profunda</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La pleuritis (con o sin derrame) es la afectación pulmonar más frecuente del LES. Cursa con dolor pleurítico característico. La HAP es rara y tardía (no precoz). Los infiltrados eosinofílicos no son típicos.</div>
+</div></details>
+
+<details class="qa"><summary>20. (Jun 2018) Sobre la nefritis lúpica — FALSO</summary>
+<div class="qa-body">
+<p>Sobre la nefritis lúpica, ¿qué considera FALSO?</p>
+<ol type="a">
+<li>Afecta aproximadamente al 30-40 % de los pacientes y aparece cuando han transcurrido menos de 5 años de evolución de la enfermedad</li>
+<li><strong>Para el diagnóstico es suficiente la clínica y los datos del laboratorio. La biopsia solo la indicaremos cuando el enfermo no evolucione bien con el tratamiento indicado</strong></li>
+<li>Las formas más frecuentes y graves son las de clase III y IV que deben tratarse de forma enérgica</li>
+<li>La biopsia, salvo contraindicación, es obligada para el diagnóstico. Nos permite clasificar el tipo de glomerulonefritis y nos aporta datos pronósticos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La biopsia renal es OBLIGADA para el diagnóstico de nefritis lúpica (salvo contraindicación). Clasifica la lesión (clases I-VI), determina el tratamiento y aporta pronóstico. No es opcional.</div>
+</div></details>
+
+<details class="qa"><summary>21. (Parc 2018/2020) Anticuerpos antinucleares en LES</summary>
+<div class="qa-body">
+<p>En relación a los anticuerpos antinucleares en el LES:</p>
+<ol type="a">
+<li>Solo tienen utilidad si se determinan mediante ELISA</li>
+<li>Los anti-DNA nativo son los únicos específicos</li>
+<li><strong>Los anti-DNA nativo son útiles para el diagnóstico y el seguimiento de la enfermedad</strong></li>
+<li>No sirven para establecer el diagnóstico</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los anti-DNAn son útiles para diagnóstico (muy específicos) y seguimiento (correlacionan con actividad y nefritis). Se determinan tanto por IFI como por ELISA/Farr. No son los únicos específicos (también anti-Sm, anti-P ribosomal).</div>
+</div></details>
+
+<details class="qa"><summary>22. (Jun 2016) Feto con bloqueo AV intraútero — anticuerpo a investigar</summary>
+<div class="qa-body">
+<p>Feto con bloqueo AV diagnosticado intraútero. ¿Cuál de los siguientes anticuerpos investigaría en la madre?</p>
+<ol type="a">
+<li>Anticuerpo anti-DNAn</li>
+<li><strong>Anti-SSA/Ro</strong></li>
+<li>Anti-RNP</li>
+<li>Anti-Sm</li>
+<li>Anti-Scl-70</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los anti-Ro/SSA maternos atraviesan la placenta y pueden dañar el sistema de conducción cardíaco fetal entre la semana 16 y 24, causando bloqueo AV congénito. Es la principal manifestación grave del lupus neonatal.</div>
+</div></details>
+
+<details class="qa"><summary>23. (Jun 2016) LES con citopenias resistentes a HCQ + prednisona 10 mg</summary>
+<div class="qa-body">
+<p>Mujer de 35 años con LES y anemia-plaquetopenia-leucopenia moderadas, que no mejoran con 10 mg diarios de prednisona, hidroxicloroquina y medidas generales habituales. ¿Qué fármaco asociaría?</p>
+<ol type="a">
+<li><strong>Rituximab</strong></li>
+<li>AINE</li>
+<li>Azatioprina</li>
+<li>Ciclofosfamida</li>
+<li>Belimumab</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Para citopenias autoinmunes en LES refractarias, rituximab (anti-CD20) tiene buena evidencia. Belimumab también es opción aceptable. AZA y CFM son menos eficaces para citopenias. AINE no tratan las citopenias.</div>
+</div></details>
+
+<details class="qa"><summary>24. (Jun 2016) Peor pronóstico en LES</summary>
+<div class="qa-body">
+<p>Señale la respuesta correcta en relación con un peor pronóstico en enfermos con LES:</p>
+<ol type="a">
+<li><strong>Aterosclerosis precoz</strong></li>
+<li>Raza blanca</li>
+<li>Alto status socioeconómico</li>
+<li>Varones mayores</li>
+<li>Todas las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La aterosclerosis acelerada es la principal causa de muerte tardía en LES. Otros factores de mal pronóstico: <em>raza negra/hispana</em> (no blanca), <em>bajo</em> nivel socioeconómico, varones <em>jóvenes</em>, afectación renal, SNC, anti-DNAn altos.</div>
+</div></details>
+
+<details class="qa"><summary>25. (Jun 2016) Mujer joven con artralgias, ANA + inespecíficos y AF de LES</summary>
+<div class="qa-body">
+<p>Mujer de 23 años que consulta por artralgias, sin otros datos significativos. Tiene una capilaroscopia normal y ANA positivos, sin ninguna especificidad. Su madre padece LES y dos hermanas hipotiroidismo. ¿Cuál es el diagnóstico más correcto?</p>
+<ol type="a">
+<li><strong>Enfermedad indeterminada del tejido conectivo</strong></li>
+<li>Lupus eritematoso sistémico</li>
+<li>Esclerosis sistémica localizada</li>
+<li>Hipotiroidismo</li>
+<li>Síndrome de Sjögren</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Conectivopatía indiferenciada (CTI/UCTD): ANA (+) sin especificidad + clínica de EAS sin cumplir criterios de ninguna. La agregación familiar apoya el diagnóstico. 1/3 evolucionan a una EAS definida en 3-5 años.</div>
+</div></details>
+
+<details class="qa"><summary>26. (Jun 2016) Etiopatogenia del LES — INCORRECTA</summary>
+<div class="qa-body">
+<p>En relación con la etiopatogenia del LES, señale la respuesta INCORRECTA:</p>
+<ol type="a">
+<li>Anomalías en la apoptosis</li>
+<li>Predisposición en portadores de HLA-B8 y DR3</li>
+<li><strong>Los tintes de pelo favorecen su desarrollo</strong></li>
+<li>Producción de citocinas proinflamatorias</li>
+<li>Numerosos polimorfismos genéticos</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (INCORRECTA).</strong> La asociación tintes de pelo / LES NO está demostrada (estudios negativos). Las demás opciones son ciertas: anomalías de apoptosis (déficit C1q), HLA-B8/DR3, hiperproducción de IFN-α y otras citoquinas, naturaleza poligénica.</div>
+</div></details>
+
+<details class="qa"><summary>27. Adolescente con artritis, edemas, HTA, proteinuria</summary>
+<div class="qa-body">
+<p>Mujer de 16 años con historia de 4 meses de evolución de artritis, síntomas constitucionales y más recientemente edemas en piernas, hipertensión y albuminuria elevada. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Glomerulonefritis membranosa</li>
+<li>Glomerulonefritis mesangial</li>
+<li><strong>Glomerulonefritis proliferativa difusa (clase IV)</strong></li>
+<li>Nefropatía de cambios mínimos</li>
+<li>Glomerulonefritis proliferativa focal (clase III)</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Síndrome nefrótico + HTA + síntomas sistémicos → la clase IV (proliferativa difusa) es la forma más frecuente y grave de nefritis lúpica. Cursa con asas de alambre y semilunas en la biopsia.</div>
+</div></details>
+
+<details class="qa"><summary>28. Paciente con LES, GN tipo IV — tratamiento</summary>
+<div class="qa-body">
+<p>Paciente de lupus de 50 años que desarrolla hipertensión, proteinuria marcada e hipocomplementemia. La biopsia demuestra una glomerulonefritis tipo IV. El tratamiento adecuado es:</p>
+<ol type="a">
+<li>Micofenolato</li>
+<li>Corticoides y antipalúdicos</li>
+<li>Corticoides y rituximab</li>
+<li><strong>Corticoides + ciclofosfamida en pulsos iv o micofenolato</strong></li>
+<li>Corticoides y azatioprina</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Inducción de nefritis lúpica III/IV: corticoides altas dosis (± pulsos de metilprednisolona) + MMF o ciclofosfamida iv en pulsos (esquema NIH o Eurolupus). Se puede añadir belimumab o voclosporina. Mantenimiento posterior con MMF o AZA.</div>
+</div></details>
+
+<details class="qa"><summary>29. GN lúpica grave — mejor opción terapéutica</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes es la mejor opción terapéutica para un paciente con glomerulonefritis lúpica grave?</p>
+<ol type="a">
+<li>Corticoides</li>
+<li>Corticoides y antipalúdicos</li>
+<li>Corticoides, AINE y antipalúdicos</li>
+<li><strong>Corticoides y micofenolato</strong></li>
+<li>Corticoides y azatioprina</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> En GN proliferativa, MMF (junto con CFM iv) es el tratamiento de inducción de elección. AZA se usa para mantenimiento, no para inducción.</div>
+</div></details>
+
+<details class="qa"><summary>30. Recién nacido con lesiones cutáneas — anticuerpo materno</summary>
+<div class="qa-body">
+<p>Recién nacido que presenta a la semana unas lesiones cutáneas diseminadas. ¿Qué anticuerpo investigaría en la madre?</p>
+<ol type="a">
+<li>Anticuerpo anti-DNAn</li>
+<li><strong>Anti-SSA/Ro</strong></li>
+<li>Anti-RNP</li>
+<li>Anti-Sm</li>
+<li>Anti-Scl-70</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Lupus neonatal: anti-Ro/SSA maternos atraviesan la placenta y causan lesiones cutáneas anulares transitorias (resuelven a los 6 meses al desaparecer los anticuerpos) ± bloqueo AV (irreversible).</div>
+</div></details>
+
+<details class="qa"><summary>31. Criterio ACR para clasificación de LES</summary>
+<div class="qa-body">
+<p>¿Cuál es criterio de la American College of Rheumatology (ACR) para la clasificación de LES?</p>
+<ol type="a">
+<li><strong>Proteinuria &gt; 0,5 gramos</strong></li>
+<li>Fenómeno de Raynaud</li>
+<li>Depresión</li>
+<li>Afectación hepática</li>
+<li>Anticuerpos anti-RNP</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La proteinuria &gt; 0,5 g/24 h (o &gt; 500 mg/g de creatinina) es criterio renal en ACR/SLICC/EULAR. NO son criterios: Raynaud, depresión (sí psicosis), hepatopatía, anti-RNP (es para EMTC).</div>
+</div></details>
+
+<details class="qa"><summary>32. LES con lesiones cutáneo-articulares refractarias</summary>
+<div class="qa-body">
+<p>Mujer de 55 años con LES y lesiones cutáneo-articulares que empeoran significativamente su calidad de vida, y no mejoran con 10 mg de prednisona, hidroxicloroquina y medidas generales habituales. ¿Qué haría?</p>
+<ol type="a">
+<li><strong>Asociar metotrexato</strong></li>
+<li>Asociar AINE</li>
+<li>Asociar azatioprina</li>
+<li>Asociar ciclofosfamida</li>
+<li>Asociar belimumab</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Para manifestaciones cutáneo-articulares refractarias, el MTX es el ahorrador de corticoide de primera elección. Belimumab también es válido (aprobado para LES cutáneo-articular). La CFM se reserva para nefritis/SNC grave.</div>
+</div></details>
+
+<details class="qa"><summary>33. NO es criterio ACR para LES</summary>
+<div class="qa-body">
+<p>¿Cuál NO es criterio de ACR para la clasificación de LES?</p>
+<ol type="a">
+<li>Eritema malar</li>
+<li>Lupus discoide</li>
+<li>Convulsiones</li>
+<li>Alteraciones renales</li>
+<li><strong>Arteriosclerosis</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> La aterosclerosis es complicación tardía del LES (causa de muerte) pero NO criterio clasificatorio. Los criterios incluyen: eritema malar, lupus discoide, fotosensibilidad, úlceras orales, artritis no erosiva, serositis, renal, neurológico (convulsiones/psicosis), hematológico, inmunológico, ANA.</div>
+</div></details>
+
+<details class="qa"><summary>34. Varón joven con acné en tetraciclinas + rash</summary>
+<div class="qa-body">
+<p>Varón de 17 años con acné en tratamiento antibiótico (tetraciclinas), que consulta por rash cutáneo y artralgias. ¿Cuál de las siguientes pruebas podría ser de más ayuda diagnóstica?</p>
+<ol type="a">
+<li>Anticuerpos anti-DNAn</li>
+<li><strong>Anticuerpos anti-histonas</strong></li>
+<li>Anticuerpos anti-SSB/La</li>
+<li>Anticuerpos anti-ribosomal P0</li>
+<li>Anticuerpos anti-centrómero</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La <em>minociclina</em> (tetraciclina) es causa clásica de lupus inducido por fármacos en adolescentes con acné. Buscar anti-histona, que son característicos (90 % de lupus inducidos).</div>
+</div></details>
+
+<details class="qa"><summary>35. Adolescente con eritema malar, edemas y orina "con espuma"</summary>
+<div class="qa-body">
+<p>Muchacha de 14 años sin antecedentes que comienza con eritema malar, edemas palpebrales y orina "con espuma". Se debe investigar por su valor diagnóstico/pronóstico:</p>
+<ol type="a">
+<li>Anticuerpos anti-RNP</li>
+<li>Anticuerpos anti-Ro/SSA</li>
+<li><strong>Anticuerpos anti-DNAn</strong></li>
+<li>Anticuerpos anti-La/SSB</li>
+<li>Todos los anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La orina "con espuma" sugiere proteinuria → sospecha de nefritis lúpica. Los anti-DNAn son los más relevantes por su valor diagnóstico (específicos) y pronóstico (predicen y siguen la actividad renal).</div>
+</div></details>
+
+<details class="qa"><summary>36. Varón con antiepilépticos, erupción solar y astenia</summary>
+<div class="qa-body">
+<p>Varón de 45 años en tratamiento con antiepilépticos, que consulta por erupción por exposición solar y astenia. ¿Cuál de las siguientes pruebas solicitaría?</p>
+<ol type="a">
+<li>Anticuerpos anti-DNAn</li>
+<li><strong>Anticuerpos anti-histonas</strong></li>
+<li>Anticuerpos anti-SSB/La</li>
+<li>Anticuerpos anti-ribosomal P0</li>
+<li>Anticuerpos anti-centrómero</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Anticonvulsivantes (fenitoína, carbamacepina) inducen lupus por fármacos → anti-histona característicos.</div>
+</div></details>
+
+<details class="qa"><summary>37. Marcador de riesgo de nefritis en LES</summary>
+<div class="qa-body">
+<p>Señale el marcador de riesgo de nefritis en un enfermo de LES:</p>
+<ol type="a">
+<li>Ser joven</li>
+<li>Varón</li>
+<li><strong>Raza negra</strong></li>
+<li>Eritema malar</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Factores de riesgo de nefritis lúpica: <em>raza negra/hispana</em>, joven (sobre todo adolescencia), varón, anti-DNAn altos, hipocomplementemia. Todas las opciones a-c son factores de riesgo, pero la "raza negra" es el más característico en preguntas de banco.</div>
+</div></details>
+
+<details class="qa"><summary>38. Anti-Ro/SSA — asociaciones</summary>
+<div class="qa-body">
+<p>Los anticuerpos anti-Ro/SSA se pueden asociar con:</p>
+<ol type="a">
+<li><strong>Lupus subagudo</strong></li>
+<li>Mola</li>
+<li>Lupus inducido por fármacos</li>
+<li>Síndrome de CREST (esclerodermia)</li>
+<li>Todas las respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Anti-Ro/SSA se asocian clásicamente al lupus cutáneo subagudo. NO se asocian a mola, lupus inducido (eso es anti-histona) ni CREST (eso es anti-centrómero).</div>
+</div></details>
+
+<details class="qa"><summary>39. Anti-Ro/SSA — entidades en las que se detectan</summary>
+<div class="qa-body">
+<p>Los anticuerpos anti-Ro/SSA se pueden detectar en:</p>
+<ol type="a">
+<li><strong>Lupus y síndrome de Sjögren asociado</strong></li>
+<li>Mola</li>
+<li>Lupus inducido por fármacos</li>
+<li>Miopatías inflamatorias</li>
+<li>Todas las respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El anti-Ro/SSA aparece en LES con Sjögren secundario asociado (overlap), Sjögren primario, lupus cutáneo subagudo, lupus neonatal, y a veces en miopatías inflamatorias (sobre todo en overlap).</div>
+</div></details>
+
+<details class="qa"><summary>40. NO es criterio ACR de LES</summary>
+<div class="qa-body">
+<p>¿Cuál NO es criterio de la ACR para la clasificación de LES?</p>
+<ol type="a">
+<li>Eritema malar</li>
+<li><strong>Cefaleas</strong></li>
+<li>Convulsiones</li>
+<li>Alteraciones renales</li>
+<li>Lupus discoide</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Las cefaleas NO son criterio ACR (a pesar de ser una manifestación común). Los criterios neurológicos son: convulsiones o psicosis.</div>
+</div></details>
+
+<details class="qa"><summary>41. Mujer con rash + leucopenia + anti-DNAn (+)</summary>
+<div class="qa-body">
+<p>Una mujer de 32 años refiere rash malar, tiene leucopenia y anticuerpos anti-DNAn (+):</p>
+<ol type="a">
+<li>No tiene lupus eritematoso sistémico</li>
+<li><strong>No tiene criterios de la ACR para clasificarla de LES, pero clínicamente podemos diagnosticarla de probable LES</strong></li>
+<li>Hay que seguir la evolución clínica para establecer el diagnóstico</li>
+<li>Puede tener un lupus inducido por anticonceptivos</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ACR clásicos requieren ≥ 4/11 criterios. Con 3 (rash, leucopenia, anti-DNAn) no se cumple formalmente, pero <em>clínicamente</em> es muy sugestivo de LES. Recuerda: criterios ≠ diagnóstico clínico.</div>
+</div></details>
+
+<details class="qa"><summary>42. Causa NO reconocida de brote lúpico</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes no es una causa reconocida de brote lúpico?</p>
+<ol type="a">
+<li>Estrés psíquico</li>
+<li>Luz ultravioleta</li>
+<li>Infecciones</li>
+<li><strong>Anticonceptivos con bajas dosis de estrógenos</strong></li>
+<li>Causas desconocidas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Los anticonceptivos con bajas dosis de estrógenos son seguros en LES estable sin aFL. Los anticonceptivos a <em>altas</em> dosis sí pueden desencadenar brotes. Otros desencadenantes claros: UV, infecciones (VEB), estrés, embarazo, ciertos fármacos.</div>
+</div></details>
+
+<details class="qa"><summary>43. Anti-La/SSB — asociaciones</summary>
+<div class="qa-body">
+<p>Los anticuerpos anti-La/SSB se pueden asociar con:</p>
+<ol type="a">
+<li><strong>Lupus subagudo</strong></li>
+<li>Preeclampsia</li>
+<li>Dermatomiositis</li>
+<li>Síndrome de CREST (esclerodermia)</li>
+<li>Todas las respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Anti-La/SSB se asocian a lupus cutáneo subagudo, síndrome de Sjögren y lupus neonatal. Suelen acompañar a anti-Ro/SSA.</div>
+</div></details>
+
+<details class="qa"><summary>44. Causas de brote lúpico</summary>
+<div class="qa-body">
+<p>Mujer de 18 años en tratamiento por LES desde los 10 años. Presenta brotes frecuentes de fiebre, afectación articular y serositis. Las causas a investigar como desencadenantes del brote son:</p>
+<ol type="a">
+<li>No hace correctamente el tratamiento</li>
+<li>Exposición al sol sin cremas de protección máxima</li>
+<li>Infecciones urinarias de repetición</li>
+<li>Ansiedad</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Cualquiera de esas causas puede desencadenar un brote: mala adherencia, UV, infecciones, estrés psíquico. Investigar las cuatro.</div>
+</div></details>
+
+<details class="qa"><summary>45. Mujer joven con fotosensibilidad + plaquetopenia + ANA (+)</summary>
+<div class="qa-body">
+<p>Mujer de 22 años que consulta por fotosensibilidad. En sangre periférica presenta 56.000 plaquetas/mm³ y anticuerpos antinucleares. ¿Cuál es la respuesta correcta?</p>
+<ol type="a">
+<li>No tiene LES</li>
+<li><strong>No tiene 4 criterios de la ACR para clasificarla de LES, pero clínicamente podemos diagnosticarla de probable LES</strong></li>
+<li>Hay que seguir la evolución clínica para establecer el diagnóstico</li>
+<li>Puede tener un lupus inducido por anticonceptivos</li>
+<li>Todas las anteriores son ciertas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Tiene 3 criterios (fotosensibilidad + plaquetopenia + ANA), insuficientes formalmente pero suficientes para un diagnóstico clínico orientativo.</div>
+</div></details>
+
+<details class="qa"><summary>46. Adolescente con GN "asas de alambre" + ANA (+)</summary>
+<div class="qa-body">
+<p>Mujer de 17 años sin antecedentes ni sintomatología, que debuta con glomerulonefritis informada con presencia de "asas de alambre" y semilunas. Tiene ANA positivo. ¿Cuál es correcta?</p>
+<ol type="a">
+<li><strong>Tiene un LES de acuerdo con los criterios de 2012 de la ACR (SLICC)</strong></li>
+<li>Tiene criterios para clasificarla de LES (ACR 1982)</li>
+<li>No tiene enfermedad lúpica</li>
+<li>Hay que seguir la evolución para decidir diagnóstico y tratamiento</li>
+<li>No tiene criterios diagnósticos de LES</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Según SLICC 2012 y EULAR/ACR 2019, una <strong>nefritis lúpica biopsiada</strong> + ANA o anti-DNAn (+) es suficiente para clasificar como LES, aunque no cumpla 4 criterios. Es una excepción importante.</div>
+</div></details>
+
+<details class="qa"><summary>47. LES con osteonecrosis + AINE + ↑ transaminasas</summary>
+<div class="qa-body">
+<p>Varón de 30 años con LES y osteonecrosis aséptica de cabeza humeral, con algias frecuentes que controla con AINE. Recientemente consulta por malestar, dolor inespecífico abdominal y discreta elevación de las transaminasas. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Hepatopatía autoinmune</li>
+<li>Isquemia intestinal</li>
+<li><strong>Efectos secundarios de AINE</strong></li>
+<li>Pancreatitis</li>
+<li>Trastorno de la motilidad gastrointestinal</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La toxicidad gástrica y hepática por AINE es muy frecuente. Antes de pensar en complicaciones graves del LES, descartar efectos farmacológicos.</div>
+</div></details>
+
+<details class="qa"><summary>48-50. Lupus inducido por minociclina o antiepilépticos</summary>
+<div class="qa-body">
+<p>Tres preguntas similares:<br>
+<strong>48.</strong> Mujer de 15 años con síntomas inespecíficos + eritemas + antecedentes de acné en tratamiento con tetraciclinas. ¿Qué prueba indicaría?<br>
+<strong>49.</strong> Varón de 36 años con convulsiones en tratamiento anticomicial, consulta por síntomas constitucionales y artralgias. ¿Qué prueba solicitaría?<br>
+<strong>50.</strong> Joven de 15 años en tratamiento antibiótico por acné, consulta por artralgias y aftas orales. ¿Qué prueba?</p>
+<ol type="a">
+<li>Anti-DNAn</li>
+<li>Anti-Ro/SSA</li>
+<li><strong>Anticuerpos anti-histonas</strong></li>
+<li>Anti-La/SSB / Anti-P ribosomal</li>
+<li>Anti-centrómero</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (las tres).</strong> Todos los escenarios apuntan a <em>lupus inducido por fármacos</em> (minociclina o anticonvulsivantes) → anti-histona.</div>
+</div></details>
+
+<details class="qa"><summary>51. LES de 10 años + brote + ardores + ↑ transaminasas</summary>
+<div class="qa-body">
+<p>Mujer de 40 años en tratamiento por LES desde hace 10 años. Tiene crisis de artritis, fiebre y derrame pleural. En el último brote refiere además ardores, náuseas y las transaminasas están elevadas. Lo más probable es que tenga:</p>
+<ol type="a">
+<li>Vasculitis intestinal</li>
+<li>Pancreatitis autoinmune</li>
+<li>Hepatitis autoinmune</li>
+<li><strong>Afectación digestiva por AINE</strong></li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Pirosis + náuseas + ↑ transaminasas en paciente con LES tratada (probablemente con AINE en brote) → gastritis/hepatotoxicidad por AINE es la causa más frecuente. Descartar siempre antes que diagnósticos más graves.</div>
+</div></details>
+
+<details class="qa"><summary>52. LES reciente — tratamiento inicial</summary>
+<div class="qa-body">
+<p>Paciente de 16 años con diagnóstico reciente de LES por cuadro constitucional, cutáneo, articular y positividad de anticuerpos anti-DNAn. Además de las medidas generales y cremas de protección, debe iniciarse tratamiento farmacológico con:</p>
+<ol type="a">
+<li>Corticoides</li>
+<li>Inmunosupresores</li>
+<li><strong>Hidroxicloroquina</strong></li>
+<li>Antiinflamatorios no esteroideos</li>
+<li>Cualquiera de los anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La HCQ es la base del tratamiento del LES desde el diagnóstico. Los corticoides se añaden si hay manifestaciones que no se controlan con HCQ + AINE. Los inmunosupresores se reservan para órgano amenazado.</div>
+</div></details>
+
+<details class="qa"><summary>53. Factores de peor pronóstico en LES</summary>
+<div class="qa-body">
+<p>Señale la respuesta correcta en relación con un peor pronóstico en enfermos con LES:</p>
+<ol type="a">
+<li>Aterosclerosis precoz</li>
+<li>Infecciones</li>
+<li>Bajo status socioeconómico</li>
+<li>Hipocomplementemia</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Todos son factores de mal pronóstico: aterosclerosis precoz (muerte tardía), infecciones (muerte precoz), bajo nivel socioeconómico (peor acceso y adherencia), hipocomplementemia (refleja actividad).</div>
+</div></details>
+
+<details class="qa"><summary>54. Osteonecrosis aséptica de cabeza femoral en LES</summary>
+<div class="qa-body">
+<p>Enfermo de LES que presenta dolores en caderas y unas lesiones radiológicas compatibles con osteonecrosis aséptica de cabeza de fémur. ¿Con qué tratamiento se relaciona esta complicación?</p>
+<ol type="a">
+<li>Antipalúdicos</li>
+<li>Azatioprina</li>
+<li><strong>Corticoides</strong></li>
+<li>AINE</li>
+<li>Ciclofosfamida</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los corticoides son la causa farmacológica más frecuente de osteonecrosis avascular (cabeza femoral, humeral, cóndilos). En LES contribuye también la vasculopatía y los aFL.</div>
+</div></details>
+
+<details class="qa"><summary>55. Varón joven con anti-DNAn altos + oliguria + edemas</summary>
+<div class="qa-body">
+<p>Varón de raza negra y 20 años que lleva 6 meses con erupción cutánea y anti-DNAn muy elevados. Comienza con oliguria, edemas e hipercolesterolemia. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Glomerulonefritis membranosa</li>
+<li>Glomerulonefritis mesangial</li>
+<li><strong>Glomerulonefritis proliferativa difusa (clase IV)</strong></li>
+<li>Nefropatía de cambios mínimos</li>
+<li>Glomerulonefritis proliferativa focal (clase III)</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Varón joven de raza negra con anti-DNAn altos → alto riesgo de nefritis clase IV (la más frecuente y grave). El síndrome nefrótico (edemas, hipercolesterolemia) + oliguria orienta a forma proliferativa difusa.</div>
+</div></details>
+
+<details class="qa"><summary>56. (Jun 2018) Manifestaciones respiratorias del LES</summary>
+<div class="qa-body">
+<p>Respecto a las manifestaciones respiratorias del LES, ¿qué considera cierto?</p>
+<ol type="a">
+<li>La afectación pleural es muy infrecuente y siempre es sintomática</li>
+<li>Si se observa derrame pleural suele tratarse de un trasudado</li>
+<li>La determinación de ANA en el líquido pleural no tiene ningún valor diagnóstico</li>
+<li><strong>Se manifiesta por dolor pleurítico, fiebre, tos y disnea, aunque a veces el derrame pleural es un hallazgo totalmente asintomático</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La pleuritis es muy frecuente. Cuando hay derrame, suele ser un <em>exudado</em> con ANA detectables (b y c falsos).</div>
+</div></details>
+
+<details class="qa"><summary>57. (Jun 2018) Enfermedad coronaria en LES</summary>
+<div class="qa-body">
+<p>Respecto a la enfermedad coronaria en pacientes con LES, ¿qué considera cierto?</p>
+<ol type="a">
+<li>Solo se aprecia en pacientes con dislipemia e HTA</li>
+<li><strong>Se ha convertido en la principal causa de muerte en pacientes con LES de inicio tardío o enfermedad de larga evolución, por lo que es obligado hacer un correcto control de los factores de riesgo cardiovascular</strong></li>
+<li>La inflamación crónica no parece jugar ningún papel en su desarrollo</li>
+<li>El tratamiento crónico con dosis elevadas de glucocorticoides no es un factor de riesgo</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Curva bimodal de mortalidad: precoz por enfermedad/infección, <em>tardía por enfermedad cardiovascular</em>. La inflamación crónica y los corticoides ↑ el riesgo CV.</div>
+</div></details>
+
+<details class="qa"><summary>58/62. (Parc/Jun 2019) Afectación cutánea del LES</summary>
+<div class="qa-body">
+<p>Sobre la afectación cutánea del lupus eritematoso (versión Parc 2019 / Jun 2019):</p>
+<ol type="a">
+<li>Las manifestaciones inespecíficas son de escasa importancia y responden fácilmente al tratamiento con corticoides tópicos</li>
+<li>Las manifestaciones específicas son fotosensibles a diferencia de las inespecíficas que no lo son</li>
+<li>El eritema en "alas de mariposa" es la única lesión específica del lupus eritematoso</li>
+<li><strong>Las manifestaciones específicas se caracterizan por presentar unos hallazgos típicos en la histología en la que hay una dermatitis de interfase</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Las lesiones inespecíficas no son banales (a falso). Las inespecíficas también son fotosensibles (b falso). Hay tres lesiones específicas: aguda, subaguda y crónica discoide (c falso).</div>
+</div></details>
+
+<details class="qa"><summary>59-61. (Parc 2019) Rebeca, LES con SAF (caso largo)</summary>
+<div class="qa-body">
+<p>Rebeca, 37 años. Hace meses: astenia, dolor poliarticular simétrico errático con rigidez matutina de 20 min, febrícula. Intolerancia al sol (lesiones eritematosas en zonas fotoexpuestas) y trastornos vasomotores acros (palidez 2º-3º dedos + cianosis tras frío). EF: TA 111/74, FC 90, eritema malar respetando surcos nasogenianos, dolor en carpos. Analítica: Hb 11,7, linfocitos 890/µL, plaquetas 125.000, PCR 8 mg/L. Orina: leucocituria, microhematuria, Pr/Cr 800 mg/g. ANA 1/1280 patrón homogéneo, anti-DNAn (+) 235 UR, C3 78, C4 8, aCL IgG &gt; 160, anti-β2GPI IgG &gt; 160, AL (+).</p>
+
+<p><strong>P59:</strong> ¿Diagnóstico?</p>
+<ol type="a">
+<li><strong>LES con afectación cutáneo-articular y SAF asociado</strong></li>
+<li>Conectivopatía indiferenciada</li>
+<li>LES (sin más)</li>
+<li>Los aFL solo cuentan si se repiten</li>
+</ol>
+<div class="answer"><strong>P59: a.</strong> Cumple LES (ANA, eritema malar, articular, linfopenia, hipocomplementemia, anti-DNAn, proteinuria). Triple aFL (+) sugiere SAF asociado (a confirmar a las 12 semanas).</div>
+
+<p><strong>P60:</strong> Sobre la orina:</p>
+<ol type="a">
+<li>Pr &gt; 500 mg/g indica nefritis lúpica que tratar de inmediato</li>
+<li><strong>Sedimento alterado + Pr &gt; 500 mg/g sugiere nefritis lúpica que confirmaremos con biopsia</strong></li>
+<li>Proteinuria de escasa entidad</li>
+<li>No vale Pr/Cr, hacer orina de 24 h</li>
+</ol>
+<div class="answer"><strong>P60: b.</strong> Sospecha alta de nefritis lúpica → <em>biopsia renal obligada</em>. El cociente Pr/Cr en orina aislada es válido.</div>
+
+<p><strong>P61:</strong> Sobre los aFL:</p>
+<ol type="a">
+<li><strong>Triple positividad confiere mayor riesgo de trombosis y complicaciones obstétricas</strong></li>
+<li>Contraindica el embarazo hasta negativizar los aFL</li>
+<li>Al tener LES se puede diagnosticar SAF sin evento previo</li>
+<li>Hay que anticoagular ya</li>
+</ol>
+<div class="answer"><strong>P61: a.</strong> Triple (+) = muy alto riesgo. NO contraindica el embarazo (se gestiona con HCQ + AAS + HBPM). NO se diagnostica SAF sin evento (criterios clínicos). NO se anticoagula sin evento previo (sólo AAS profiláctico).</div>
+</div></details>
+
+<details class="qa"><summary>63. (Jun 2019) Anticuerpos esperables en LES</summary>
+<div class="qa-body">
+<p>¿Qué anticuerpos esperas encontrar en un paciente con LES?</p>
+<ol type="a">
+<li>Los más característicos son los anti-centrómero</li>
+<li>Los anti-Mi2 son propios de la afectación osteomuscular</li>
+<li><strong>Prácticamente el 100 % de los pacientes tienen ANA. Los anti-DNAn se relacionan con la actividad</strong></li>
+<li>Los anti-histona solo se encuentran en pacientes con lupus inducido</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Anti-centrómero es de esclerodermia (a falso). Anti-Mi2 es de dermatomiositis (b falso). Anti-histona aparece en lupus inducido pero también en otros LES (d falso).</div>
+</div></details>
+
+<details class="qa"><summary>64. (Jun 2019) Artropatía de Jaccoud</summary>
+<div class="qa-body">
+<p>La artropatía de Jaccoud:</p>
+<ol type="a">
+<li>Aparece única y exclusivamente en el LES</li>
+<li>Se caracteriza por una artritis erosiva propia de enfermos con LES de larga evolución</li>
+<li>Es propio de los enfermos con RHUPUS (criterios de LES y AR) de larga evolución</li>
+<li><strong>Es una artropatía que cursa con deformaciones articulares, en principio reductibles, y se relaciona con el consumo de glucocorticoides, presencia de anti-Ro y anti-La</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Jaccoud: deformidades <em>NO erosivas, REDUCTIBLES</em> (cuello de cisne, desviación cubital) por afectación periarticular. También aparece tras fiebre reumática.</div>
+</div></details>
+
+<details class="qa"><summary>65. (Parc 2020) Nefritis lúpica — FALSO</summary>
+<div class="qa-body">
+<p>Sobre la nefritis lúpica, ¿qué considera FALSO?</p>
+<ol type="a">
+<li><strong>Afecta aproximadamente al 30-40 % de los pacientes y aparece cuando han transcurrido al menos 5 años de evolución</strong></li>
+<li>El tratamiento se ajusta según el tipo de nefritis</li>
+<li>Las formas más frecuentes y graves son las de clase III y IV que deben tratarse de forma enérgica</li>
+<li>La biopsia, salvo contraindicación, es obligada para el diagnóstico</li>
+</ol>
+<div class="answer"><strong>Respuesta: a (FALSA).</strong> La NL suele aparecer en los <em>primeros 5 años</em> de evolución del LES (no "después de"). Por eso hay que cribarla con sedimento, proteinuria y función renal en cada visita.</div>
+</div></details>
+
+<details class="qa"><summary>66. (Parc 2020) Afectación cutánea del LES — CIERTO</summary>
+<div class="qa-body">
+<p>Sobre la afectación cutánea del lupus eritematoso, ¿qué considera cierto?</p>
+<ol type="a">
+<li>No requiere tratamiento sistémico. El tratamiento tópico es suficiente</li>
+<li><strong>Las lesiones específicas se caracterizan, entre otras cosas, por tener dermatitis de interfase en la biopsia cutánea</strong></li>
+<li>Nunca preceden a las manifestaciones sistémicas</li>
+<li>Hay lesiones específicas e inespecíficas. Las inespecíficas suelen ser más benignas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Igual razonamiento que en preguntas 1, 3 y 58.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 4: SAF =============== -->
+<section class="card" id="t4">
+<h2 class="section-title"><span class="num">4</span>Síndrome Antifosfolípido (SAF)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Trombofilia autoinmune adquirida</strong>: trombosis y/o morbilidad obstétrica + aFL persistentes ≥ 12 semanas.</li>
+    <li><strong>Primario</strong> o <strong>secundario</strong> (sobre todo a LES).</li>
+    <li><strong>aFL clínicamente útiles (3):</strong> anticoagulante lúpico (AL), anticardiolipina (aCL), anti-β2GPI.</li>
+    <li><strong>Triple positividad</strong> → muy alto riesgo.</li>
+    <li><strong>SAF catastrófico (CAPS):</strong> microangiopatía trombótica en ≥ 3 órganos en &lt; 1 semana — mortalidad &gt; 30 %.</li>
+  </ul>
+</div>
+
+<h3>4.1 Criterios clasificatorios (Sapporo/Sídney 2006)</h3>
+<p>≥ 1 criterio clínico + ≥ 1 de laboratorio (con confirmación a ≥ 12 semanas).</p>
+
+<div class="compare">
+  <div>
+    <h4>📋 Criterios clínicos</h4>
+    <ul>
+      <li><strong>Trombosis vascular</strong> (venosa, arterial o de pequeño vaso) confirmada.</li>
+      <li><strong>Morbilidad obstétrica:</strong>
+        <ul>
+          <li>≥ 1 muerte fetal ≥ semana 10 sin causa morfológica.</li>
+          <li>≥ 1 parto prematuro &lt; sem 34 por preeclampsia/eclampsia/insuficiencia placentaria.</li>
+          <li>≥ 3 abortos consecutivos &lt; semana 10 sin otra causa.</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div>
+    <h4>🧪 Criterios de laboratorio</h4>
+    <p>Positividad en <strong>≥ 2 ocasiones separadas ≥ 12 semanas</strong>:</p>
+    <ul>
+      <li><strong>AL (+)</strong></li>
+      <li>aCL IgG/IgM a títulos medios-altos</li>
+      <li>anti-β2GPI IgG/IgM a títulos medios-altos</li>
+    </ul>
+  </div>
+</div>
+
+<h3>4.2 Manifestaciones (más allá de criterios)</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Vascular</span><span class="v">TVP MMII, TEP, ictus, IAM, trombosis venosa cerebral, Budd-Chiari</span></div>
+  <div class="kv"><span class="k">Cutáneo</span><span class="v">Livedo reticularis/racemosa, úlceras, <em>anetodermia</em>, Raynaud</span></div>
+  <div class="kv"><span class="k">Hematológico</span><span class="v"><strong>Trombocitopenia</strong>, anemia hemolítica</span></div>
+  <div class="kv"><span class="k">Cardíaco</span><span class="v">Endocarditis de Libman-Sacks</span></div>
+  <div class="kv"><span class="k">Neurológico</span><span class="v">Migraña, deterioro cognitivo, mielitis, déficit de atención</span></div>
+  <div class="kv"><span class="k">Renal</span><span class="v">Microangiopatía trombótica</span></div>
+  <div class="kv"><span class="k">Óseo</span><span class="v">Osteonecrosis aséptica de cadera</span></div>
+  <div class="kv"><span class="k">Coagulación</span><span class="v"><strong>TTPA alargado que NO corrige con plasma normal</strong> (AL)</span></div>
+</div>
+
+<h3>4.3 Tratamiento</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Situación</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>aFL (+) sin evento (profilaxis primaria)</td><td>AAS 100 mg/día + control FRCV; en LES asociado, añadir HCQ</td></tr>
+<tr><td>Trombosis venosa</td><td><strong>AVK (warfarina/acenocumarol) INR 2-3 indefinida</strong></td></tr>
+<tr><td>Trombosis arterial o triple (+)</td><td>INR 3-4 o INR 2-3 + AAS</td></tr>
+<tr><td>ACOD</td><td><strong>Contraindicados en triple (+)</strong> (rivaroxabán inferior a warfarina, sobre todo arterial)</td></tr>
+<tr><td>SAF obstétrico</td><td>AAS 100 + HBPM profiláctica/terapéutica · 6 semanas posparto</td></tr>
+<tr><td>SAF obstétrico refractario</td><td>+ HCQ ± pravastatina</td></tr>
+<tr><td>CAPS</td><td>Anticoagulación + corticoides altas dosis + <strong>plasmaféresis o IGIV</strong>; rituximab/eculizumab si refractario</td></tr>
+</tbody></table></div>
+
+<h3>4.4 Preguntas — SAF</h3>
+
+<details class="qa"><summary>1. (Parc 2018) Síndrome antifosfolípido catastrófico (CAPS)</summary>
+<div class="qa-body">
+<p>¿Qué caracteriza al síndrome antifosfolípido catastrófico?</p>
+<ol type="a">
+<li>Siempre cursa con trombosis venosa profunda</li>
+<li><strong>La aparición de una microangiopatía trombótica afectando a 3 o más órganos, sistemas o tejidos, de forma simultánea o en menos de 3 semanas</strong></li>
+<li>La presencia obligada de anticoagulante lúpico de forma persistente</li>
+<li>La benignidad del proceso</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> CAPS: microangiopatía trombótica multiorgánica (≥ 3 órganos/sistemas/tejidos) en &lt; 1 semana (criterios actualizados; antes &lt; 3 semanas) + confirmación histológica + aFL persistentes. Mortalidad &gt; 30 %.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2018) TVP clasificable como SAF</summary>
+<div class="qa-body">
+<p>Un paciente con una trombosis venosa profunda puede clasificarse como portador de un SAF si:</p>
+<ol type="a">
+<li>Solo si se detecta la presencia de anticoagulante lúpico</li>
+<li>Se debe detectar la presencia de AL, aCL o anti-β2GPI, hasta 5 años después del evento trombótico</li>
+<li><strong>Se debe detectar la presencia de AL, aCL o anti-β2GPI, hasta 5 años después del evento trombótico y confirmar su persistencia al menos 12 semanas después</strong></li>
+<li>Las trombosis venosas profundas no son criterio de SAF</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Criterios de Sapporo/Sídney: criterio clínico (trombosis o morbilidad obstétrica) + aFL (+) confirmados en ≥ 2 ocasiones separadas ≥ 12 semanas.</div>
+</div></details>
+
+<details class="qa"><summary>3. Mujer con LES + fallo multiorgánico + necrosis auricular + TEP</summary>
+<div class="qa-body">
+<p>Mujer de 41 años con antecedentes de LES desde hace 10 años que desarrolla en el último mes un cuadro de fallo multiorgánico con necrosis de pabellones auriculares, fracaso renal agudo y tromboembolismo pulmonar. Lo más probable es que se haya complicado por:</p>
+<ol type="a">
+<li>Nefritis lúpica</li>
+<li>Brote lúpico</li>
+<li>Abandono de tratamiento</li>
+<li><strong>Síndrome antifosfolípido catastrófico (CAPS)</strong></li>
+<li>Endocarditis</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Microangiopatía trombótica multiorgánica (piel acral, riñón, pulmón) en LES → CAPS. Mortalidad alta. Tratamiento: anticoagulación + corticoides + plasmaféresis o IGIV (± rituximab/eculizumab).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2016) SAF — verdadero</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes respuestas es verdadera respecto del SAF?</p>
+<ol type="a">
+<li>Hay acortamiento del TTPA</li>
+<li>Trombocitosis</li>
+<li>Anti-DNAn positivo</li>
+<li><strong>Hay asociación entre anticoagulante lúpico y tromboembolismo pulmonar</strong></li>
+<li>Anticuerpos anti-SSR/Ro (+)</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> El AL es el aFL con mayor riesgo trombogénico. En SAF hay <em>alargamiento</em> del TTPA (no acortamiento) que no corrige con plasma normal. Suele haber <em>trombocitopenia</em>, no trombocitosis.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2016) Adolescente con disnea + dímero D + aftas orogenitales</summary>
+<div class="qa-body">
+<p>Mujer de 15 años con disnea, dolor de costado y dímero D elevado. Refiere aftas orogenitales durante los últimos meses. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Síndrome antifosfolípido</li>
+<li>Lupus eritematoso sistémico</li>
+<li><strong>Enfermedad de Behçet</strong></li>
+<li>Enfermedad mixta del tejido conectivo</li>
+<li>Déficit de proteína C</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> ¡Pregunta trampa! Las aftas orogenitales recurrentes orientan a Behçet. La enfermedad de Behçet cursa con vasculitis con tendencia a TVP y TEP (componente trombótico característico). Asociación con HLA-B51.</div>
+</div></details>
+
+<details class="qa"><summary>6. Varón con trombosis venosas recurrentes y TEP</summary>
+<div class="qa-body">
+<p>Varón de 22 años con trombosis venosas de repetición y reciente TEP. ¿Cuál de los siguientes anticuerpos es más posible que le detectemos?</p>
+<ol type="a">
+<li>Anti-β2GPI</li>
+<li>Anticardiolipina IgG</li>
+<li><strong>Anticoagulante lúpico</strong></li>
+<li>Anticardiolipina IgM</li>
+<li>Anticardiolipina IgA</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> El AL es el aFL con mayor riesgo trombótico. La triple positividad es la situación de máximo riesgo. La IgG suele ser más patógena que IgM; la IgA tiene menor valor clínico.</div>
+</div></details>
+
+<details class="qa"><summary>7. Mujer con dos abortos + TEP + TTPA alargado</summary>
+<div class="qa-body">
+<p>Mujer de 29 años con antecedentes personales de dos abortos en las semanas 11 y 13 de gestación y tromboembolismo pulmonar. Se realiza determinación del TTPA y se encuentra alargado. ¿Cuál es el diagnóstico más probable?</p>
+<ol type="a">
+<li>Coagulación intravascular diseminada</li>
+<li>Déficit de proteína C</li>
+<li>Intoxicación por sintrom</li>
+<li><strong>Síndrome antifosfolípido</strong></li>
+<li>Policitemia vera</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Trombosis + morbilidad obstétrica + TTPA alargado paradójico (que no corrige con plasma normal) = patrón típico de SAF (anticoagulante lúpico in vitro, protrombótico in vivo).</div>
+</div></details>
+
+<details class="qa"><summary>8. Manifestaciones del SAF</summary>
+<div class="qa-body">
+<p>Puede ser manifestación del SAF:</p>
+<ol type="a">
+<li>Anetodermia</li>
+<li>Síndrome de Budd-Chiari</li>
+<li>Migrañas</li>
+<li>Trombopenia</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> El SAF puede afectar a casi cualquier sistema: piel (anetodermia, livedo, úlceras), hígado (Budd-Chiari), SNC (migrañas, ictus, deterioro cognitivo), hematológico (trombocitopenia, anemia hemolítica).</div>
+</div></details>
+
+<details class="qa"><summary>9. Mujer con flebitis + rash malar + aftas + AL (+)</summary>
+<div class="qa-body">
+<p>Mujer de 35 años con historia de flebitis, rash malar, aftas orales, ANA + patrón periférico y anticoagulante lúpico (+). El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Lupus eritematoso sistémico</li>
+<li><strong>LES con SAF asociado</strong></li>
+<li>SAF primario</li>
+<li>EMTC</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cumple criterios clínicos de LES (rash malar, aftas, ANA) + trombosis venosa + AL (+) → LES con SAF secundario asociado.</div>
+</div></details>
+
+<details class="qa"><summary>10. aFL clínicamente útiles</summary>
+<div class="qa-body">
+<p>¿Cuáles son los anticuerpos antifosfolípido que se emplean en la práctica clínica habitual para el diagnóstico del SAF?</p>
+<ol type="a">
+<li>AL + anti-β2GPI</li>
+<li>AL + anti-β2GPI + anti-protrombina</li>
+<li>aCL + anti-β2GPI + anti-protrombina</li>
+<li>AL + aCL</li>
+<li><strong>AL + aCL + anti-β2GPI</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Los tres aFL del panel clásico (Sapporo/Sídney) son: anticoagulante lúpico, anticardiolipina y anti-β2-glicoproteína I. Anti-protrombina no se usa en la práctica clínica habitual.</div>
+</div></details>
+
+<details class="qa"><summary>11. Mujer con abortos + livedo + AL (+)</summary>
+<div class="qa-body">
+<p>Mujer de 30 años con historia de abortos, afectación cutánea y livedo reticularis. Los ANA son positivos, patrón periférico, y el anticoagulante lúpico positivo. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Lupus eritematoso sistémico</li>
+<li><strong>LES con SAF asociado</strong></li>
+<li>SAF primario</li>
+<li>EMTC</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ANA (+) con patrón periférico (sugiere anti-DNAn) + clínica cutánea + abortos + AL (+) → más probable LES con SAF secundario. SAF primario tendría ANA negativos.</div>
+</div></details>
+
+<details class="qa"><summary>12. Mujer con abortos + TTPA alargado — prueba siguiente</summary>
+<div class="qa-body">
+<p>Mujer de 29 años con antecedentes personales de abortos en semanas 11 y 13 de gestación. TTPA alargado. ¿Cuál de las siguientes pruebas pediría a continuación?</p>
+<ol type="a">
+<li>Dímero D y fibrinógeno</li>
+<li>Proteína C y S</li>
+<li>Tomografía axial computerizada</li>
+<li><strong>Anticuerpos antifosfolípido</strong></li>
+<li>Extensión de sangre periférica</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Patrón de SAF (abortos + TTPA alargado) → solicitar panel completo de aFL (AL + aCL + anti-β2GPI).</div>
+</div></details>
+
+<details class="qa"><summary>13. Mujer con flebitis repetidas + astenia + artritis + ANA + aCL</summary>
+<div class="qa-body">
+<p>Mujer de 33 años con historia de flebitis repetidas de causa no aclarada, consulta por astenia, malestar general y artritis. Los ANA y aCL IgG e IgM son positivos. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Lupus eritematoso sistémico</li>
+<li><strong>LES con SAF asociado</strong></li>
+<li>SAF primario</li>
+<li>EMTC</li>
+<li>Todas las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Flebitis recurrentes (criterio trombótico) + artritis + ANA (+) + aCL (+) → LES (artritis + ANA) con SAF asociado.</div>
+</div></details>
+
+<details class="qa"><summary>14. ¿Quién puede ser clasificado como SAF?</summary>
+<div class="qa-body">
+<p>Solo uno de los siguientes pacientes puede ser clasificado como SAF. ¿Cuál?</p>
+<ol type="a">
+<li>Mujer de 31 años con 2 abortos (11 y 13 semanas) con AL (+) a títulos moderados-altos, <em>determinados en una ocasión</em></li>
+<li><strong>Varón de 41 años con TVP y TEP con aCL (+) a títulos moderados-altos repetidos en dos ocasiones separadas por 12 semanas</strong></li>
+<li>Mujer de 26 años, fumadora, en anticonceptivos, con TVP</li>
+<li>Varón de 68 años fumador, obeso, hipertenso, hipercolesterolémico ingresado por IAM con aCL bajos que se negativizan</li>
+<li>Mujer de 43 años con migrañas y anti-β2GPI bajos en dos ocasiones</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cumple criterio clínico (TVP + TEP) + criterio de laboratorio (aCL moderado-alto confirmado a las 12 semanas). El resto fallan: a no se ha confirmado a las 12 semanas; c-d-e no cumplen criterios clínicos o de laboratorio.</div>
+</div></details>
+
+<details class="qa"><summary>15. Mujer con abortos + fiebre + artritis + rash + aCL</summary>
+<div class="qa-body">
+<p>Mujer de 29 años con historia de varios abortos previos de causa no aclarada; consulta por fiebre, artritis y rash malar. Los ANA y aCL IgG e IgM son positivos. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Lupus eritematoso sistémico</li>
+<li><strong>LES con SAF asociado</strong></li>
+<li>SAF primario</li>
+<li>EMTC</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Mismo patrón: cumple LES + morbilidad obstétrica con aFL (+).</div>
+</div></details>
+
+<details class="qa"><summary>16. Manifestaciones del SAF — completa</summary>
+<div class="qa-body">
+<p>En el SAF puede haber:</p>
+<ol type="a">
+<li>Alargamiento del TTPA</li>
+<li>Trombocitopenia</li>
+<li>Osteonecrosis aséptica de cabeza de fémur</li>
+<li>Déficit de memoria/atención</li>
+<li><strong>Todo lo anterior</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> SAF puede cursar con: TTPA alargado (AL), trombocitopenia, osteonecrosis (por vasculopatía/trombosis subcondral), deterioro cognitivo (lesiones isquémicas múltiples en SNC).</div>
+</div></details>
+
+<details class="qa"><summary>17. (Parc 2019/Jun 2020) aFL y manejo de anticoagulación</summary>
+<div class="qa-body">
+<p>Respecto al SAF y los aFL, ¿qué considera cierto?</p>
+<ol type="a">
+<li><strong>Puede considerarse retirar la anticoagulación en caso de que la determinación de anticuerpos se haga negativa de forma persistente</strong></li>
+<li>Todos confieren el mismo riesgo de trombosis</li>
+<li>El riesgo de trombosis asociado a AL es muy bajo</li>
+<li>Otros factores (obesidad, HTA, dislipemia) no modifican el riesgo</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> En casos seleccionados (negativización persistente de aFL durante años, tras consenso multidisciplinar) se puede considerar retirar la anticoagulación. NO todos los aFL son iguales (b falso): el AL es el de mayor riesgo, especialmente la triple positividad. Los factores de riesgo CV SÍ modifican el riesgo (d falso).</div>
+</div></details>
+
+<details class="qa"><summary>18. (Jun 2019) NO es criterio clasificatorio del SAF</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes NO es criterio clasificatorio del SAF?</p>
+<ol type="a">
+<li><strong>Flebitis superficial</strong></li>
+<li>Una pérdida fetal</li>
+<li>Más de tres abortos consecutivos</li>
+<li>Trombosis arterial en cualquier territorio</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Las flebitis superficiales NO son criterio (solo TVP profunda u otros eventos trombóticos objetivados). Sí lo son: muerte fetal ≥ 10 sem, ≥ 3 abortos &lt; 10 sem, trombosis arterial.</div>
+</div></details>
+
+<details class="qa"><summary>19. (Jun 2019) SAF obstétrico con preeclampsia refractaria</summary>
+<div class="qa-body">
+<p>En mujeres con SAF obstétrico y desarrollo de preeclampsia a pesar de AAS y HBPM, una alternativa puede ser:</p>
+<ol type="a">
+<li>Administrar dosis elevadas de AAS</li>
+<li><strong>Añadir pravastatina</strong></li>
+<li>Añadir dosis elevadas de corticoides</li>
+<li>Sustituir la HBPM por sintrom</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Estudios prospectivos del grupo de Khamashta / Ruiz-Irastorza demuestran que añadir pravastatina mejora la perfusión placentaria y los resultados perinatales en SAF obstétrico con preeclampsia refractaria. La warfarina/sintrom está CONTRAINDICADA en el embarazo.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 5: Sjögren =============== -->
+<section class="card" id="t5">
+<h2 class="section-title"><span class="num">5</span>Síndrome de Sjögren</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Exocrinopatía autoinmune crónica</strong> con infiltración linfocítica de glándulas (xeroftalmia + xerostomía).</li>
+    <li><strong>Mujer 40-60 años, 9:1.</strong> Primario o secundario (AR, LES, ES).</li>
+    <li><strong>Anti-Ro/SSA (+) en 70 %, anti-La/SSB en 40 %.</strong></li>
+    <li><strong>Riesgo aumentado de LINFOMA B</strong> (sobre todo <em>MALT parotídeo</em>) — × 16-44.</li>
+  </ul>
+</div>
+
+<h3>5.1 Clínica</h3>
+<div class="compare">
+  <div>
+    <h4>👁️ Glandular</h4>
+    <ul>
+      <li><strong>Xeroftalmia:</strong> arenilla, fotofobia, queratoconjuntivitis seca. <em>Schirmer &lt; 5 mm/5 min</em>, tinciones con verde lisamina/rosa de Bengala.</li>
+      <li><strong>Xerostomía:</strong> caries cervicales múltiples, candidiasis, queilitis. <em>Flujo salival no estimulado &lt; 0,1 mL/min</em>.</li>
+      <li><strong>Hipertrofia parotídea</strong> recurrente.</li>
+      <li>Sequedad vaginal, cutánea, respiratoria.</li>
+    </ul>
+  </div>
+  <div>
+    <h4>🌐 Extraglandular</h4>
+    <ul>
+      <li>Artralgias / artritis no erosiva (60 %)</li>
+      <li>Fenómeno de Raynaud</li>
+      <li><strong>Vasculitis cutánea</strong> (púrpura palpable; crioglobulinas en ~10 %)</li>
+      <li>EPI (NSIP &gt; UIP), bronquiolitis</li>
+      <li><strong>Nefritis tubulointersticial con acidosis tubular tipo I</strong></li>
+      <li><strong>Polineuropatía sensitiva</strong>, ganglionopatía</li>
+      <li>Hipergammaglobulinemia, FR (+), crioglobulinemia</li>
+    </ul>
+  </div>
+</div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🚨</span>¡Sospecha de linfoma MALT en Sjögren!</div>
+  <ul style="margin:6px 0">
+    <li>Hipertrofia parotídea <strong>persistente unilateral</strong></li>
+    <li>Descenso súbito de IgM (de hipergamma a hipogamma)</li>
+    <li>Aparición de paraproteína</li>
+    <li>Descenso del C4</li>
+    <li>↑ β2-microglobulina</li>
+    <li>Púrpura, neuropatía</li>
+  </ul>
+</div>
+
+<h3>5.2 Diagnóstico (ACR/EULAR 2016)</h3>
+<p>Suma ≥ 4 puntos:</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Criterio</th><th>Puntos</th></tr></thead>
+<tbody>
+<tr><td>Biopsia de glándula salival menor con sialoadenitis linfocítica focal y <em>focus score ≥ 1</em></td><td><strong>3</strong></td></tr>
+<tr><td><strong>Anti-Ro/SSA (+)</strong></td><td><strong>3</strong></td></tr>
+<tr><td>Tinción ocular ≥ 5</td><td>1</td></tr>
+<tr><td>Schirmer ≤ 5 mm/5 min</td><td>1</td></tr>
+<tr><td>Flujo salival no estimulado ≤ 0,1 mL/min</td><td>1</td></tr>
+</tbody></table></div>
+
+<h3>5.3 Tratamiento</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Ocular</span><span class="v">Lágrimas artificiales · ciclosporina tópica · tapones lagrimales</span></div>
+  <div class="kv"><span class="k">Oral</span><span class="v">Hidratación · <strong>pilocarpina / cevimelina</strong> (agonistas muscarínicos)</span></div>
+  <div class="kv"><span class="k">Articular</span><span class="v">AINE · <strong>hidroxicloroquina</strong> (de elección)</span></div>
+  <div class="kv"><span class="k">Manifestaciones graves</span><span class="v">Corticoides · MTX/AZA/MMF · <strong>rituximab</strong> (vasculitis, crioglobulinas)</span></div>
+</div>
+
+<h3>5.4 Preguntas — Sjögren</h3>
+
+<details class="qa"><summary>1. Criterio diagnóstico del Sjögren</summary>
+<div class="qa-body">
+<p>Es criterio diagnóstico en el síndrome de Sjögren la presencia de:</p>
+<ol type="a">
+<li>Anticuerpos anticentrómero</li>
+<li>Autoanticuerpos anti-SSA/Ro</li>
+<li>Autoanticuerpos anti-SSB/La</li>
+<li><strong>Solo las respuestas b y c son correctas</strong></li>
+<li>Ninguna es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Anti-Ro/SSA (criterio mayor, 3 puntos en ACR/EULAR 2016) y anti-La/SSB son los autoanticuerpos típicos. Anti-centrómero es de esclerodermia limitada.</div>
+</div></details>
+
+<details class="qa"><summary>2. Anti-Ro/SSA — asociaciones</summary>
+<div class="qa-body">
+<p>El anticuerpo anti-Ro/SSA se relaciona con:</p>
+<ol type="a">
+<li>Lupus subagudo</li>
+<li>Síndrome de Sjögren</li>
+<li>Abortos</li>
+<li>Lupus neonatal</li>
+<li><strong>Todos los anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Lupus cutáneo subagudo, Sjögren primario/secundario, lupus neonatal y SAF obstétrico secundario.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2019/2020) Vigilancia de linfoma B en Sjögren</summary>
+<div class="qa-body">
+<p>En pacientes con síndrome de Sjögren:</p>
+<ol type="a">
+<li>Debemos vigilar el posible desarrollo de un linfoma no Hodgkin de linfocitos B. Lo sospecharemos sobre todo en pacientes <em>jóvenes</em>, tratados previamente con inmunodepresores</li>
+<li><strong>Debemos vigilar el posible desarrollo de un linfoma no Hodgkin de linfocitos B. Lo sospecharemos sobre todo en pacientes en los que los niveles de β2-microglobulina elevados previamente se normalicen de forma súbita, sobre todo si mantienen elevados los niveles de IgM</strong></li>
+<li>Lo sospecharemos en pacientes mayores con crioglobulinas negativas</li>
+<li>Lo sospecharemos en pacientes diagnosticados &gt; 60 años</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Riesgo de linfoma × 16-44 (sobre todo MALT parotídeo). Banderas rojas: <em>parotidomegalia unilateral persistente</em>, descenso súbito de IgM (paso de hipergamma a hipogamma), descenso del C4, aparición de paraproteína, ↑ β2-microglobulina, púrpura palpable, neuropatía, crioglobulinemia.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2017) Cómo diagnosticar Sjögren</summary>
+<div class="qa-body">
+<p>¿Cómo establecería el diagnóstico de un síndrome de Sjögren?</p>
+<ol type="a">
+<li>Es un diagnóstico de laboratorio. Se fundamenta en la presencia de anti-Ro y anti-La a título elevado</li>
+<li>La biopsia de labio es fundamental y debe hacerse siempre para confirmar el diagnóstico</li>
+<li><strong>Se fundamenta en la clínica de sequedad de mucosas, que debemos objetivar. Nos apoyaremos en la presencia de autoanticuerpos y, en ocasiones, en la biopsia de labio</strong></li>
+<li>Solo lo podremos establecer en pacientes diagnosticados de otra conectivopatía como LES o esclerodermia</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Diagnóstico clínico-laboratorio: clínica de sequedad de mucosas (objetivada con Schirmer, tinciones oculares, sialometría) + autoanticuerpos (anti-Ro/La) y/o biopsia de labio con focus score ≥ 1 si se necesita.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2016) Mujer con polineuropatía + parotidomegalia + sedimento</summary>
+<div class="qa-body">
+<p>Mujer de 45 años, remitida por el neurólogo, quien la ha diagnosticado de polineuropatía sensitivo-motora para la que no encuentra la causa. Refiere hipertrofia parotídea y se detectan alteraciones en el sedimento urinario. ¿Cuál de las siguientes pruebas le ayudaría más en el diagnóstico?</p>
+<ol type="a">
+<li>Anti-RNP</li>
+<li>Anti-PL7</li>
+<li>Anti-Jo-1</li>
+<li><strong>Anti-SSA/Ro</strong></li>
+<li>Anti-centrómero</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Polineuropatía + parotidomegalia + nefritis intersticial (alteraciones urinarias) = tríada extraglandular típica del Sjögren. Anti-Ro/SSA es el anticuerpo más característico.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2016) Mujer con artromialgias + anti-Ro</summary>
+<div class="qa-body">
+<p>Mujer de 65 años con artromialgias y astenia. ANA y anti-SSA/Ro positivos. ¿Cuál de los siguientes diagnósticos le parece más probable?</p>
+<ol type="a">
+<li>Lupus eritematoso sistémico</li>
+<li><strong>Síndrome de Sjögren</strong></li>
+<li>Enfermedad mixta del tejido conectivo</li>
+<li>Esclerosis sistémica limitada</li>
+<li>Miositis autoinmune</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Mujer mayor con artromialgias y anti-Ro/SSA → más probable Sjögren primario. El LES suele iniciarse antes (mujeres jóvenes). La EMTC tendría anti-RNP. Esclerodermia tendría anti-Scl-70/centrómero.</div>
+</div></details>
+
+<details class="qa"><summary>7. SS + artritis en mujer hipertensa — tratamiento</summary>
+<div class="qa-body">
+<p>¿Cuál es el tratamiento farmacológico más adecuado para una paciente de 60 años, hipertensa, con síndrome de Sjögren y artritis?</p>
+<ol type="a">
+<li>AINE</li>
+<li><strong>Hidroxicloroquina</strong></li>
+<li>Paracetamol</li>
+<li>Prednisona</li>
+<li>Metotrexato</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> HCQ es de elección para artritis no erosiva en Sjögren (igual que en LES). En hipertensa, evitar AINE crónicos. Corticoides y MTX se reservan para casos refractarios o manifestaciones graves.</div>
+</div></details>
+
+<details class="qa"><summary>8. Mujer con polineuropatía + sequedad leve</summary>
+<div class="qa-body">
+<p>Mujer de 40 años, remitida por el neurólogo con polineuropatía sensitivo-motora. Refiere leve sequedad de mucosas. ¿Cuál de las siguientes pruebas solicitaría?</p>
+<ol type="a">
+<li>Anti-RNP</li>
+<li>Anti-DNAn</li>
+<li>Anti-Sm</li>
+<li><strong>Anti-SSA/Ro</strong></li>
+<li>Anti-centrómero</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Sjögren puede cursar con polineuropatía sensitiva (a veces antes de la sequedad clara). Anti-Ro/SSA es el biomarcador clave.</div>
+</div></details>
+
+<details class="qa"><summary>9. Varón con SS de 5 años + disnea reciente</summary>
+<div class="qa-body">
+<p>Varón de 49 años con síndrome de Sjögren de 5 años de evolución estable, que consulta por cuadro reciente de malestar general, tos y disnea. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Hipertensión pulmonar</li>
+<li>Insuficiencia cardíaca</li>
+<li><strong>Linfoma</strong></li>
+<li>Leucemia</li>
+<li>Sarcoidosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Sjögren tiene riesgo aumentado × 16-44 de linfoma no Hodgkin B (especialmente MALT). En un paciente "estable" durante años que de pronto desarrolla síntomas constitucionales y respiratorios → sospechar linfoma pulmonar o sistémico.</div>
+</div></details>
+
+<details class="qa"><summary>10. Mujer mayor con artralgias incapacitantes + sequedad + anti-La</summary>
+<div class="qa-body">
+<p>Mujer de 60 años con artralgias que le han quitado calidad de vida, de 10 años de evolución, leve sequedad de mucosas y positividad de ANA y anti-SSB/La. ¿Qué fármaco indicaría de forma pautada?</p>
+<ol type="a">
+<li>Ibuprofeno</li>
+<li>Prednisona</li>
+<li>Paracetamol</li>
+<li><strong>Hidroxicloroquina</strong></li>
+<li>Metotrexato</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Igual que en preguntas anteriores: HCQ es el fármaco de elección para artralgias/artritis en Sjögren.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 6: Esclerodermia =============== -->
+<section class="card" id="t6">
+<h2 class="section-title"><span class="num">6</span>Esclerodermia / Esclerosis Sistémica (ES)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Enfermedad de <strong>vasculopatía + fibrosis + autoinmunidad</strong>.</li>
+    <li><strong>3 pilares patogénicos:</strong> vasculopatía (Raynaud, crisis renal) · activación inmune (autoanticuerpos) · fibrosis (TGF-β, PDGF).</li>
+    <li><strong>Mujer 4:1, 40-60 años.</strong> Alta mortalidad por <em>EPI</em> y <em>HAP</em>.</li>
+    <li>Variantes: <strong>limitada (lcSSc/CREST)</strong> vs <strong>difusa (dcSSc)</strong>.</li>
+  </ul>
+</div>
+
+<h3>6.1 Limitada vs difusa</h3>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>Limitada (lcSSc / CREST)</th><th>Difusa (dcSSc)</th></tr></thead>
+<tbody>
+<tr><td>Esclerosis cutánea</td><td><strong>Distal a codos y rodillas</strong> + cara</td><td><strong>Generalizada</strong> (proximal a codos/rodillas + tronco)</td></tr>
+<tr><td>Raynaud</td><td>Larga evolución previa (años)</td><td>Corta evolución antes del engrosamiento</td></tr>
+<tr><td>Capilaroscopia</td><td>Patrón "lento" / "late"</td><td>Patrón "activo" / agresivo</td></tr>
+<tr><td><strong>Anti-centrómero</strong></td><td><strong>+ (40-80 %)</strong></td><td>—</td></tr>
+<tr><td><strong>Anti-Scl-70</strong></td><td>—</td><td><strong>+ (20-40 %)</strong></td></tr>
+<tr><td>Anti-RNA pol III</td><td>—</td><td>+ (10-20 %), <em>crisis renal</em></td></tr>
+<tr><td>HAP</td><td><strong>Frecuente y tardía</strong></td><td>Menos frecuente</td></tr>
+<tr><td>EPI</td><td>Menos frecuente, leve</td><td><strong>Frecuente y precoz</strong></td></tr>
+<tr><td>Crisis renal</td><td>Rara</td><td><strong>Más frecuente</strong> (sobre todo en &lt; 4 años de evolución)</td></tr>
+<tr><td>Pronóstico</td><td>Mejor</td><td>Peor</td></tr>
+<tr><td>CREST</td><td><strong>C</strong>alcinosis · <strong>R</strong>aynaud · dismotilidad <strong>E</strong>sofágica · e<strong>S</strong>clerodactilia · <strong>T</strong>elangiectasias</td><td>—</td></tr>
+</tbody></table></div>
+
+<h3>6.2 Variantes especiales</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Pre-esclerodermia</span><span class="v">Raynaud + autoanticuerpos típicos + capilaroscopia anormal, sin esclerosis aún</span></div>
+  <div class="kv"><span class="k">Sine esclerodermia</span><span class="v">Visceral propia de ES sin afectación cutánea (raro, &lt; 5 %)</span></div>
+  <div class="kv"><span class="k">Solapamiento</span><span class="v">ES + miositis, ES + AR…</span></div>
+  <div class="kv"><span class="k">Morfea (esclerodermia localizada)</span><span class="v">Placas cutáneas sin afectación visceral — <strong>NO es ES</strong></span></div>
+</div>
+
+<h3>6.3 Manifestaciones por sistema</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Raynaud</span><span class="v">&gt; 95 % · úlceras digitales · pitting scars</span></div>
+  <div class="kv"><span class="k">Piel</span><span class="v">Edema → induración → atrofia · esclerodactilia · facies en máscara · microstomía · calcinosis · telangiectasias</span></div>
+  <div class="kv"><span class="k">Tendinosos</span><span class="v">Roces tendinosos palpables (forma difusa, <em>predicen crisis renal</em>)</span></div>
+  <div class="kv"><span class="k">Digestivo</span><span class="v"><strong>Dismotilidad esofágica + ERGE</strong> · Barrett · GAVE · sobrecrecimiento · neumatosis</span></div>
+  <div class="kv"><span class="k">Pulmonar — EPI</span><span class="v">NSIP en difusa con Scl-70 · TC: vidrio deslustrado, panal</span></div>
+  <div class="kv"><span class="k">Pulmonar — HAP</span><span class="v">Limitada de larga evolución · Eco + <em>cateterismo derecho confirmatorio</em></span></div>
+  <div class="kv"><span class="k">Cardíaco</span><span class="v">Miocardiopatía fibrótica · arritmias · derrame pericárdico</span></div>
+</div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🚨</span>Crisis renal esclerodérmica (CRE)</div>
+  <p style="margin:4px 0"><strong>Emergencia</strong>: HTA maligna de aparición brusca + IRA + microangiopatía trombótica + encefalopatía.</p>
+  <p style="margin:4px 0"><strong>Factores de riesgo:</strong> ES difusa de &lt; 4 años · anti-RNA pol III · <em>corticoides ≥ 15 mg/día</em> · anemia · derrame pericárdico.</p>
+  <p style="margin:4px 0"><strong>Tratamiento:</strong> <em>IECA (captopril)</em> a dosis crecientes — única intervención que cambia el pronóstico. <strong>NO retirar aunque la creatinina suba inicialmente.</strong> <strong>NO usar corticoides altas dosis</strong> (precipita la CRE).</p>
+</div>
+
+<h3>6.4 Tratamiento</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Raynaud / úlceras</span><span class="v">Medidas generales · calcioantagonistas · sildenafilo · <strong>bosentán</strong> (prevenir úlceras) · iloprost iv</span></div>
+  <div class="kv"><span class="k">Piel / fibrosis</span><span class="v">MTX (limitada) · MMF (difusa con EPI) · ciclofosfamida iv (EPI grave) · <strong>nintedanib</strong> · <strong>tocilizumab</strong> (ES temprana)</span></div>
+  <div class="kv"><span class="k">HAP</span><span class="v">Bosentán/macitentán · sildenafilo/tadalafilo · riociguat · iloprost/epoprostenol · <strong>terapia combinada precoz</strong></span></div>
+  <div class="kv"><span class="k">CRE</span><span class="v"><strong>IECA (captopril)</strong> en escalada · diálisis si precisa</span></div>
+  <div class="kv"><span class="k">Digestivo</span><span class="v">IBP a dosis altas · procinéticos · antibióticos rotatorios</span></div>
+</div>
+
+<h3>6.5 Preguntas — Esclerodermia</h3>
+
+<details class="qa"><summary>1. Tratamiento de la ES limitada no complicada</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes es el mejor tratamiento de la esclerosis limitada no complicada?</p>
+<ol type="a">
+<li>D-penicilamina</li>
+<li>Bosentán</li>
+<li><strong>Protección del frío, evitar estrés, tabaco y medidas generales</strong></li>
+<li>Prednisona a dosis bajas</li>
+<li>Antipalúdicos a dosis bajas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> En ES limitada SIN complicaciones, el tratamiento es conservador (medidas para el Raynaud, evitar tabaco, antiácidos para ERGE). El bosentán se reserva para prevenir úlceras digitales o tratar HAP. Los corticoides altos pueden precipitar crisis renal.</div>
+</div></details>
+
+<details class="qa"><summary>2. Mujer con Raynaud + disfagia + telangiectasias + capilaroscopia lenta</summary>
+<div class="qa-body">
+<p>Mujer de 35 años con síndrome de Raynaud de 8 años de evolución, disfagia y telangiectasias en manos. Capilaroscopia con patrón "lento". Se debe solicitar:</p>
+<ol type="a">
+<li>ANA</li>
+<li><strong>Anti-centrómero</strong></li>
+<li>Anti-SSB/La</li>
+<li>Anti-histona</li>
+<li>Anti-fosfolípido</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cuadro de CREST (Calcinosis, Raynaud, Esofagopatía, eSclerodactilia, Telangiectasias) = ES limitada. Anti-centrómero es el marcador típico (40-80 %).</div>
+</div></details>
+
+<details class="qa"><summary>3. Tratamiento de la HAP en ES</summary>
+<div class="qa-body">
+<p>El tratamiento más habitual y eficaz de la hipertensión pulmonar en la esclerosis sistémica es:</p>
+<ol type="a">
+<li>Inhibidores de la fosfodiesterasa</li>
+<li>Pentoxifilina</li>
+<li>Bosentán</li>
+<li><strong>Análogos de la prostaciclina</strong></li>
+<li>Vasodilatadores antagonistas del calcio</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> En el banco UGR, la respuesta es <em>análogos de prostaciclina</em> (epoprostenol, iloprost). En la práctica actual se usa terapia combinada precoz (ARE + PDE-5 ± prostaciclina ± riociguat). Los Ca antagonistas NO son eficaces en HAP grupo 1.</div>
+</div></details>
+
+<details class="qa"><summary>4. Mujer joven con Raynaud + esclerodermia progresiva + Scl-70</summary>
+<div class="qa-body">
+<p>Mujer de 15 años con síndrome de Raynaud de un año de evolución, esclerodermia progresiva, capilaroscopia con patrón agresivo y anti-Scl-70 (+):</p>
+<ol type="a">
+<li>Se trata muy probablemente de una esclerosis sistémica forma difusa</li>
+<li>Se debe tratar con IECA</li>
+<li>Hay que vigilar la afectación precoz visceral</li>
+<li>Es la esclerodermia con peor pronóstico</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Raynaud corto + esclerodermia rápida + Scl-70 = ES difusa. Tiene peor pronóstico, riesgo de crisis renal (tratar con IECA si aparece HTA + IRA), EPI y miocardiopatía precoces.</div>
+</div></details>
+
+<details class="qa"><summary>5. Tratamiento de la ES limitada</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes es el mejor tratamiento de la esclerosis sistémica limitada?</p>
+<ol type="a">
+<li>D-penicilamina</li>
+<li>Corticoides</li>
+<li><strong>Medidas generales: protección Raynaud, evitar estrés y el tabaco</strong></li>
+<li>Inmunosupresores (MMF)</li>
+<li>Plasmaféresis / hidroxicloroquina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Igual que la P1 — la ES limitada sin complicaciones se maneja con medidas generales. Los inmunosupresores y antifibróticos se reservan para EPI/fibrosis progresiva.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2016) ¿Qué fármaco empeora el Raynaud?</summary>
+<div class="qa-body">
+<p>¿Qué fármaco empeoraría el síndrome de Raynaud de una enferma con ES limitada?</p>
+<ol type="a">
+<li>Vasodilatador</li>
+<li><strong>Vasoconstrictor nasal / betabloqueante</strong></li>
+<li>Metotrexato</li>
+<li>Azatioprina</li>
+<li>Ciclofosfamida</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los β-bloqueantes (especialmente no selectivos) y vasoconstrictores nasales empeoran el Raynaud por vasoconstricción periférica adicional. <em>Evitar también ergotamina, sumatriptán, cocaína, anfetaminas.</em></div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2017/2020) Difusa vs limitada — ¿en qué se diferencian?</summary>
+<div class="qa-body">
+<p>¿Qué diferencia la esclerodermia sistémica difusa de la limitada?</p>
+<ol type="a">
+<li>El tipo de autoanticuerpo detectado. En la variante difusa encontraremos anti-Scl70 y en la limitada anti-centrómero</li>
+<li><strong>La diferencia se establece en función de la extensión de la afectación cutánea. En la variante limitada la esclerosis es distal a codos y rodillas, y en la difusa la esclerosis es generalizada</strong></li>
+<li>En la forma limitada los pacientes presentan HAP y calcinosis. En la difusa, EPI y afectación del tubo digestivo</li>
+<li>La presencia de ANA es una constante en la forma difusa. En la limitada faltan en la mitad de los casos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Por definición, la clasificación se basa en la extensión cutánea: <em>limitada = distal a codos y rodillas + cara</em>; <em>difusa = proximal a codos/rodillas + tronco</em>. Los autoanticuerpos suelen seguir el patrón pero no son obligatorios. Las complicaciones viscerales se superponen.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Jun 2018) Sobre el fenómeno de Raynaud</summary>
+<div class="qa-body">
+<p>Respecto al fenómeno de Raynaud, ¿qué considera cierto?</p>
+<ol type="a">
+<li><strong>Suele aparecer en mujeres jóvenes. Afecta preferentemente a la porción terminal de uno o varios dedos de las manos y cursa típicamente con tres fases</strong></li>
+<li>Siempre precede al desarrollo de una esclerodermia</li>
+<li>Aparece en más del 90 % de los pacientes con esclerodermia. En la forma difusa suele ser la primera y única manifestación durante años</li>
+<li>Solo se observa en las conectivopatías</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Tres fases: palidez (vasoespasmo) → cianosis (desoxigenación) → rubor (reperfusión). Aparece en &gt; 90 % de ES, pero suele ser la primera manifestación durante años en la <em>limitada</em>, no en la difusa (c falso). Es un fenómeno muy común incluso fuera de las conectivopatías (d falso).</div>
+</div></details>
+
+<details class="qa"><summary>9. Mujer mayor con Raynaud largo + disnea + anti-centrómero</summary>
+<div class="qa-body">
+<p>Mujer de 69 años con síndrome de Raynaud de 20 años. Recientemente presenta disnea de ligeros esfuerzos. Capilaroscopia con extravasaciones y megacapilares, pero muy pocas zonas avasculares. Anti-centrómero (+). El diagnóstico más probable es:</p>
+<ol type="a">
+<li><strong>ES limitada con probable hipertensión pulmonar</strong></li>
+<li>EMTC</li>
+<li>ES forma difusa, con afectación cardiopulmonar</li>
+<li>ES forma difusa cutánea</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Raynaud largo + anti-centrómero = ES limitada. Disnea de novo en ES limitada de larga evolución → sospechar <em>HAP</em>. Eco TT como cribado, confirmar con cateterismo derecho.</div>
+</div></details>
+
+<details class="qa"><summary>10. Úlceras digitales muy dolorosas — fármaco de elección</summary>
+<div class="qa-body">
+<p>Mujer de 48 años con ES y úlceras digitales muy dolorosas. El fármaco de elección es:</p>
+<ol type="a">
+<li><strong>Bosentán</strong></li>
+<li>Sildenafilo</li>
+<li>Análogos de prostaciclina</li>
+<li>Guanilato ciclasa</li>
+<li>Diltiazem</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Bosentán (antagonista del receptor de endotelina) está aprobado específicamente para <em>prevenir nuevas úlceras digitales</em> en ES. Para úlceras agudas o crisis isquémicas se usa <em>iloprost iv</em>.</div>
+</div></details>
+
+<details class="qa"><summary>11. Varón joven con Raynaud reciente + disnea + Scl-70 + capilaroscopia agresiva</summary>
+<div class="qa-body">
+<p>Varón de 19 años con Raynaud de 3 meses de evolución y reciente comienzo de disnea; capilaroscopia con zonas avasculares, extravasaciones y megacapilares; anti-Scl-70 (+). El diagnóstico más probable es:</p>
+<ol type="a">
+<li>ES forma limitada</li>
+<li>EMTC</li>
+<li><strong>ES forma difusa, con afectación cardiopulmonar</strong></li>
+<li>ES forma difusa cutánea</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Raynaud reciente + Scl-70 + capilaroscopia agresiva = forma difusa precoz, con riesgo de afectación cardiopulmonar (EPI sobre todo). Disnea en ES difusa con Scl-70 → pensar en EPI (no en HAP primaria).</div>
+</div></details>
+
+<details class="qa"><summary>12. Manifestaciones dermatológicas de la ES</summary>
+<div class="qa-body">
+<p>Pueden ser manifestaciones dermatológicas de la esclerosis sistémica:</p>
+<ol type="a">
+<li>Hinchazón</li>
+<li>Endurecimiento</li>
+<li>Retracciones cutáneas</li>
+<li>Calcificaciones subcutáneas</li>
+<li><strong>Todo lo anterior</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Tres fases cutáneas: edematosa (hinchazón) → indurativa (endurecimiento) → atrófica (retracciones). Más: telangiectasias, calcinosis subcutánea (típica del CREST), úlceras digitales, pitting scars.</div>
+</div></details>
+
+<details class="qa"><summary>13. Mujer mayor con Raynaud largo + esclerodactilia + anti-centrómero + disnea + síncopes</summary>
+<div class="qa-body">
+<p>Mujer de 65 años con Raynaud de larga evolución, endurecimiento de la piel en zonas acras, anti-centrómero (+), y recientemente cuadro de disnea de esfuerzo y algunos síncopes. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>ES forma preesclerodermia</li>
+<li>Esclerodermia sine esclerodermia</li>
+<li>ES forma localizada</li>
+<li><strong>ES limitada complicada con HAP</strong></li>
+<li>ES cutánea localizada (morfea)</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Síntomas clave de HAP avanzada: disnea de esfuerzo + síncopes (síncope = signo de mal pronóstico, refleja insuficiencia derecha por hipertensión pulmonar grave).</div>
+</div></details>
+
+<details class="qa"><summary>14. Mujer con Raynaud + capilaroscopia con megacapilares + anti-centrómero</summary>
+<div class="qa-body">
+<p>Mujer de 30 años con sintomatología de Raynaud. Capilaroscopia con megacapilares y extravasaciones. Anti-centrómero (+). El diagnóstico más probable es:</p>
+<ol type="a">
+<li><strong>ES forma preesclerodermia</strong></li>
+<li>Esclerodermia sine esclerodermia</li>
+<li>ES síndrome CREST</li>
+<li>ES forma difusa</li>
+<li>ES cutánea localizada (morfea)</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Raynaud + capilaroscopia anormal + autoanticuerpo de ES, pero SIN esclerosis cutánea aún → <em>pre-esclerodermia</em>. Conviene seguimiento porque muchos evolucionan a ES definida en años.</div>
+</div></details>
+
+<details class="qa"><summary>15. Mujer con Raynaud largo + disnea + megacapilares</summary>
+<div class="qa-body">
+<p>Mujer de 58 años con Raynaud de larga evolución y cuadro reciente de disnea con esfuerzos leves. Capilaroscopia con algunos megacapilares y extravasaciones. ¿Cuál es el diagnóstico más probable?</p>
+<ol type="a">
+<li>ES sistémica difusa</li>
+<li>ES sistémica limitada</li>
+<li><strong>ES limitada con HAP</strong></li>
+<li>Pre-esclerodermia</li>
+<li>Morfea</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Raynaud largo + disnea de novo + capilaroscopia de patrón limitado → ES limitada complicada con HAP.</div>
+</div></details>
+
+<details class="qa"><summary>16. Mujer joven con Raynaud + capilaroscopia con megacapilares + anti-centrómero</summary>
+<div class="qa-body">
+<p>Mujer de 40 años que consulta por Raynaud. Capilaroscopia con megacapilares y alguna extravasación, anti-centrómero (+). ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>Pre-esclerodermia</strong></li>
+<li>ES difusa</li>
+<li>ES localizada</li>
+<li>Esclerodermia sine esclerodermia</li>
+<li>Morfea</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Sin esclerosis cutánea aún + autoanticuerpo + capilaroscopia anormal = pre-esclerodermia. Aún no es ES limitada (haría falta esclerodactilia/esclerosis acra) ni sine (que tendría afectación visceral).</div>
+</div></details>
+
+<details class="qa"><summary>17. Varón con Raynaud + disnea + megacapilares + anti-centrómero</summary>
+<div class="qa-body">
+<p>Varón de 45 años con Raynaud de 10 años de evolución y reciente comienzo de disnea; capilaroscopia con megacapilares sin zonas avasculares; anti-centrómero (+). El diagnóstico más probable es:</p>
+<ol type="a">
+<li><strong>ES forma limitada con probable afectación cardiopulmonar</strong></li>
+<li>EMTC</li>
+<li>ES difusa con afectación cardiopulmonar</li>
+<li>ES difusa cutánea</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Raynaud largo + anti-centrómero = ES limitada. Disnea reciente → sospechar HAP. Sin áreas avasculares (todavía).</div>
+</div></details>
+
+<details class="qa"><summary>18. Mujer con Raynaud + endurecimiento cutáneo + crepitantes + áreas avasculares</summary>
+<div class="qa-body">
+<p>Mujer de 52 años con Raynaud de 2 años y endurecimiento progresivo de la piel. Refiere disnea de esfuerzo y crepitantes bibasales; capilaroscopia con zonas avasculares. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>ES preesclerodermia</li>
+<li>Esclerodermia sine esclerodermia</li>
+<li><strong>ES difusa complicada con fibrosis pulmonar (EPI)</strong></li>
+<li>ES limitada complicada con HAP</li>
+<li>ES cutánea localizada (morfea)</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Raynaud corto + endurecimiento progresivo + crepitantes bibasales (signo de EPI) + áreas avasculares (capilaroscopia agresiva) = ES difusa con EPI (NSIP en la mayoría, sobre todo con anti-Scl-70).</div>
+</div></details>
+
+<details class="qa"><summary>19. Mujer con CREST completo — anticuerpos a solicitar</summary>
+<div class="qa-body">
+<p>Mujer de 26 años con calcificaciones subcutáneas, Raynaud, disfagia, esclerodactilia y telangiectasias. ¿Qué anticuerpos deberían solicitarse?</p>
+<ol type="a">
+<li>ANA</li>
+<li><strong>Anti-centrómero</strong></li>
+<li>Anti-Scl-70</li>
+<li>Anti-RNP</li>
+<li>Anti-DNAn</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> CREST completo (Calcinosis, Raynaud, Esofagopatía, eSclerodactilia, Telangiectasias) = ES limitada → anti-centrómero (40-80 %).</div>
+</div></details>
+
+<details class="qa"><summary>20. (Jun 2018) ES limitada de 8 años + disnea progresiva</summary>
+<div class="qa-body">
+<p>Una paciente diagnosticada de esclerodermia limitada 8 años antes refiere disnea progresiva durante los meses anteriores. La AC y la placa de tórax son normales. ¿Qué proceso hay que descartar?</p>
+<ol type="a">
+<li>Fibrosis pulmonar complicada con sobreinfección</li>
+<li>Carcinoma de células alveolares</li>
+<li>Crisis renal</li>
+<li><strong>Hipertensión arterial pulmonar</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> ES limitada de larga evolución + disnea + Rx tórax normal → HAP. La fibrosis daría infiltrados; la crisis renal cursa con HTA/IRA, no disnea aislada; el carcinoma es muy raro.</div>
+</div></details>
+
+<details class="qa"><summary>21. (Jun 2018) Crisis renal esclerodérmica</summary>
+<div class="qa-body">
+<p>Una mujer de 36 años con ES difusa de 2 años es tratada con 30 mg de prednisona por un problema ocular. Consulta por cefalea con cifras de TA elevadas y deterioro de la función renal. ¿Cuál es correcta?</p>
+<ol type="a">
+<li>La crisis renal esclerodérmica es más frecuente en la forma limitada</li>
+<li><strong>La utilización de esteroides a dosis moderadas puede precipitar su aparición</strong></li>
+<li>El diagnóstico requiere una biopsia renal</li>
+<li>Los IECA se utilizan de forma rutinaria para prevenir su aparición</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> CRE: factor desencadenante reconocido = corticoides ≥ 15 mg/día. La CRE es más frecuente en la <em>difusa</em> (a falso). El diagnóstico es clínico (HTA brusca + IRA + MAT), no requiere biopsia rutinaria. Los IECA se usan para <em>tratar</em>, no para prevenir (d falso).</div>
+</div></details>
+
+<details class="qa"><summary>22. (Jun 2018) Capilaroscopia — utilidad</summary>
+<div class="qa-body">
+<p>La principal utilidad de la capilaroscopia es:</p>
+<ol type="a">
+<li>Establecer el diagnóstico de acrocianosis</li>
+<li>No tiene utilidad diagnóstica</li>
+<li><strong>Si se observa un patrón esclerodermiforme, en un paciente con Raynaud sin otras manifestaciones, contribuye a predecir el desarrollo de esclerodermia</strong></li>
+<li>Se utiliza sobre todo en pacientes con esclerodermia para guiar el tratamiento</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Capilaroscopia: distingue Raynaud primario (normal) de secundario (patrones SD: early, active, late). En Raynaud aislado + patrón SD → ↑↑ riesgo de evolucionar a ES.</div>
+</div></details>
+
+<details class="qa"><summary>23. (Jun 2019) Crisis renal esclerodérmica — FALSA</summary>
+<div class="qa-body">
+<p>Sobre la crisis renal en la esclerodermia, ¿qué considera FALSO?</p>
+<ol type="a">
+<li>Suele presentarse en los primeros años del curso de la enfermedad</li>
+<li>Es más prevalente en pacientes con la variante difusa</li>
+<li>Los glucocorticoides en dosis &gt; 15 mg/d en los 6 meses previos se consideran factor desencadenante</li>
+<li><strong>Es una complicación grave que no dispone de otro tratamiento salvo la nefrectomía</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d (FALSA).</strong> El tratamiento de la CRE son los <em>IECA (captopril)</em> a dosis crecientes — única intervención que cambia el pronóstico. Diálisis si precisa. NO requiere nefrectomía. NO retirar los IECA aunque la creatinina suba inicialmente.</div>
+</div></details>
+
+<details class="qa"><summary>24. (Jun 2019) Beatriz, ES limitada con disnea — diagnóstico</summary>
+<div class="qa-body">
+<p>Beatriz, 46 años. Hace 8 años diagnosticada de ES limitada (Raynaud + esclerodactilia + úlceras digitales + esofagopatía + capilaroscopia activa). Visita actual: disnea de esfuerzo de 4 meses. AC, ECG y TC de tórax normales. ¿Qué complicación puede tener y cómo la diagnosticaría?</p>
+<ol type="a">
+<li>Probablemente neumopatía intersticial → confirmar con exploración funcional respiratoria</li>
+<li>La disnea en esclerodermia suele ser transitoria</li>
+<li>Hay que pensar en HAP. La ecocardiografía puede mostrar PAPs elevada. El cateterismo confirmará</li>
+<li><strong>Hay que pensar en HAP que diagnosticaría mediante ecocardiografía. El cateterismo es necesario en casos de duda</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> En ES limitada de larga evolución con disnea progresiva y TC tórax normal (excluye EPI) → la causa más probable es HAP. Cribado con eco TT (PAPs estimada) y <em>cateterismo derecho confirmatorio en casos de duda</em> (la opción c es correcta pero d es la del banco — ambas dicen prácticamente lo mismo).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 7: Miopatías =============== -->
+<section class="card" id="t7">
+<h2 class="section-title"><span class="num">7</span>Miopatías inflamatorias idiopáticas (MII)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Subtipos:</strong> Polimiositis · Dermatomiositis · DM amiopática · Miositis por cuerpos de inclusión · Miopatía necrosante autoinmune · Síndrome antisintetasa.</li>
+    <li><strong>Clínica nuclear:</strong> debilidad muscular proximal simétrica subaguda.</li>
+    <li><strong>DM:</strong> + lesiones cutáneas patognomónicas (heliotropo, Gottron).</li>
+    <li><strong>MCI:</strong> &gt; 50 años, asimétrica distal, <em>mala respuesta al tratamiento</em>.</li>
+    <li>Buscar <strong>neoplasia oculta</strong> en DM &gt; 40 años (anti-TIF1γ, NXP-2).</li>
+  </ul>
+</div>
+
+<h3>7.1 Subtipos clave</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Subtipo</th><th>Características</th><th>Anticuerpos</th></tr></thead>
+<tbody>
+<tr><td>Polimiositis (PM)</td><td>Diagnóstico de exclusión; más rara de lo pensado</td><td>—</td></tr>
+<tr><td>Dermatomiositis (DM)</td><td>Debilidad + manifestaciones cutáneas</td><td>Anti-Mi-2, anti-TIF1γ (paraneoplásica), anti-NXP-2</td></tr>
+<tr><td>DM amiopática</td><td>Sólo piel, EPI rápidamente progresiva</td><td><strong>Anti-MDA5</strong></td></tr>
+<tr><td>Miositis por cuerpos de inclusión (MCI)</td><td>&gt; 50 años · varones · <em>asimétrica distal</em> (flexores dedos, cuádriceps) · <strong>refractaria</strong></td><td>Anti-cN1A</td></tr>
+<tr><td>Miopatía necrosante autoinmune (MNAI)</td><td>Debilidad proximal grave · <em>CK muy altas (10-50 mil)</em> · necrosis sin infiltrado</td><td><strong>Anti-SRP</strong> (cardio), <strong>anti-HMGCR</strong> (estatinas)</td></tr>
+<tr><td>Síndrome antisintetasa (SAS)</td><td>Miositis + artritis + Raynaud + <em>EPI</em> + <em>manos de mecánico</em> + fiebre + telangiectasias</td><td><strong>Anti-Jo-1</strong> (más frecuente) · PL-7, PL-12, EJ, OJ, KS</td></tr>
+</tbody></table></div>
+
+<h3>7.2 Lesiones cutáneas patognomónicas de DM</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Heliotropo</span><span class="v">Eritema violáceo en párpados superiores</span></div>
+  <div class="kv"><span class="k">Pápulas de Gottron</span><span class="v">Sobre MCF/IFP, codos, rodillas</span></div>
+  <div class="kv"><span class="k">Signo del chal</span><span class="v">Eritema en V cervical y hombros</span></div>
+  <div class="kv"><span class="k">Signo de la funda</span><span class="v">Eritema en cara externa de brazos y hombros</span></div>
+  <div class="kv"><span class="k">Manos de mecánico</span><span class="v">Hiperqueratosis fisurada lateral / palmar (síndrome antisintetasa)</span></div>
+  <div class="kv"><span class="k">Calcinosis</span><span class="v">Frecuente en <em>DM juvenil</em></span></div>
+  <div class="kv"><span class="k">Capilaroscopia</span><span class="v">Megacapilares y otras alteraciones</span></div>
+</div>
+
+<h3>7.3 Diagnóstico</h3>
+<ol>
+  <li>Clínica + signos cutáneos.</li>
+  <li><strong>CK elevada</strong> + aldolasa + AST + LDH.</li>
+  <li>EMG (patrón miopático).</li>
+  <li>RM muscular (edema T2/STIR; guía biopsia).</li>
+  <li><strong>Biopsia muscular</strong> (DM: perivascular CD4/B + atrofia perifascicular + C5b-9 en capilares; PM: endomisial CD8; MCI: vacuolas ribeteadas; MNAI: necrosis sin infiltrado).</li>
+  <li>Autoanticuerpos (MSA, MAA).</li>
+  <li><strong>Cribado de neoplasia</strong> en &gt; 40 años: TAC TAP · mamografía · ginecológica · endoscopia · PET-TAC si TIF1γ/NXP-2.</li>
+</ol>
+
+<h3>7.4 Tratamiento</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Base</span><span class="v">Corticoides 1 mg/kg</span></div>
+  <div class="kv"><span class="k">Ahorradores</span><span class="v">MTX · AZA</span></div>
+  <div class="kv"><span class="k">EPI / refractario</span><span class="v"><strong>MMF</strong> · <strong>rituximab</strong> · ciclofosfamida iv</span></div>
+  <div class="kv"><span class="k">DM grave / disfagia</span><span class="v"><strong>IGIV</strong></span></div>
+  <div class="kv"><span class="k">MNAI por estatinas</span><span class="v">Retirar estatina + IGIV + corticoide ± inmunosupresor</span></div>
+  <div class="kv"><span class="k">MCI</span><span class="v"><strong>NO responde bien</strong> a inmunosupresión</span></div>
+</div>
+
+<h3>7.5 Preguntas — Miopatías inflamatorias</h3>
+
+<details class="qa"><summary>1. (Jun 2019/2020) Miopatía necrosante autoinmune</summary>
+<div class="qa-body">
+<p>Sobre la miopatía necrosante autoinmune:</p>
+<ol type="a">
+<li>Es una forma muy infrecuente de miopatía que sucede única y exclusivamente en pacientes tratados con estatinas</li>
+<li>En los casos que aparecen en pacientes tratados con estatinas se resuelve una vez que se retira dicho tratamiento</li>
+<li>Siempre aparece en enfermos con alguna conectivopatía</li>
+<li><strong>Los niveles de CK suelen ser más elevados que en otras miopatías inflamatorias y situarse entre 6.000-15.000 UI</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> MNAI tiene CK muy elevadas (10-50 mil UI). Biopsia: necrosis sin infiltrado linfocitario. Anti-SRP (cardiopatía grave) o anti-HMGCR (estatinas). En el caso de anti-HMGCR, NO basta con retirar la estatina (b falso) — requiere inmunosupresión (IGIV + corticoide + MTX/AZA).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2017) Síndrome antisintetasa</summary>
+<div class="qa-body">
+<p>El síndrome antisintetasa:</p>
+<ol type="a">
+<li>Se caracteriza por la asociación de miopatía inflamatoria, poliartritis, fenómeno de Raynaud y manos de mecánico</li>
+<li>La enfermedad pulmonar intersticial es una manifestación frecuente</li>
+<li>Suele cursar con anticuerpos antisintetasa, de los cuales el más frecuente es el anti-Jo-1</li>
+<li><strong>Todas las anteriores son ciertas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> SAS tríada/pentada: miositis + artritis no erosiva + Raynaud + EPI (la manifestación dominante) + manos de mecánico + fiebre + telangiectasias. Anti-Jo-1 es el más frecuente; otros: PL-7, PL-12, EJ, OJ.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2016) En la dermatomiositis</summary>
+<div class="qa-body">
+<p>En la dermatomiositis hay:</p>
+<ol type="a">
+<li>Afectación muscular distal y facial</li>
+<li>Excepcional asociación con neoplasia</li>
+<li>No hay infiltración de linfocitos T en el estudio AP</li>
+<li>No hay alteraciones en la electromiografía</li>
+<li><strong>Suele haber alteraciones en la capilaroscopia</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> DM cursa con capilaroscopia anormal (megacapilares, áreas avasculares). La debilidad es <em>proximal</em>, no distal (a falso). Asociación con neoplasia importante (especialmente &gt; 40 años; anti-TIF1γ y NXP-2). Biopsia: infiltrado perivascular CD4/B con atrofia perifascicular. EMG: patrón miopático.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2016) Anticuerpo de peor pronóstico en miopatías</summary>
+<div class="qa-body">
+<p>¿Qué anticuerpo se relaciona con peor pronóstico en las miopatías autoinmunes?</p>
+<ol type="a">
+<li>ANA</li>
+<li><strong>Anti-PL7</strong></li>
+<li>Anti-Jo-1</li>
+<li>Anti-PL12</li>
+<li>Anti-Mi</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los anti-sintetasas <em>no Jo-1</em> (PL-7, PL-12, EJ, OJ) se asocian con peor pronóstico por mayor afectación pulmonar (EPI rápidamente progresiva). Anti-MDA5 también es de muy mal pronóstico (DM amiopática con EPI fulminante). Anti-Mi-2 es de mejor pronóstico (DM "clásica" sin EPI grave).</div>
+</div></details>
+
+<details class="qa"><summary>5. Enunciado NO correcto en miopatías</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes enunciados NO es correcto?</p>
+<ol type="a">
+<li>Las calcificaciones son más frecuentes en la dermatomiositis juvenil</li>
+<li>Hay que investigar neoplasia en las distrofias musculares de personas mayores</li>
+<li>La miositis por cuerpos de inclusión responde mal al tratamiento</li>
+<li><strong>Las manos de "mecánico" no son hallazgo sugerente de dermatomiositis</strong></li>
+<li>Las miopatías pueden complicarse con afectación cardiopulmonar</li>
+</ol>
+<div class="answer"><strong>Respuesta: d (INCORRECTA).</strong> Las "manos de mecánico" SÍ son típicas de la dermatomiositis dentro del síndrome antisintetasa. Las demás son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>6. DM grave con deseo de embarazo</summary>
+<div class="qa-body">
+<p>Mujer de 32 años con DM grave (muscular y cutánea) que desea quedarse embarazada. ¿Cuál es el tratamiento de elección?</p>
+<ol type="a">
+<li>Prednisona</li>
+<li>Prednisona + metotrexato</li>
+<li><strong>Prednisona + rituximab</strong></li>
+<li>Prednisona + ciclofosfamida</li>
+<li>Prednisona + azatioprina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> MTX y CFM son teratógenos (contraindicados). AZA sería la opción más segura como ahorrador de corticoide en embarazo planeado, pero entre las opciones del banco, rituximab es aceptable (recordar evitar embarazo durante 6-12 meses tras rituximab). En la práctica actual: prednisona + AZA + IGIV son la mejor combinación segura.</div>
+</div></details>
+
+<details class="qa"><summary>7. Manifestaciones de la DM</summary>
+<div class="qa-body">
+<p>En la dermatomiositis hay:</p>
+<ol type="a">
+<li>Afectación muscular y cutánea predominante</li>
+<li>Hay que descartar neoplasia oculta</li>
+<li>Hay infiltración de linfocitos T en el estudio AP</li>
+<li>Puede haber alteraciones en la capilaroscopia</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Todas correctas: piel + músculo, cribar neoplasia (sobre todo &gt; 40 años, anti-TIF1γ/NXP-2), biopsia con infiltrado perivascular (T CD4/B), capilaroscopia con megacapilares.</div>
+</div></details>
+
+<details class="qa"><summary>8. LES con HCQ + estatinas + debilidad muscular</summary>
+<div class="qa-body">
+<p>Mujer de 28 años con LES en HCQ + prednisona + hipercolesterolemia familiar grave con estatina. Presenta algias difusas y debilidad muscular. ¿Posible diagnóstico?</p>
+<ol type="a">
+<li>Miopatía esteroidea</li>
+<li>Miopatía de causa tiroidea</li>
+<li>Miopatía por estatinas</li>
+<li>Miopatía por hidroxicloroquina</li>
+<li><strong>Cualquiera de las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Polifarmacia + LES con riesgo de hipotiroidismo. Hay que evaluar TODAS las causas: corticoides (sin elevación de CK), estatinas (con CK alta o miopatía necrosante anti-HMGCR), hipotiroidismo (TSH), HCQ (rara, vacuolar).</div>
+</div></details>
+
+<details class="qa"><summary>9. Varón con debilidad + cataratas + miocardiopatía</summary>
+<div class="qa-body">
+<p>Varón de 36 años con gran debilidad muscular, cataratas y miocardiopatía. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Miopatía congénita tipo Thomsen</li>
+<li><strong>Distrofia miotónica de Steinert</strong></li>
+<li>Enfermedad de Becker</li>
+<li>Enfermedad de Duchenne</li>
+<li>Enfermedad de Emery-Dreyfuss</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ¡Pregunta trampa! NO es miopatía inflamatoria. Steinert (distrofia miotónica tipo 1) cursa con miotonía + debilidad distal + <em>cataratas + alopecia frontal + atrofia gonadal + miocardiopatía con trastornos de conducción + diabetes</em>. Herencia AD, gen DMPK.</div>
+</div></details>
+
+<details class="qa"><summary>10. Síndrome de solapamiento</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes afirmaciones es correcta?</p>
+<ol type="a">
+<li>Es fundamental hacer el diagnóstico de cada una de las entidades que conforman un overlap para instaurar un tratamiento curativo</li>
+<li><strong>Un paciente tiene un overlap cuando coexisten síntomas, signos, hallazgos histológicos y autoanticuerpos que permiten identificar dos o más EAS a la vez o de forma solapada</strong></li>
+<li>La clínica y autoinmunidad de las EAS permanecen invariables a lo largo de la evolución</li>
+<li>La asociación DM/PM + esclerodermia es un overlap excepcional</li>
+<li>Cada overlap tiene un patrón de autoanticuerpos específico</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Overlap = solapamiento clínico-serológico de ≥ 2 EAS. La clínica y autoinmunidad pueden evolucionar con el tiempo (c falso). DM/PM + ES es uno de los overlaps más frecuentes (anti-PM/Scl); d falso. No existe un patrón único para cada overlap (e falso).</div>
+</div></details>
+
+<details class="qa"><summary>11. Mujer con artritis + Raynaud + manos de mecánico + Jo-1</summary>
+<div class="qa-body">
+<p>Mujer de 43 años con artritis, eritema, Raynaud, "manos de mecánico", fibrosis pulmonar y anticuerpos Jo-1. El diagnóstico más correcto es:</p>
+<ol type="a">
+<li><strong>Síndrome antisintetasa</strong></li>
+<li>Dermatomiositis asociada a overlap</li>
+<li>Síndrome overlap/solapamiento</li>
+<li>Polimiositis</li>
+<li>Miositis por cuerpos de inclusión</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Tríada/pentada clásica del SAS: miositis + artritis + Raynaud + manos de mecánico + EPI + anti-Jo-1.</div>
+</div></details>
+
+<details class="qa"><summary>12. Joven con Raynaud + artritis + manos de mecánico</summary>
+<div class="qa-body">
+<p>Mujer de 19 años con Raynaud, artritis y "manos de mecánico". ¿Qué anticuerpo solicitaría?</p>
+<ol type="a">
+<li>Anti-Ro/SSA</li>
+<li>Anti-centrómero</li>
+<li>Anti-Scl-70</li>
+<li>Anti-RNP</li>
+<li><strong>Anti-Jo-1</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Manos de mecánico = característica del síndrome antisintetasa → anti-Jo-1 (el más frecuente de los anti-tRNA-sintetasas).</div>
+</div></details>
+
+<details class="qa"><summary>13. Mujer con debilidad + manos de mecánico + crepitantes bibasales</summary>
+<div class="qa-body">
+<p>¿Qué anticuerpo solicitaría a una paciente de 49 años con debilidad muscular, "manos de mecánico" y estertores crepitantes bibasales?</p>
+<ol type="a">
+<li>ANA</li>
+<li>Anti-RNP</li>
+<li><strong>Anti-Jo-1</strong></li>
+<li>Anti-PL12</li>
+<li>Anti-PM/Scl</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Otra presentación del síndrome antisintetasa con EPI (crepitantes) — anti-Jo-1 el más frecuente.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 8: EMTC =============== -->
+<section class="card" id="t8">
+<h2 class="section-title"><span class="num">8</span>EMTC y conectivopatía indiferenciada</h2>
+
+<h3>8.1 Conectivopatía indiferenciada (CTI / UCTD)</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🔍</span>Concepto</div>
+  <p style="margin:0">Pacientes con <strong>clínica de EAS</strong> y <strong>ANA (+)</strong> que NO cumplen criterios de ninguna entidad concreta. <em>1/3 evolucionan a una EAS, 1/3 permanecen indiferenciados, 1/3 remiten.</em></p>
+</div>
+
+<h3>8.2 Enfermedad Mixta del Tejido Conectivo (EMTC)</h3>
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Solapamiento de <strong>LES + ES + miositis ± AR</strong>.</li>
+    <li><strong>Anti-RNP a títulos altos (obligatorio).</strong></li>
+    <li>Mujer 9:1, 30-40 años.</li>
+    <li>Clínica: <em>manos hinchadas (puffy hands) + Raynaud + artritis no erosiva + miositis + esclerodactilia</em>.</li>
+    <li><strong>HAP = principal causa de mortalidad</strong> en EMTC.</li>
+    <li>Menos frecuente que en LES: <em>nefritis grave y SNC</em>.</li>
+  </ul>
+</div>
+
+<h3>8.3 Criterios de Alarcón-Segovia</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Criterio</th><th>Descripción</th></tr></thead>
+<tbody>
+<tr><td><strong>Serológico</strong></td><td>Anti-RNP (+) a título <strong>≥ 1:1.600</strong></td></tr>
+<tr><td colspan="2"><strong>Clínicos (≥ 3 de 5):</strong></td></tr>
+<tr><td>1</td><td>Edema de manos</td></tr>
+<tr><td>2</td><td>Sinovitis</td></tr>
+<tr><td>3</td><td>Miositis (clínica o de laboratorio)</td></tr>
+<tr><td>4</td><td>Raynaud</td></tr>
+<tr><td>5</td><td>Acroesclerosis (esclerodactilia)</td></tr>
+</tbody></table></div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">⚠</span>Atención</div>
+  <p style="margin:0"><strong>El anti-DNAn NO es criterio de EMTC.</strong> Su presencia habla a favor de LES.</p>
+</div>
+
+<h3>8.4 Preguntas — EMTC y CTI</h3>
+
+<details class="qa"><summary>1. (Jun 2016) Complicación más frecuente en EMTC que en LES</summary>
+<div class="qa-body">
+<p>En la EMTC se describe una complicación de forma más frecuente que en el lupus. ¿Cuál es?</p>
+<ol type="a">
+<li>Nefritis</li>
+<li><strong>Hipertensión pulmonar</strong></li>
+<li>Miocarditis</li>
+<li>Afectación del SNC</li>
+<li>Fibrosis pulmonar</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> HAP es la <em>principal causa de mortalidad en EMTC</em>. Es más frecuente en EMTC que en LES. Por eso se hace cribado anual con ecocardiograma en EMTC.</div>
+</div></details>
+
+<details class="qa"><summary>2. Complicación menos frecuente en EMTC que en LES</summary>
+<div class="qa-body">
+<p>En la EMTC se describe una complicación de forma menos frecuente que en el lupus. ¿Cuál es?</p>
+<ol type="a">
+<li><strong>Nefritis</strong></li>
+<li>Hipertensión pulmonar</li>
+<li>Miocarditis</li>
+<li>Afectación intersticial pulmonar</li>
+<li>Fibrosis pulmonar</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La nefritis es menos frecuente en EMTC que en LES (también la afectación grave del SNC). La afectación intersticial sí es frecuente en EMTC.</div>
+</div></details>
+
+<details class="qa"><summary>3. Mujer con artralgias + ANA ↑</summary>
+<div class="qa-body">
+<p>Mujer de 19 años con artralgias y ANA (+) a título elevado:</p>
+<ol type="a">
+<li>No tiene criterios de ACR de enfermedad concreta</li>
+<li>Se deben ampliar el estudio de autoanticuerpos específicos</li>
+<li>Sugiere una conectivopatía indiferenciada</li>
+<li>Se debe vigilar periódicamente</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Patrón típico de inicio: artralgias + ANA (+) inespecíficos. Conducta: ampliar autoanticuerpos (ENA panel completo, anti-DNAn, complemento), considerar CTI provisional, vigilancia periódica para detectar evolución a EAS definida.</div>
+</div></details>
+
+<details class="qa"><summary>4. Mujer con Raynaud + rash + HAP + artritis</summary>
+<div class="qa-body">
+<p>Mujer de 24 años con Raynaud, rash cutáneo, hipertensión pulmonar y artritis:</p>
+<ol type="a">
+<li>Tiene un LES</li>
+<li><strong>Se deben solicitar anti-RNP pues sugiere EMTC</strong></li>
+<li>Se debe pedir anti-Sm</li>
+<li>Se deben solicitar anti-Jo-1</li>
+<li>Tiene conectivopatía indiferenciada</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Raynaud + rash + HAP (clave) + artritis = sospecha de EMTC. Pedir anti-RNP — si son a títulos altos (≥ 1:1600), confirma EMTC (criterios Alarcón-Segovia).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2017/2020) Conectivopatía indiferenciada</summary>
+<div class="qa-body">
+<p>Sobre la conectivopatía indiferenciada:</p>
+<ol type="a">
+<li><strong>Es el término con el que nos referimos a pacientes con ANA (+) y manifestaciones propias de alguna o algunas EAS, pero que no reúnen criterios clasificatorios de ninguna de ellas</strong></li>
+<li>Los autoanticuerpos típicos son anti-RNP a título elevado</li>
+<li>Se denomina también enfermedad mixta del tejido conectivo</li>
+<li>El Raynaud es muy poco frecuente y, de aparecer, se acompaña de HAP en la mitad de los casos</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> CTI = ANA (+) inespecíficos + clínica de EAS sin criterios de ninguna entidad. NO equivale a EMTC (que tiene anti-RNP altos como marcador definitorio). El Raynaud sí es muy frecuente en CTI.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2016) Mujer con eritema + manos edematizadas + Raynaud</summary>
+<div class="qa-body">
+<p>Mujer de 30 años con eritemas, edematización de manos, Raynaud, artralgias y mialgias. ¿Cuál es el diagnóstico más probable?</p>
+<ol type="a">
+<li>Miopatía autoinmune necrosante</li>
+<li><strong>Enfermedad mixta del tejido conectivo</strong></li>
+<li>Miopatía por cuerpos de inclusión</li>
+<li>Esclerosis sistémica difusa</li>
+<li>Polimiositis</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> "Puffy hands" + Raynaud + artralgias + mialgias = combinación clásica de EMTC. Pedir anti-RNP a títulos altos.</div>
+</div></details>
+
+<details class="qa"><summary>7. Pronóstico de la EMTC — FALSA</summary>
+<div class="qa-body">
+<p>Respecto al pronóstico de la EMTC, indique la respuesta FALSA:</p>
+<ol type="a">
+<li>Los pacientes con EMTC tienen menos afectación renal que los pacientes de LES</li>
+<li>Los pacientes con EMTC tienen menos afectación del SNC que los pacientes de LES</li>
+<li>Los pacientes con EMTC tienen más probabilidad de tener Raynaud y miositis que los pacientes de LES</li>
+<li>La principal causa de muerte en la EMTC es la hipertensión pulmonar</li>
+<li><strong>El pronóstico global de la EMTC es peor que el LES</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e (FALSA).</strong> El pronóstico global de la EMTC es <em>mejor que el del LES</em>, salvo cuando aparece HAP (que ensombrece el pronóstico). La afectación renal y SNC graves son menos frecuentes en EMTC.</div>
+</div></details>
+
+<details class="qa"><summary>8. Mujer con astenia + artromialgias + ANA</summary>
+<div class="qa-body">
+<p>Mujer de 22 años con astenia, artromialgias y ANA (+). ¿Cuál de los siguientes es un diagnóstico posible?</p>
+<ol type="a">
+<li>Conectivopatía indiferenciada</li>
+<li>Enfermedad mixta del tejido conectivo</li>
+<li>Esclerosis sistémica</li>
+<li>Síndrome de Sjögren</li>
+<li><strong>Cualquiera de las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> En un inicio inespecífico, cualquier EAS puede empezar así. Hay que ampliar estudios (panel de autoanticuerpos, capilaroscopia, biopsia de glándula salival si sequedad) y seguir clínicamente.</div>
+</div></details>
+
+<details class="qa"><summary>9. Mujer con dedos asalchichados, Raynaud, artritis, miositis</summary>
+<div class="qa-body">
+<p>Mujer de 38 años, sin antecedentes, acude por cuadro de 7 meses de cansancio intenso, dedos "asalchichados", úlceras en pulpejos, Raynaud, artritis MCF, disfagia, dolor y debilidad muscular. ¿Cuál es correcta?</p>
+<ol type="a">
+<li>Es poco probable que la paciente tenga una EAS</li>
+<li><strong>Si tuviera ANA (+) y anti-RNP &gt; 100 U/L, lo más probable es que padezca EMTC</strong></li>
+<li>Si tuviera ANA (+) y anti-RNP &gt; 100 U/L, lo más probable es que tenga un overlap LES + ES + polimiositis</li>
+<li>La EMTC es un tipo de overlap</li>
+<li>Tratar con prednisona 1 mg/kg/día inmediatamente</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (la más correcta).</strong> El cuadro es típico de EMTC: dedos asalchichados, Raynaud, artritis, disfagia, miositis. Anti-RNP altos confirma. La opción d también es cierta (EMTC = un tipo de overlap), pero la b es la respuesta clave para el banco.</div>
+</div></details>
+
+<details class="qa"><summary>10. Mujer con febrícula + Raynaud + ANA</summary>
+<div class="qa-body">
+<p>Mujer de 25 años con febrícula, síntomas generales, artralgias, Raynaud y ANA (+). ¿Cuál es el diagnóstico más probable?</p>
+<ol type="a">
+<li>Conectivopatía indiferenciada</li>
+<li>EMTC</li>
+<li>LES</li>
+<li>Síndrome de Sjögren</li>
+<li><strong>Cualquiera de las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Igual que la P8: cuadro inespecífico al inicio puede corresponder a cualquier EAS. Vigilancia y ampliación de estudios.</div>
+</div></details>
+
+<details class="qa"><summary>11. Mujer con Raynaud dudoso + ANA 1/320</summary>
+<div class="qa-body">
+<p>Mujer de 23 años, con algias inespecíficas. Anamnesis dirigida: dudoso Raynaud, EF normal sin artritis, capilaroscopia normal. ANA + 1/320, ENAs (−), anti-DNAn y anti-Sm (−). El diagnóstico más probable es:</p>
+<ol type="a">
+<li><strong>Conectivopatía indiferenciada</strong></li>
+<li>EMTC</li>
+<li>Esclerosis sistémica</li>
+<li>Síndrome de Sjögren</li>
+<li>Cualquiera de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> ANA + sin especificidad + clínica leve sin cumplir criterios de ninguna entidad = CTI. Seguimiento clínico.</div>
+</div></details>
+
+<details class="qa"><summary>12. Adolescente con Raynaud + ANA moderado</summary>
+<div class="qa-body">
+<p>Muchacha de 15 años con malestar general, algias osteomusculares, palidez de extremidades con frío/emociones, ANA (+) a título moderado. ¿Cuál es posible?</p>
+<ol type="a">
+<li>Conectivopatía indiferenciada</li>
+<li>EMTC</li>
+<li>Esclerosis sistémica</li>
+<li><strong>Cualquiera de las anteriores</strong></li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Igual que P8 y P10: inicio inespecífico de cualquier EAS. Seguimiento.</div>
+</div></details>
+
+<details class="qa"><summary>13. Criterio de Alarcón-Segovia para EMTC que NO es válido</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes criterios clasificatorios de Alarcón-Segovia para la EMTC NO es correcto?</p>
+<ol type="a">
+<li>Sinovitis</li>
+<li>Fenómeno de Raynaud</li>
+<li>Acroesclerosis</li>
+<li><strong>Títulos elevados de anti-DNA nativo</strong></li>
+<li>Títulos elevados de anti-RNP</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Anti-DNAn es de LES, NO de EMTC. Los criterios de Alarcón-Segovia: anti-RNP ≥ 1:1600 (obligatorio) + ≥ 3 de 5 clínicos (edema manos, sinovitis, miositis, Raynaud, acroesclerosis).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 9: Vasculitis =============== -->
+<section class="card" id="t9">
+<h2 class="section-title"><span class="num">9</span>Vasculitis sistémicas</h2>
+
+<h3>9.1 Clasificación de Chapel Hill 2012</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tamaño</th><th>Entidades</th></tr></thead>
+<tbody>
+<tr><td><strong>Grandes vasos</strong></td><td>Arteritis de células gigantes (Horton) · Takayasu</td></tr>
+<tr><td><strong>Medianos</strong></td><td>Poliarteritis nodosa (PAN, VHB) · Kawasaki</td></tr>
+<tr><td><strong>Pequeños — ANCA</strong></td><td>GPA (Wegener · c-ANCA/PR3) · PAM (p-ANCA/MPO) · GEPA (Churg-Strauss · p-ANCA/MPO)</td></tr>
+<tr><td><strong>Pequeños — inmunocomplejos</strong></td><td>Vasculitis IgA (Schönlein-Henoch) · Crioglobulinémica (VHC) · Goodpasture · urticarial (anti-C1q)</td></tr>
+<tr><td>Variable</td><td>Behçet · Cogan</td></tr>
+<tr><td>Órgano único</td><td>SNC · cutánea aislada</td></tr>
+</tbody></table></div>
+
+<h3>9.2 Vasculitis ANCA-asociadas (AAV)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>GPA (Wegener)</th><th>PAM</th><th>GEPA (Churg-Strauss)</th></tr></thead>
+<tbody>
+<tr><td>ANCA</td><td><strong>c-ANCA / PR3</strong> (75-90 %)</td><td><strong>p-ANCA / MPO</strong> (70 %)</td><td>p-ANCA/MPO (40 %)</td></tr>
+<tr><td>Granulomas</td><td>Sí</td><td>No</td><td>Sí</td></tr>
+<tr><td>Eosinofilia</td><td>No</td><td>No</td><td><strong>Sí (&gt; 10 %, &gt; 1.500/µL)</strong></td></tr>
+<tr><td>Asma</td><td>No</td><td>No</td><td><strong>Sí (precede)</strong></td></tr>
+<tr><td>ORL</td><td><strong>Sí (clásico)</strong> · nariz en silla de montar</td><td>Raro</td><td>Rinitis · pólipos</td></tr>
+<tr><td>Pulmón</td><td>Nódulos cavitados · hemorragia</td><td>Hemorragia alveolar · capilaritis</td><td>Infiltrados migratorios · asma</td></tr>
+<tr><td>Riñón</td><td>GN necrotizante pauciinmune</td><td><strong>GN crescéntica (más frecuente)</strong></td><td>Menos frecuente</td></tr>
+<tr><td>Otros</td><td>Estenosis subglótica</td><td>Mejor pronóstico que GPA</td><td>Neuropatía · coronariopatía</td></tr>
+</tbody></table></div>
+
+<div class="box box-tip">
+  <div class="box-title"><span class="icon">💊</span>Tratamiento AAV (resumen)</div>
+  <ul style="margin:6px 0">
+    <li><strong>Inducción:</strong> rituximab (de elección) o ciclofosfamida iv + corticoides altas dosis ± pulsos de metilprednisolona ± plasmaféresis (PEXIVAS: si hemorragia alveolar grave o Cr &gt; 5,7 o anti-MBG asociada).</li>
+    <li><strong>Avacopán</strong> (antagonista C5a) — ahorrador de corticoide.</li>
+    <li><strong>Mantenimiento:</strong> rituximab c/6 meses (preferido) o AZA/MTX/MMF · 18-24 meses mínimo.</li>
+    <li><strong>GEPA:</strong> mepolizumab (anti-IL-5) eficaz.</li>
+  </ul>
+</div>
+
+<h3>9.3 Arteritis de células gigantes (Horton) / PMR</h3>
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">👁</span>¡Riesgo de ceguera!</div>
+  <p style="margin:4px 0">&gt; 50 años · cefalea temporal nueva · <em>claudicación mandibular</em> · alteraciones visuales (NOIA) · ↑↑ VSG y PCR.</p>
+  <p style="margin:4px 0"><strong>Iniciar corticoides INMEDIATAMENTE</strong> ante la sospecha (no esperar a la biopsia): prednisona 40-60 mg/día, pulsos iv si afectación visual. Biopsia o ecografía Doppler temporal después. <strong>Tocilizumab</strong> ahorrador.</p>
+</div>
+
+<p><strong>Polimialgia reumática:</strong> &gt; 50 años · dolor y rigidez matutina de cinturas escapular y pélvica · VSG/PCR ↑ · respuesta espectacular a prednisona 15-20 mg/día.</p>
+
+<h3>9.4 Enfermedad de Behçet</h3>
+<p><strong>HLA-B51</strong> · ruta de la seda · varones jóvenes.</p>
+<ul>
+  <li>Criterios: <strong>aftosis oral recurrente (≥ 3/año)</strong> + ≥ 2 de:
+    <ul>
+      <li>Aftas genitales recurrentes</li>
+      <li>Lesiones cutáneas (eritema nudoso, pseudofoliculitis, papulopustulosis)</li>
+      <li>Uveítis (anterior, posterior, vitritis o vasculitis retiniana)</li>
+      <li><strong>Patergia (+)</strong> (pústula 24-48 h tras pinchazo)</li>
+    </ul>
+  </li>
+  <li>Otras: neuro-Behçet · vasculitis con trombosis venosa + aneurismas arteriales (pulmonares) · digestiva · orquiepididimitis.</li>
+</ul>
+
+<h3>9.5 Otras entidades clave</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Vasculitis IgA (Schönlein-Henoch)</span><span class="v">Niños post-VRS · púrpura palpable MMII + artralgias + dolor abdominal + GN IgA</span></div>
+  <div class="kv"><span class="k">Crioglobulinemia mixta</span><span class="v">VHC en &gt; 80 % · tríada Meltzer: <em>púrpura + artralgia + astenia</em> · GN MPGN · tratamiento etiológico VHC + rituximab</span></div>
+  <div class="kv"><span class="k">PAN</span><span class="v">VHB · HTA grave · isquemia mesentérica · mononeuritis · ANCA (−) · <strong>NO afecta a glomérulo</strong></span></div>
+  <div class="kv"><span class="k">Takayasu</span><span class="v">Mujer joven asiática · claudicación de extremidades superiores · ausencia de pulsos</span></div>
+  <div class="kv"><span class="k">Kawasaki</span><span class="v">Niños · fiebre &gt; 5 días + 4 de 5 signos · coronarias · IGIV + AAS</span></div>
+</div>
+
+<div class="box box-mnemo">
+  <div class="box-title"><span class="icon">🧠</span>Reglas mnemotécnicas vasculitis</div>
+  <ul style="margin:6px 0">
+    <li><strong>Hemorragia alveolar + GN + p-ANCA → PAM</strong></li>
+    <li><strong>Sinusitis crónica + nódulos pulmonares cavitados + GN + c-ANCA → GPA</strong></li>
+    <li><strong>Asma + eosinofilia + neuropatía + p-ANCA → GEPA</strong></li>
+    <li><strong>Cefalea temporal + claudicación mandibular + VSG↑↑ → Horton → corticoides YA</strong></li>
+    <li><strong>Aftas orales + genitales + uveítis + patergia → Behçet (HLA-B51)</strong></li>
+    <li><strong>Niño + púrpura MMII + dolor abdominal + GN IgA → Schönlein-Henoch</strong></li>
+    <li><strong>Púrpura + artralgia + astenia + VHC → crioglobulinemia mixta</strong></li>
+    <li><strong>HTA maligna + isquemia mesentérica + neuropatía + VHB → PAN</strong></li>
+  </ul>
+</div>
+
+<h3>9.6 Preguntas — Vasculitis</h3>
+
+<details class="qa"><summary>1. PAM — manifestación NO pertenece a su cuadro</summary>
+<div class="qa-body">
+<p>La sintomatología de la poliangeítis microscópica (PAM) es compleja. De todas las afirmaciones, una NO pertenece a su cuadro clínico:</p>
+<ol type="a">
+<li>Infiltrados pulmonares con hemorragia</li>
+<li>Púrpura cutánea</li>
+<li><strong>Positividad de c-ANCA</strong></li>
+<li>Glomerulonefritis necrosante</li>
+<li>Deterioro importante de la función renal</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La PAM cursa con <em>p-ANCA / MPO</em> (no c-ANCA, que es de GPA/Wegener). Las demás manifestaciones (hemorragia alveolar, púrpura, GN crescéntica, FRA) son típicas.</div>
+</div></details>
+
+<details class="qa"><summary>2. PAN — afirmación FALSA</summary>
+<div class="qa-body">
+<p>De las siguientes afirmaciones para la poliarteritis nodosa (PAN), enfermedad de pequeño y mediano vaso con afectación renal, una es FALSA:</p>
+<ol type="a">
+<li>Hay síntomas generales pseudogripales</li>
+<li>Acostumbra a asociarse con virus B</li>
+<li>Hipertensión arterial grave</li>
+<li>ANCA negativos</li>
+<li><strong>Lesión de glomerulitis necrotizante</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e (FALSA).</strong> La PAN es vasculitis de mediano vaso y <em>NO afecta a glomérulo</em>. Causa isquemia renal con HTA grave (renovascular) y microaneurismas en arteriografía, pero no GN. La GN necrotizante es de vasculitis de pequeño vaso (AAV, anti-MBG).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2016) Mujer con FRA + hematuria + p-ANCA/MPO</summary>
+<div class="qa-body">
+<p>Mujer de 71 años con antecedente de hidronefrosis y pielonefritis. Ingresa por fiebre, escalofríos, odinofagia y afectación del estado general, con sensación de enfermedad grave. PCR y VSG elevadas, leucocitosis. Desarrolla insuficiencia renal y hematuria. Los ANCA, especificidad MPO, son positivos. El diagnóstico más probable es:</p>
+<ol type="a">
+<li><strong>Poliangeítis microscópica</strong></li>
+<li>Sepsis secundaria a pielonefritis</li>
+<li>Glomerulonefritis postestreptocócica</li>
+<li>—</li>
+<li>—</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> p-ANCA/MPO + FRA + hematuria + síntomas constitucionales graves = poliangeítis microscópica. Tratamiento: rituximab o ciclofosfamida + corticoides altas dosis ± plasmaféresis si afectación grave.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 10: Sarcoidosis =============== -->
+<section class="card" id="t10">
+<h2 class="section-title"><span class="num">10</span>Sarcoidosis</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Enfermedad <strong>granulomatosa sistémica</strong> de causa desconocida con <em>granulomas NO caseificantes</em>.</li>
+    <li><strong>Adultos jóvenes 20-40 años</strong>; más grave en raza negra y escandinava.</li>
+    <li><strong>Pulmón afectado en &gt; 90 %.</strong></li>
+    <li><strong>Síndrome de Löfgren</strong> (40 % en España): eritema nudoso + adenopatías hiliares bilaterales + artritis tobillos + fiebre. <em>Benigno, remite espontáneamente.</em></li>
+    <li><strong>Síndrome de Heerfordt:</strong> uveítis + parotiditis + parálisis facial + fiebre.</li>
+  </ul>
+</div>
+
+<h3>10.1 Estadios radiológicos de Scadding</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Estadio</th><th>Hallazgos</th><th>Pronóstico</th></tr></thead>
+<tbody>
+<tr><td>0</td><td>Rx normal</td><td>Excelente</td></tr>
+<tr><td><strong>I</strong></td><td><strong>Adenopatías hiliares bilaterales</strong> (la más frecuente)</td><td>Mejor</td></tr>
+<tr><td>II</td><td>Adenopatías + infiltrados parenquimatosos</td><td>Bueno</td></tr>
+<tr><td>III</td><td>Infiltrados sin adenopatías</td><td>Intermedio</td></tr>
+<tr><td>IV</td><td>Fibrosis pulmonar</td><td>Peor</td></tr>
+</tbody></table></div>
+
+<h3>10.2 Manifestaciones por órgano</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Pulmón</span><span class="v">Adenopatías hiliares · opacidades reticulonodulares · fibrosis</span></div>
+  <div class="kv"><span class="k">Piel</span><span class="v"><strong>Eritema nudoso</strong> (inespecífico) · <strong>lupus pernio</strong> (placas violáceas en nariz/mejillas, peor pronóstico) · placas · nódulos</span></div>
+  <div class="kv"><span class="k">Ocular</span><span class="v"><strong>Uveítis anterior</strong> la más frecuente · queratoconjuntivitis seca</span></div>
+  <div class="kv"><span class="k">Articulaciones</span><span class="v">Poliartritis simétrica de <em>tobillos</em> en Löfgren</span></div>
+  <div class="kv"><span class="k">Cardíaca</span><span class="v">Trastornos de conducción · miocardiopatía · muerte súbita (25 % subclínica)</span></div>
+  <div class="kv"><span class="k">SNC</span><span class="v"><strong>Parálisis facial</strong> (la más frecuente) · meningitis basal · neuropatías · DI</span></div>
+  <div class="kv"><span class="k">Hígado/bazo</span><span class="v">Hepatoesplenomegalia con granulomas</span></div>
+  <div class="kv"><span class="k">Riñón</span><span class="v"><strong>Hipercalcemia / hipercalciuria</strong> por calcitriol macrofágico · nefritis intersticial · nefrocalcinosis</span></div>
+</div>
+
+<h3>10.3 Diagnóstico</h3>
+<ul>
+  <li>Clínica compatible + <strong>granulomas no caseificantes en biopsia</strong> + exclusión de otras causas (TBC, micosis, beriliosis, linfoma).</li>
+  <li><strong>ECA</strong> elevada (no específica) · hipercalcemia · hipercalciuria · linfopenia · ↑ vitamina D activa.</li>
+  <li><strong>LBA:</strong> ↑ linfocitos con CD4/CD8 &gt; 3,5.</li>
+  <li>Biopsia transbronquial (EBUS-TBNA) · cutánea · glándulas salivales · ganglios. <strong>NO biopsia hepática</strong> (granulomas inespecíficos).</li>
+  <li>Imagen: TC tórax · PET-TAC · gammagrafía Ga-67 ("signo del panda" parótidas + "lambda" mediastinal).</li>
+</ul>
+
+<h3>10.4 Tratamiento</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Asintomático estadio I</span><span class="v">Observación</span></div>
+  <div class="kv"><span class="k">Corticoides</span><span class="v">Pulmonar progresivo · <strong>cardíaco</strong> · <strong>SNC</strong> · uveítis · hipercalcemia · hepatitis · hipopituitarismo</span></div>
+  <div class="kv"><span class="k">Inmunosupresores</span><span class="v">MTX (ahorrador) · AZA · MMF · leflunomida</span></div>
+  <div class="kv"><span class="k">Biológicos</span><span class="v"><strong>Infliximab/adalimumab</strong> en lupus pernio, neurosarcoidosis, refractarios</span></div>
+  <div class="kv"><span class="k">Cutáneo / hipercalcemia</span><span class="v">Hidroxicloroquina</span></div>
+  <div class="kv"><span class="k">Löfgren</span><span class="v">AINE · colchicina · corticoides cortos</span></div>
+</div>
+
+<div class="box box-mnemo">
+  <div class="box-title"><span class="icon">🔑</span>Claves recurrentes en exámenes</div>
+  <ul style="margin:6px 0">
+    <li><strong>Löfgren = eritema nudoso + adenopatías hiliares bilaterales + artritis tobillos.</strong></li>
+    <li><strong>Heerfordt = uveítis + parotiditis + parálisis facial.</strong></li>
+    <li>Granulomas <em>no caseificantes</em>.</li>
+    <li>Hipercalcemia por calcitriol macrofágico.</li>
+    <li>ECA apoya el diagnóstico (no específica).</li>
+    <li>Estadio I = mejor pronóstico.</li>
+    <li>Tratamiento base = corticoides en órgano vital o progresiva.</li>
+  </ul>
+</div>
+</section>
+
+<!-- ============================================================ -->
+<!-- BLOQUE A2 -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-a2">
+  <h2>🦴 BLOQUE A2 · Reumatología</h2>
+  <div class="b-sub">11 temas · AR, AIJ, espondiloartritis, artrosis, microcristalinas, autoinflamatorios, óseo, fibromialgia, embarazo</div>
+</div>
+
+<!-- =============== TEMA 11: Aspectos generales reuma =============== -->
+<section class="card" id="t11">
+<h2 class="section-title"><span class="num">11</span>Aspectos generales · semiología articular</h2>
+
+<h3>11.1 Conceptos clave</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Artralgia</span><span class="v">Dolor sin signos inflamatorios</span></div>
+  <div class="kv"><span class="k">Artritis</span><span class="v">Dolor + signos inflamatorios (calor, tumefacción, eritema, impotencia)</span></div>
+  <div class="kv"><span class="k">Mono / oligo / poliartritis</span><span class="v">1 / 2-4 / ≥ 5 articulaciones</span></div>
+  <div class="kv"><span class="k">Aguda / crónica</span><span class="v">&lt; 6 semanas / ≥ 6 semanas</span></div>
+</div>
+
+<h3>11.2 Ritmo del dolor</h3>
+<div class="compare">
+  <div>
+    <h4>⚙️ Mecánico</h4>
+    <ul>
+      <li>Empeora con el uso</li>
+      <li>Mejora con el reposo</li>
+      <li><strong>Rigidez matutina &lt; 30 min</strong></li>
+      <li>Ej: artrosis, lesiones estructurales</li>
+    </ul>
+  </div>
+  <div>
+    <h4>🔥 Inflamatorio</h4>
+    <ul>
+      <li>Mejora con el ejercicio</li>
+      <li><strong>Empeora con el reposo</strong></li>
+      <li>Rigidez matutina &gt; 30-60 min</li>
+      <li>Dolor nocturno</li>
+      <li>Ej: AR, espondiloartritis</li>
+    </ul>
+  </div>
+</div>
+
+<h3>11.3 Líquido sinovial</h3>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>Normal</th><th>Mecánico</th><th>Inflamatorio</th><th>Séptico</th><th>Hemorrágico</th></tr></thead>
+<tbody>
+<tr><td>Aspecto</td><td>Claro, viscoso</td><td>Claro / amarillo</td><td>Turbio, amarillo</td><td>Purulento</td><td>Sangre</td></tr>
+<tr><td>Células/µL</td><td>&lt; 200</td><td>&lt; 2.000</td><td>2.000-50.000</td><td><strong>&gt; 50.000 (a menudo &gt; 100.000)</strong></td><td>Variable</td></tr>
+<tr><td>PMN</td><td>&lt; 25 %</td><td>&lt; 25 %</td><td>&gt; 50 %</td><td><strong>&gt; 90 %</strong></td><td>Variable</td></tr>
+<tr><td>Glucosa</td><td>= sérica</td><td>= sérica</td><td>↓</td><td>↓↓</td><td>= sérica</td></tr>
+<tr><td>Cultivo</td><td>–</td><td>–</td><td>–</td><td>+</td><td>–</td></tr>
+</tbody></table></div>
+
+<h3>11.4 Cristales — luz polarizada con compensador rojo</h3>
+<div class="compare">
+  <div>
+    <h4>🪡 Urato monosódico (gota)</h4>
+    <ul>
+      <li>Aguja larga</li>
+      <li><strong>Birrefringencia NEGATIVA fuerte</strong></li>
+      <li><span class="tag warn">Amarillo</span> cuando paralelo al eje</li>
+      <li><span class="tag">Azul</span> cuando perpendicular</li>
+    </ul>
+  </div>
+  <div>
+    <h4>🟦 Pirofosfato cálcico (CPPD)</h4>
+    <ul>
+      <li>Romboidal / cuboidal</li>
+      <li><strong>Birrefringencia POSITIVA débil</strong></li>
+      <li><span class="tag">Azul</span> cuando paralelo al eje</li>
+      <li><span class="tag warn">Amarillo</span> cuando perpendicular</li>
+    </ul>
+  </div>
+</div>
+
+<h3>11.5 Preguntas — Aspectos generales reuma</h3>
+
+<details class="qa"><summary>1. (Jun 2018) En reumatología</summary>
+<div class="qa-body">
+<p>En reumatología:</p>
+<ol type="a">
+<li>Las "pruebas reumáticas" son básicas para el diagnóstico</li>
+<li>El concepto de oligoartritis hace referencia a la afectación inflamatoria de más de cuatro articulaciones</li>
+<li>El dolor de ritmo mecánico de raquis es muy típico de la espondilitis anquilosante</li>
+<li><strong>Ninguna de las respuestas anteriores es correcta</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> a) Las "pruebas reumáticas" no son básicas — el diagnóstico es clínico-radiológico. b) Oligoartritis = 2-4 articulaciones (no &gt; 4). c) En EA el dolor es <em>inflamatorio</em>, no mecánico (mejora con ejercicio, empeora con reposo, rigidez matutina prolongada).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2018) Las enfermedades reumáticas</summary>
+<div class="qa-body">
+<p>Las enfermedades reumáticas:</p>
+<ol type="a">
+<li><strong>Pueden presentarse a cualquier edad, pero su frecuencia en general se incrementa con la edad, siendo su mayor incidencia a partir de la cuarta década</strong></li>
+<li>La espondilitis anquilosante muestra un claro predominio femenino (3:1)</li>
+<li>El lupus eritematoso muestra un notable predominio por el sexo masculino (9:1)</li>
+<li>Ninguna de las respuestas anteriores es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La EA tiene predominio <em>masculino</em> 3:1 (b falso). El LES tiene predominio <em>femenino</em> 9:1 (c falso).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 12: AR y AIJ =============== -->
+<section class="card" id="t12">
+<h2 class="section-title"><span class="num">12</span>Artritis Reumatoide (AR) y AIJ</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés — AR</div>
+  <ul>
+    <li><strong>La artritis crónica inflamatoria más frecuente</strong> (prevalencia 0,5-1 %).</li>
+    <li><strong>Mujer 3:1</strong>, inicio típico 40-60 años.</li>
+    <li>Patogenia: <em>HLA-DR4</em> + tabaco → citrulinación → ACPA → sinovitis (<em>TNF-α, IL-6, IL-1, RANKL</em>) → pannus → erosiones.</li>
+    <li>Clínica: <strong>poliartritis simétrica de pequeñas articulaciones</strong> (carpos, MCF, IFP — <em>respeta IFD</em>).</li>
+    <li>Columna: solo <strong>cervical alta (C1-C2)</strong> — riesgo de subluxación atloaxoidea.</li>
+    <li><strong>Tratamiento de inicio: METOTREXATO.</strong></li>
+    <li><em>Window of opportunity</em>: tratar en &lt; 12 semanas.</li>
+  </ul>
+</div>
+
+<h3>12.1 Manifestaciones extraarticulares</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Nódulos reumatoides</span><span class="v">Codos, tendones</span></div>
+  <div class="kv"><span class="k">Pulmón</span><span class="v">EPI (UIP &gt; NSIP) · pleuritis con glucosa baja y FR+ · Caplan</span></div>
+  <div class="kv"><span class="k">Cardiovascular</span><span class="v">Aterosclerosis acelerada (riesgo similar DM) · pericarditis</span></div>
+  <div class="kv"><span class="k">Ocular</span><span class="v">Queratoconjuntivitis seca · epiescleritis · escleritis · escleromalacia</span></div>
+  <div class="kv"><span class="k">Felty</span><span class="v">AR + esplenomegalia + neutropenia</span></div>
+  <div class="kv"><span class="k">Amiloidosis AA</span><span class="v">En enfermedad de larga evolución mal controlada</span></div>
+  <div class="kv"><span class="k">Vasculitis reumatoide</span><span class="v">Úlceras · mononeuritis múltiple</span></div>
+  <div class="kv"><span class="k">¡NO produce GN!</span><span class="v">Afectación renal solo por amiloidosis o fármacos</span></div>
+</div>
+
+<h3>12.2 Diagnóstico — autoanticuerpos</h3>
+<div class="compare">
+  <div>
+    <h4>FR (factor reumatoide)</h4>
+    <ul>
+      <li>IgM anti-IgG</li>
+      <li>Sensibilidad 60-80 % · especificidad moderada</li>
+      <li>(+) en Sjögren, crioglobulinemia, hepatitis, sanos &gt; 65 años</li>
+      <li>5-10 % de la población general</li>
+    </ul>
+  </div>
+  <div>
+    <h4>ACPA / anti-CCP</h4>
+    <ul>
+      <li><strong>Más específicos que el FR</strong> (95 %)</li>
+      <li>Detectables antes del inicio clínico (preclínico)</li>
+      <li><strong>Marcador de peor pronóstico</strong> (erosiones)</li>
+      <li>Asociación con HLA-DR4</li>
+    </ul>
+  </div>
+</div>
+
+<h3>12.3 Tratamiento — escalera terapéutica</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🎯</span>Treat-to-target</div>
+  <p style="margin:0">Objetivo: <strong>remisión (DAS28 &lt; 2,6)</strong> o baja actividad. Evaluación cada 3 meses, ajuste si no se alcanza.</p>
+</div>
+
+<ol>
+  <li><strong>MTX 10-25 mg/sem + ácido fólico</strong> (primera línea). Controlar transaminasas, hemograma, <em>síntomas respiratorios (neumonitis)</em>.</li>
+  <li>Alternativas: leflunomida · sulfasalazina ± HCQ (combinación triple).</li>
+  <li><strong>Corticoides</strong> como puente, dosis bajas, &lt; 5 mg/día.</li>
+  <li>Si no respuesta a csDMARDs en 3-6 meses → biológicos / tsDMARDs:</li>
+</ol>
+
+<h4>Biológicos y JAKi</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Diana</th><th>Fármacos</th><th>Notas</th></tr></thead>
+<tbody>
+<tr><td><strong>Anti-TNF</strong></td><td>Infliximab (quimérico) · adalimumab (humano) · etanercept (fusión) · golimumab · <em>certolizumab</em> (Fab pegilado, <strong>sin Fc</strong>, preferido en embarazo)</td><td>Cribar TBC latente · serologías VHB/VHC</td></tr>
+<tr><td><strong>Anti-IL-6R</strong></td><td>Tocilizumab (humanizado), sarilumab</td><td>—</td></tr>
+<tr><td><strong>Anti-CD20</strong></td><td>Rituximab (quimérico)</td><td>—</td></tr>
+<tr><td><strong>CTLA-4-Ig</strong></td><td>Abatacept — <em>se une a CD80/CD86 evitando interacción con CD28</em></td><td>Bloquea coestimulación</td></tr>
+<tr><td><strong>JAKi</strong></td><td>Tofacitinib · baricitinib · upadacitinib · filgotinib</td><td>Vía oral · intracelular · <strong>↑ herpes zóster</strong> (japoneses/coreanos) · cardiovascular en &gt; 65 años</td></tr>
+</tbody></table></div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">⚠</span>Antes de empezar un biológico</div>
+  <ul style="margin:6px 0">
+    <li><strong>Cribado de TBC latente: Mantoux y/o IGRA</strong> + Rx tórax. Si (+) → <em>isoniacida</em> (¡NO penicilina!).</li>
+    <li>Serologías VHB y VHC.</li>
+    <li>Vacunación (no vivas bajo tratamiento).</li>
+  </ul>
+</div>
+
+<h3>12.4 Artritis Idiopática Juvenil (AIJ)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Subtipo</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td><strong>Oligoarticular</strong> (la más frecuente, 50 %)</td><td>≤ 4 articulaciones; niñas pequeñas; ANA (+) frecuentes; FR (−); <strong>UVEÍTIS anterior crónica silente</strong> → revisiones cada 3-6 meses</td></tr>
+<tr><td>Poliarticular FR (−)</td><td>≥ 5 articulaciones</td></tr>
+<tr><td>Poliarticular FR (+)</td><td>Equivalente a AR del adulto</td></tr>
+<tr><td>Sistémica (Still juvenil)</td><td>Fiebre cotidiana · exantema asalmonado · adenopatías · hepatoesplenomegalia · serositis · artritis. <em>Riesgo de SAM.</em> Descartar leucemia / linfoma.</td></tr>
+<tr><td>Psoriásica</td><td>—</td></tr>
+<tr><td>Relacionada con entesitis</td><td>HLA-B27; equivalente juvenil de espondiloartritis</td></tr>
+</tbody></table></div>
+
+<p><strong>Tratamiento AIJ poliarticular:</strong> AINE + <em>MTX</em> 10-15 mg/m²/semana en niños (no se limita a 5 mg). Biológicos anti-TNF/anti-IL-6 si refractaria.</p>
+
+<h3>12.5 Preguntas — AR y AIJ</h3>
+
+<details class="qa"><summary>1. (Parc 2018) Factor genético más significativo en AR</summary>
+<div class="qa-body">
+<p>De los factores genéticos asociados con la artritis reumatoide, indica el más significativo:</p>
+<ol type="a">
+<li>HLA-B27</li>
+<li>HLA-B51</li>
+<li><strong>HLA-DR4</strong></li>
+<li>HLA-DR3</li>
+<li>HLA-DQ2</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> HLA-DR4 (concretamente alelos con el "epítopo compartido") es el factor genético más fuerte en AR. B27 = espondiloartritis; B51 = Behçet; DQ2/DQ8 = celíaca.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2017) Sobre la AR — FALSA</summary>
+<div class="qa-body">
+<p>Sobre la artritis reumatoide, señala la respuesta FALSA:</p>
+<ol type="a">
+<li>La AR es la enfermedad reumática inflamatoria más frecuente</li>
+<li>La prevalencia es de 0,5-1 % de la población</li>
+<li><strong>Es una oligoartritis inflamatoria crónica asimétrica de predominio en miembros inferiores</strong></li>
+<li>Es más frecuente en mujeres: 50-70 %, con edad de inicio 40-60 años</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (FALSA).</strong> La AR es una <em>POLIartritis SIMÉTRICA</em> de pequeñas articulaciones de manos y pies (carpos, MCF, IFP, MTF), no oligoarticular asimétrica de MMII.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2017) Metotrexato — efectos adversos/recomendaciones — FALSA</summary>
+<div class="qa-body">
+<p>Para el control de efectos adversos del MTX en AR, señala la respuesta FALSA:</p>
+<ol type="a">
+<li>Si se planifica un embarazo se debe suspender el MTX un mínimo de 3 meses previamente</li>
+<li>Los efectos adversos más frecuentes son los gastrointestinales</li>
+<li>El metotrexato es de primera elección y se usa en escalada rápida</li>
+<li>Se debe preguntar en cada revisión por síntomas respiratorios (tos, disnea)</li>
+<li><strong>Se deben realizar hemograma y bioquímica con enzimas hepáticas una vez al año</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e (FALSA).</strong> Los controles analíticos con MTX deben ser cada 4-12 semanas (no anuales). Las demás son ciertas: suspender 3 meses antes del embarazo, GI más frecuentes (náuseas, dispepsia), 1ª línea (escalada moderada hasta 25 mg/sem), vigilar neumonitis (síntomas respiratorios).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2017) Artritis idiopática juvenil — VERDADERA</summary>
+<div class="qa-body">
+<p>Referente a la AIJ, señala la respuesta VERDADERA:</p>
+<ol type="a">
+<li><strong>La forma clínica más frecuente es la oligoarticular</strong></li>
+<li>La epiescleritis es la forma ocular asociada más frecuente</li>
+<li>Están contraindicadas las terapias biológicas anti-TNF y anti-IL6</li>
+<li>En la forma sistémica no hace falta realizar diagnóstico diferencial con procesos hematológicos agudos</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Oligoarticular = 50 % de AIJ. La forma ocular más frecuente es la <em>uveítis anterior crónica silente</em> (no epiescleritis). Los biológicos sí están indicados. En la forma sistémica (Still juvenil) ES OBLIGATORIO descartar leucemia/linfoma/infecciones.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2018) Anti-TNF — correcta</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes afirmaciones es correcta en relación con los tratamientos biológicos inhibidores del TNF?</p>
+<ol type="a">
+<li>No se puede utilizar en combinación con metotrexato</li>
+<li><strong>Hay riesgo de reactivar una tuberculosis latente</strong></li>
+<li>Está contraindicado en pacientes con prueba de intradermoreacción Mantoux o positividad de IGRA</li>
+<li>No se puede utilizar en pacientes diabéticos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los anti-TNF reactivan TBC latente → cribar SIEMPRE (Mantoux/IGRA + Rx tórax) antes de iniciar. <em>Si Mantoux/IGRA (+) NO está contraindicado</em>: hay que dar <em>quimioprofilaxis con isoniacida</em> 9 meses y luego se puede iniciar el anti-TNF. Se combinan habitualmente con MTX. Diabetes no es contraindicación.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2017) Tratamiento de inicio en AR</summary>
+<div class="qa-body">
+<p>Una vez diagnosticado a un paciente de AR, el tratamiento de inicio será:</p>
+<ol type="a">
+<li>Ciclosporina</li>
+<li><strong>Metotrexato</strong></li>
+<li>Hidroxicloroquina</li>
+<li>Ciclofosfamida</li>
+<li>Salazopirina</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> MTX es el FAME convencional de primera elección en AR (10-25 mg/sem + ácido fólico). Eficaz, barato, gran experiencia. SSZ y HCQ son alternativas si MTX está contraindicado (combinación triple).</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2019) Anti-CCP (ACPA)</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes afirmaciones es correcta respecto a los anticuerpos antipéptidos cíclicos citrulinados (ACPA, anti-CCP)?</p>
+<ol type="a">
+<li>Su presencia es obligatoria para el diagnóstico de AR</li>
+<li>Son menos sensibles que el factor reumatoide</li>
+<li><strong>Se asocian a un peor pronóstico de la AR</strong></li>
+<li>Se utilizan solo para investigación</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> ACPA tienen sensibilidad similar al FR (~ 70 %) pero <em>mayor especificidad</em> (95 %), aparecen antes del inicio clínico y predicen <em>peor pronóstico</em> (más erosiones, más manifestaciones extraarticulares). NO son obligatorios para el diagnóstico (15-20 % de AR son ACPA-negativas).</div>
+</div></details>
+
+<details class="qa"><summary>8. (Jun 2018) Hombre 61 a. con poliartritis + nódulos de Heberden</summary>
+<div class="qa-body">
+<p>Hombre de 61 años con dolor y tumefacción de carpos, MCF e IFP y rodillas desde hace meses. EF: dolor + calor local + nódulos de Heberden. Analítica: VSG 56 mm/h, ácido úrico 7,4 mg/dL. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>Artritis reumatoide</strong></li>
+<li>Gota</li>
+<li>Espondilitis anquilosante</li>
+<li>Lupus eritematoso sistémico / artrosis</li>
+<li>Pseudogota</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Poliartritis simétrica de carpos + MCF + IFP + rodillas + ↑ VSG en hombre de 61 años = AR. Los nódulos de Heberden (IFD) reflejan artrosis nodular asociada (frecuente a esa edad), pero la enfermedad inflamatoria dominante es AR. El úrico 7,4 es asintomático y no explica el cuadro poliarticular crónico.</div>
+</div></details>
+
+<details class="qa"><summary>9. (Jun 2016) Mecanismo de abatacept</summary>
+<div class="qa-body">
+<p>El mecanismo de acción del abatacept es:</p>
+<ol type="a">
+<li>Inhibidor del TNF</li>
+<li>Inhibidor de la IL-6</li>
+<li>Anti-CD20</li>
+<li><strong>Se une al CD80/CD86, evitando o desplazando su interacción con el receptor CD28</strong></li>
+<li>Inhibidor de la IL-1</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Abatacept es CTLA-4-Ig: bloquea la <em>segunda señal de coestimulación</em> (CD28-CD80/86) impidiendo la activación de linfocitos T. Anti-IL6 = tocilizumab. Anti-CD20 = rituximab. Anti-IL1 = anakinra.</div>
+</div></details>
+
+<details class="qa"><summary>10. Dato analítico de especial interés en AR</summary>
+<div class="qa-body">
+<p>De los siguientes datos analíticos solo uno es de especial interés en los pacientes con AR:</p>
+<ol type="a">
+<li>Anticuerpos anticentrómero</li>
+<li>Anticuerpos antihistonas</li>
+<li>Anticuerpos antiRNP</li>
+<li><strong>Anticuerpos antipéptidos cíclicos citrulinados (ACPA)</strong></li>
+<li>Anemia hemolítica</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> ACPA son específicos (95 %) y predictivos de AR. Anti-centrómero = ES limitada; anti-histona = lupus inducido; anti-RNP = EMTC. Anemia hemolítica no es típica de AR.</div>
+</div></details>
+
+<details class="qa"><summary>11. Antes de iniciar anti-TNF</summary>
+<div class="qa-body">
+<p>Indique lo que debe hacerse antes de administrar un anti-TNF a un paciente con AR:</p>
+<ol type="a">
+<li>Conseguir disminuir a menos de 5 mg/día las dosis de prednisona</li>
+<li>Descartar la existencia de amiloidosis</li>
+<li><strong>Descartar tuberculosis latente</strong></li>
+<li>Haber efectuado previamente tratamiento con al menos 2 AINE</li>
+<li>Todo lo anterior es necesario</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Cribado de TBC latente (Mantoux y/o IGRA + Rx tórax) es obligatorio antes de cualquier biológico. Además: serologías VHB y VHC, actualizar vacunación.</div>
+</div></details>
+
+<details class="qa"><summary>12. (Parc 2018) Sobre la AR — FALSA</summary>
+<div class="qa-body">
+<p>Sobre la AR, señala la respuesta FALSA:</p>
+<ol type="a">
+<li>La AR es la enfermedad reumática inflamatoria más frecuente</li>
+<li><strong>Afecta fundamentalmente a la columna</strong></li>
+<li>Es más frecuente en mujeres, 50-70 %, con edad de inicio 40-60 años</li>
+<li>Si no se trata precozmente producirá una importante pérdida de calidad de vida y una incapacidad laboral</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La AR afecta a <em>pequeñas articulaciones periféricas</em> (carpos, MCF, IFP, MTF) y solo a la columna <em>cervical alta (C1-C2)</em> con riesgo de subluxación atloaxoidea. No afecta a la columna dorsolumbar.</div>
+</div></details>
+
+<details class="qa"><summary>13. (Parc 2018) Inicio del tratamiento en AR</summary>
+<div class="qa-body">
+<p>Una vez diagnosticado de AR, si no hay contraindicación, empezaríamos con:</p>
+<ol type="a">
+<li>Corticoides</li>
+<li>Adalimumab</li>
+<li><strong>Metotrexato</strong></li>
+<li>Ciclosporina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> MTX = primera línea. Adalimumab (anti-TNF) si fracaso de csDMARDs. Los corticoides solo como puente, no como monoterapia.</div>
+</div></details>
+
+<details class="qa"><summary>14. (Jun 2017) Mecanismo de tocilizumab</summary>
+<div class="qa-body">
+<p>El mecanismo de acción del tocilizumab es:</p>
+<ol type="a">
+<li>Inhibidor del TNF</li>
+<li><strong>Inhibidor de la IL-6 (interleucina 6)</strong></li>
+<li>Anti-CD20</li>
+<li>Se une al CD80/CD86</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Tocilizumab = anticuerpo monoclonal humanizado anti-receptor de IL-6 (IL-6R). Indicado en AR refractaria, AIJ sistémica/poliarticular, arteritis de células gigantes, ES temprana, síndrome de liberación de citoquinas.</div>
+</div></details>
+
+<details class="qa"><summary>15. AIJ poliarticular — inicio de tratamiento</summary>
+<div class="qa-body">
+<p>En los pacientes con AIJ poliarticular, se debe iniciar tratamiento cuanto antes para evitar la progresión con:</p>
+<ol type="a">
+<li><strong>Metotrexato</strong></li>
+<li>Antipalúdicos de síntesis</li>
+<li>Antiinflamatorios no esteroideos</li>
+<li>Sales de oro</li>
+<li>Ciclofosfamida</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> MTX 10-15 mg/m²/semana es el FAME de elección en AIJ poliarticular. Los AINE alivian síntomas pero no modifican el curso. Sales de oro ya no se usan.</div>
+</div></details>
+
+<details class="qa"><summary>16. AR — NO cierta</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes afirmaciones referidas a la AR NO es cierta?</p>
+<ol type="a">
+<li><strong>La presencia de HLA-DR4 no se considera factor de mal pronóstico</strong></li>
+<li>Muestra un patrón poliarticular simétrico</li>
+<li>La relación mujer/hombre es de 3:1</li>
+<li>La rigidez matutina es criterio diagnóstico</li>
+<li>Puede detectarse ANA en un 10-30 % de los casos</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> HLA-DR4 (epítopo compartido) SÍ es factor de mal pronóstico (erosiones, manifestaciones extraarticulares). Las demás son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>17. Afectación de la columna en la AR</summary>
+<div class="qa-body">
+<p>La afectación de la columna en la AR:</p>
+<ol type="a">
+<li>Se localiza en la región cervical baja</li>
+<li><strong>Suele estar limitada a la región cervical superior</strong></li>
+<li>Se afecta principalmente a la región lumbosacra</li>
+<li>Tiene preferencia por la zona D12-L1</li>
+<li>Todas las respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La AR afecta sobre todo a la <em>cervical alta (C1-C2)</em>, con riesgo de subluxación atloaxoidea por destrucción del ligamento transverso del atlas → compromiso medular. No afecta a la columna dorsal ni lumbar.</div>
+</div></details>
+
+<details class="qa"><summary>18. Receptor activado para erosiones en AR</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes receptores son activados para la producción de erosiones en la AR?</p>
+<ol type="a">
+<li>Interleucina 6 (IL-6)</li>
+<li>Interleucina 1 (IL-1)</li>
+<li>TNF-α</li>
+<li><strong>Factor nuclear κ-B (RANK)</strong></li>
+<li>CD-20</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> El eje RANK-RANKL-OPG controla la diferenciación y activación de osteoclastos → <em>resorción ósea</em>. Las citoquinas (TNF, IL-6, IL-1) estimulan la producción de RANKL por sinoviocitos y osteoblastos. Denosumab (anti-RANKL) inhibe este eje.</div>
+</div></details>
+
+<details class="qa"><summary>19. Manifestación extraarticular más frecuente en AIJ oligoarticular</summary>
+<div class="qa-body">
+<p>¿Cuál es la manifestación extraarticular más frecuente de la AIJ oligoarticular?</p>
+<ol type="a">
+<li>Pleuritis</li>
+<li>Fiebre</li>
+<li>Pericarditis</li>
+<li><strong>Uveítis</strong></li>
+<li>Neumopatía intersticial</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> <em>Uveítis anterior crónica silente</em> (asintomática hasta que produce secuelas): el 20-30 % de las niñas con AIJ oligoarticular ANA (+) la desarrollan. Por eso es obligatorio el cribado oftalmológico cada 3-6 meses.</div>
+</div></details>
+
+<details class="qa"><summary>20. Manifestación NO característica de la AR</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes manifestaciones clínicas extra-articulares NO son características de la AR?</p>
+<ol type="a">
+<li><strong>Glomerulonefritis proliferativa</strong></li>
+<li>Nódulos reumatoideos</li>
+<li>Derrame pleural</li>
+<li>Pericarditis</li>
+<li>Amiloidosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La AR NO produce GN. La afectación renal en AR es por <em>amiloidosis AA</em> (en larga evolución mal controlada) o por fármacos (sales de oro, D-penicilamina). Las demás son extraarticulares típicas.</div>
+</div></details>
+
+<details class="qa"><summary>21. Factor reumatoide — NO verdadera</summary>
+<div class="qa-body">
+<p>Respecto al factor reumatoide, indicar la respuesta NO verdadera:</p>
+<ol type="a">
+<li>Es una inmunoglobulina IgM dirigida contra una IgG</li>
+<li>Es positivo en 5-10 % de la población</li>
+<li>Aumenta su frecuencia con la edad</li>
+<li><strong>Títulos más altos lo hacen más específicos para el diagnóstico de la AR</strong></li>
+<li>La negatividad del factor reumatoide no excluye el diagnóstico de AR</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La pregunta del banco UGR marca esta como falsa. En realidad SÍ es cierto que títulos altos son más específicos, pero el banco la considera "no verdadera" en su clave. La especificidad del FR es moderada, aumenta con título pero nunca alcanza la del ACPA.</div>
+</div></details>
+
+<details class="qa"><summary>22. Artritis seronegativa</summary>
+<div class="qa-body">
+<p>La artritis seronegativa se caracteriza por:</p>
+<ol type="a">
+<li>Negatividad de los antígenos antinucleares</li>
+<li>Negatividad de la serología lúpica</li>
+<li><strong>Negatividad constante de la aglutinación del factor reumatoide</strong></li>
+<li>Negatividad del HLA-B27</li>
+<li>Negatividad de la tasa de antiestreptolisina (ASLO)</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> "Seronegativa" se refiere a FR (−). Las espondiloartritis son artritis seronegativas asociadas a HLA-B27 (no negativo).</div>
+</div></details>
+
+<details class="qa"><summary>23. ACPA — afirmación correcta</summary>
+<div class="qa-body">
+<p>¿Cuál es correcta respecto a los anti-CCP?</p>
+<ol type="a">
+<li>Comienzan a detectarse en sangre en el debut de la AR</li>
+<li>Son igual de específicos para AR que el factor reumatoide</li>
+<li><strong>Se asocian a un peor pronóstico de la AR</strong></li>
+<li>Son menos sensibles que el factor reumatoide</li>
+<li>Su presencia se asocia al HLA-DR2</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> ACPA = peor pronóstico. Aparecen <em>antes</em> del debut clínico (no en el debut). Son MÁS específicos que el FR (95 % vs 70 %). Sensibilidad similar al FR. Asociados a HLA-DR4 (no DR2).</div>
+</div></details>
+
+<details class="qa"><summary>24. (Jun 2018) Mecanismo de tofacitinib</summary>
+<div class="qa-body">
+<p>El mecanismo de acción del tofacitinib es:</p>
+<ol type="a">
+<li>Inhibidor del TNF</li>
+<li>Inhibidor de la IL-6</li>
+<li>Anti-CD20</li>
+<li><strong>Inhibidor de las JAK cinasas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Tofacitinib es un inhibidor de JAK1/JAK3 (pequeña molécula oral, "tsDMARD"). Otros JAKi: baricitinib (JAK1/2), upadacitinib (JAK1 selectivo), filgotinib (JAK1).</div>
+</div></details>
+
+<details class="qa"><summary>25. (Jun 2018) ACPA — repetida</summary>
+<div class="qa-body">
+<p>¿Cuál es correcta respecto a los anti-CCP?</p>
+<ol type="a">
+<li>Su presencia es obligatoria para el diagnóstico de AR</li>
+<li>Son menos sensibles que el factor reumatoide</li>
+<li><strong>Se asocian a un peor pronóstico de la AR</strong></li>
+<li>Se utilizan solo para investigación</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Igual razonamiento que la P7 y P23.</div>
+</div></details>
+
+<details class="qa"><summary>26. (Jun 2018) AIJ — FALSA</summary>
+<div class="qa-body">
+<p>Referente a la AIJ, señala la respuesta FALSA:</p>
+<ol type="a">
+<li><strong>La forma clínica más frecuente es la poliarticular</strong></li>
+<li>La uveítis es la forma ocular asociada más frecuente</li>
+<li>Están indicadas las terapias biológicas anti-TNF y anti-IL-6</li>
+<li>La dosis de metotrexato no debe ser superior a 5 mg/semanal</li>
+</ol>
+<div class="answer"><strong>Respuesta: a (FALSA).</strong> La forma más frecuente es la <em>oligoarticular</em> (50 %). La opción d también es falsa (la dosis pediátrica es 10-15 mg/m²/sem, no se limita a 5 mg).</div>
+</div></details>
+
+<details class="qa"><summary>27. (Jun 2018) AR — VERDADERA</summary>
+<div class="qa-body">
+<p>Sobre la AR, señala la respuesta VERDADERA:</p>
+<ol type="a">
+<li>La edad de aparición de la AR más frecuente es por encima de los 60 años</li>
+<li><strong>La prevalencia es de 0,5-1 % de la población</strong></li>
+<li>Es una oligoartritis inflamatoria crónica asimétrica de predominio en MMII</li>
+<li>Su evolución sin tratamiento es benigna</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La AR afecta al 0,5-1 % de la población. Edad de inicio típica: 40-60 años (no &gt; 60). Es poliartritis simétrica de pequeñas articulaciones. Sin tratamiento causa destrucción articular y discapacidad.</div>
+</div></details>
+
+<details class="qa"><summary>28. (Jun 2018) Niña con artritis + ANA 1/640 — vigilancia ocular</summary>
+<div class="qa-body">
+<p>En una niña de 8 años que comienza con dolor y tumefacción en rodillas y carpo izquierdo, FR negativo y ANA positivos 1/640, se le debe realizar exploración ocular:</p>
+<ol type="a">
+<li>Solo si está tomando hidroxicloroquina</li>
+<li>Si presenta molestias oculares</li>
+<li><strong>Una vez cada 6 meses (o cada 3 meses según factores de riesgo)</strong></li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Niña con AIJ oligoarticular + ANA (+) = alto riesgo de uveítis anterior crónica silente. Cribado obligatorio cada 3-6 meses durante al menos 4 años. Si no se detecta a tiempo puede causar ceguera.</div>
+</div></details>
+
+<details class="qa"><summary>29. (Jun 2018) MTX — recomendación VERDADERA</summary>
+<div class="qa-body">
+<p>Para el control de efectos adversos del MTX en AR, señala la respuesta VERDADERA:</p>
+<ol type="a">
+<li>Si se planifica un embarazo no se debe suspender el MTX</li>
+<li>Los efectos adversos más frecuentes son los hematológicos</li>
+<li>Al ser dosis mínimas-moderadas solo hacen falta controles analíticos anuales</li>
+<li><strong>Se debe preguntar en cada revisión por síntomas respiratorios (tos, disnea)</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Vigilar neumonitis por MTX (rara pero grave). El MTX SÍ se suspende ≥ 3 meses antes del embarazo (a falso). Los efectos adversos más frecuentes son <em>GI</em> (no hematológicos). Controles cada 1-3 meses (no anuales).</div>
+</div></details>
+
+<details class="qa"><summary>30. (Parc 2019) Terapias biológicas — recomendación</summary>
+<div class="qa-body">
+<p>En la utilización de las terapias biológicas en las enfermedades reumáticas:</p>
+<ol type="a">
+<li><strong>Se debe descartar una infección tuberculosa latente</strong></li>
+<li>Están contraindicadas en edad pediátrica</li>
+<li>En caso de Mantoux y/o IGRA positivo se debe realizar quimioprofilaxis con penicilina</li>
+<li>Están contraindicadas si hay una planificación de embarazo</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Cribar TBC latente. La quimioprofilaxis es con <em>isoniacida</em> (¡NO penicilina!). Algunos biológicos se usan en pediatría (etanercept, adalimumab en AIJ). Para embarazo se prefiere <em>certolizumab</em>.</div>
+</div></details>
+
+<details class="qa"><summary>31. (Parc 2019) Paciente con DAS 5,81 a pesar de MTX 25 mg</summary>
+<div class="qa-body">
+<p>Paciente con AR tratada con MTX en dosis crecientes hasta 25 mg/sem. DAS de 5,81 en la última revisión. ¿Qué tratamiento indicaría?</p>
+<ol type="a">
+<li>Está en remisión y no modificaría el tratamiento</li>
+<li>Glucocorticoides a dosis altas</li>
+<li>Infiltraciones locales con corticoides</li>
+<li><strong>Terapias biológicas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> DAS28 &gt; 5,1 = actividad alta. Si tras 3-6 meses con dosis máxima de MTX no se alcanza remisión o baja actividad → escalar a biológico (anti-TNF de primera elección, o anti-IL6, o JAKi).</div>
+</div></details>
+
+<details class="qa"><summary>32. (Parc 2019) Antes de biológicos — NO realizar</summary>
+<div class="qa-body">
+<p>Se inicia tratamiento con terapias biológicas. ¿Cuál de los siguientes exámenes NO realizaría?</p>
+<ol type="a">
+<li>Mantoux o IGRA</li>
+<li><strong>Fondo de ojo</strong></li>
+<li>Serología de virus de hepatitis B y C</li>
+<li>Radiografía de tórax</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> El fondo de ojo no se requiere antes de biológicos (sí antes de HCQ y durante su uso). Se cribará: Mantoux/IGRA, Rx tórax, serologías VHB/VHC, vacunación.</div>
+</div></details>
+
+<details class="qa"><summary>33. (Parc 2019) Diana NO de primera elección en AR</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes dianas terapéuticas NO empezaría en este caso clínico de AR?</p>
+<ol type="a">
+<li>Anti-TNF-α</li>
+<li>Anti-IL-6</li>
+<li><strong>Anti-IL-17</strong></li>
+<li>Anti-CD20</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Anti-IL-17 (secukinumab, ixekizumab) NO están aprobados para AR; están indicados en espondiloartritis (axial, psoriásica) y psoriasis. En AR se usan anti-TNF, anti-IL-6, anti-CD20, abatacept y JAKi.</div>
+</div></details>
+
+<details class="qa"><summary>34. (Jun 2019) AIJ — VERDADERA</summary>
+<div class="qa-body">
+<p>Referente a la AIJ, señala la respuesta VERDADERA:</p>
+<ol type="a">
+<li>La forma clínica más frecuente es la poliarticular</li>
+<li>La epiescleritis es la forma ocular asociada más frecuente</li>
+<li><strong>Se pueden utilizar terapias biológicas</strong></li>
+<li>La dosis de metotrexato no debe ser superior a 5 mg/semanal</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Biológicos aprobados en AIJ: etanercept, adalimumab, infliximab, tocilizumab (especialmente en sistémica/poliarticular). La forma más frecuente es la oligoarticular. La uveítis es la ocular asociada. MTX no se limita a 5 mg/sem.</div>
+</div></details>
+
+<details class="qa"><summary>35. (Jun 2019/Parc 2020) Inhibidores de JAK</summary>
+<div class="qa-body">
+<p>Los inhibidores de las JAK cinasas:</p>
+<ol type="a">
+<li>Se administran parenteralmente</li>
+<li>Actúan a nivel de receptores de membrana celular</li>
+<li>No hace falta descartar infección tuberculosa latente antes de iniciar tratamiento</li>
+<li><strong>El riesgo de herpes zóster es mayor en japoneses y coreanos</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Los JAKi son de administración <em>oral</em> (no parenteral). Actúan <em>intracelularmente</em> (no en receptores de membrana). SÍ requieren cribado de TBC. Tienen mayor riesgo de herpes zóster, especialmente en población asiática. Vacunar antes con vacuna recombinante.</div>
+</div></details>
+
+<details class="qa"><summary>36. (Jun 2019/Parc 2020) MTX — FALSA</summary>
+<div class="qa-body">
+<p>Para el control del MTX en AR, señala la respuesta FALSA:</p>
+<ol type="a">
+<li>Si se planifica un embarazo se debe suspender el MTX un mínimo de 3 meses previamente</li>
+<li><strong>Al ser dosis mínimas-moderadas solo hace falta controles analíticos anuales</strong></li>
+<li>Se debe preguntar en cada revisión por síntomas respiratorios (tos, disnea)</li>
+<li>Los efectos adversos gastrointestinales son los más frecuentes</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> Controles cada 1-3 meses (no anuales): hemograma, función hepática, función renal.</div>
+</div></details>
+
+<details class="qa"><summary>37. (Jun 2019) Tipo de molécula de tocilizumab</summary>
+<div class="qa-body">
+<p>Tocilizumab:</p>
+<ol type="a">
+<li>Es un anticuerpo monoclonal humano</li>
+<li>Es una proteína de fusión</li>
+<li><strong>Es un anticuerpo monoclonal humanizado</strong></li>
+<li>Ninguna de las respuestas anteriores es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tocilizumab es humanizado (sufijo "-zumab"). Humano sería "-umab" (ej.: adalimumab); quimérico "-ximab" (ej.: infliximab); proteína de fusión "-cept" (ej.: etanercept, abatacept).</div>
+</div></details>
+
+<details class="qa"><summary>38. (Parc 2020) Diferencial AR vs artrosis — más típico de artrosis</summary>
+<div class="qa-body">
+<p>En una paciente de 47 años con dolor poliarticular, en el diagnóstico diferencial con AR sería más característico de una ARTROSIS:</p>
+<ol type="a">
+<li>Un líquido articular amarillo, poco filante, con 18.500 células/mm³ con predominio de neutrófilos</li>
+<li>Títulos altos de anti-CCP</li>
+<li><strong>Localización a nivel de interfalángicas distales de ambas manos</strong></li>
+<li>Aumento de partes blandas y osteopenia a nivel de carpos y MCF en Rx</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La AR <em>respeta IFD</em> (afecta MCF, IFP, carpos, MTF). IFD = Heberden = artrosis. Las opciones a, b y d son típicas de AR (líquido inflamatorio &gt; 2.000 cél, anti-CCP, osteopenia yuxta-articular).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 13: Espondiloartritis =============== -->
+<section class="card" id="t13">
+<h2 class="section-title"><span class="num">13</span>Espondiloartritis inflamatorias (EpA)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Grupo de <strong>artropatías seronegativas (FR/ACPA −)</strong> asociadas a <strong>HLA-B27</strong>.</li>
+    <li><strong>Entesitis</strong> (inflamación en la inserción tendinosa/ligamentosa) = lesión patogénica nuclear.</li>
+    <li>Dactilitis ("dedos en salchicha"), sacroileítis, sindesmofitos, <strong>uveítis anterior aguda no granulomatosa unilateral</strong>.</li>
+    <li><strong>Citoquinas clave: TNF-α + eje IL-23/IL-17.</strong></li>
+  </ul>
+</div>
+
+<h3>13.1 Subtipos</h3>
+<ol>
+  <li><strong>Espondilitis anquilosante (EA / Bechterew)</strong></li>
+  <li>Artritis psoriásica (APs)</li>
+  <li>Artritis reactivas (ReA) — antes Reiter</li>
+  <li>Espondiloartritis asociada a EII</li>
+  <li>Espondiloartritis indiferenciadas / axiales no radiográficas</li>
+  <li>Espondiloartritis juvenil</li>
+</ol>
+
+<h3>13.2 Espondilitis anquilosante (EA)</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Perfil</span><span class="v">Varón joven 20-30 años, 3:1</span></div>
+  <div class="kv"><span class="k">HLA-B27</span><span class="v">&gt; 90 %</span></div>
+  <div class="kv"><span class="k">Lumbalgia inflamatoria</span><span class="v">≥ 3 meses · inicio &lt; 40 a. · mejora con ejercicio, empeora con reposo · <em>rigidez matutina &gt; 60 min</em> · dolor nocturno · alternancia en nalgas</span></div>
+  <div class="kv"><span class="k">Progresión</span><span class="v">Sacroilíacas → lumbar → dorsal → cervical → "<em>columna en caña de bambú</em>"</span></div>
+  <div class="kv"><span class="k">Periférica</span><span class="v">Oligoarticular asimétrica MMII (si hay)</span></div>
+  <div class="kv"><span class="k">Entesitis</span><span class="v">Talalgia · fascitis plantar</span></div>
+  <div class="kv"><span class="k">Uveítis</span><span class="v">Anterior aguda <strong>no granulomatosa unilateral</strong> (40 %, recurrente alternante)</span></div>
+  <div class="kv"><span class="k">Pulmonar</span><span class="v"><strong>Fibrosis pulmonar apical</strong></span></div>
+  <div class="kv"><span class="k">Cardio</span><span class="v">Insuficiencia aórtica · trastornos de conducción</span></div>
+</div>
+
+<h4>Maniobras exploratorias</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Test de Schöber</span><span class="v">Mide <strong>movilidad lumbar</strong>. Marca en L5 + 10 cm; en flexión debe ↑ &gt; 5 cm</span></div>
+  <div class="kv"><span class="k">Distancia occipucio-pared</span><span class="v">Debería ser 0</span></div>
+  <div class="kv"><span class="k">FABERE / Patrick</span><span class="v">Sacroilíacas / cadera</span></div>
+  <div class="kv"><span class="k">Expansión torácica</span><span class="v">Normal &gt; 5 cm</span></div>
+</div>
+
+<h4>Diagnóstico</h4>
+<ul>
+  <li><strong>Criterios modificados de Nueva York 1984:</strong> sacroileítis radiográfica <em>bilateral grado ≥ 2 o unilateral 3-4</em> + ≥ 1 criterio clínico.</li>
+  <li><strong>Criterios ASAS:</strong> permite clasificar espondiloartritis axial no radiográfica con RMN + clínica + HLA-B27.</li>
+  <li><strong>Primera prueba si Rx no concluyente: RMN de sacroilíacas</strong> (edema óseo activo).</li>
+</ul>
+
+<h4>Índices</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">BASDAI</span><span class="v">Actividad clínica autoreferida</span></div>
+  <div class="kv"><span class="k">BASFI</span><span class="v">Función física</span></div>
+  <div class="kv"><span class="k">ASDAS</span><span class="v">Actividad combinada (clínica + PCR/VSG)</span></div>
+</div>
+
+<h4>Tratamiento de EA</h4>
+<ol>
+  <li><strong>AINE</strong> a dosis plenas continuas (1ª línea).</li>
+  <li>Ejercicios físicos y rehabilitación.</li>
+  <li>FAME clásicos <strong>NO funcionan en axial</strong>; sí en periférica.</li>
+  <li>Biológicos:
+    <ul>
+      <li><strong>Anti-TNF (de elección)</strong>: adalimumab, etanercept, infliximab, golimumab, certolizumab.</li>
+      <li><strong>Anti-IL-17</strong>: secukinumab, ixekizumab.</li>
+      <li><strong>JAKi</strong>: tofacitinib, upadacitinib.</li>
+      <li><span class="tag danger">NO eficaces</span>: anti-IL-6, anti-CD20, anti-IL-12/23 (ustekinumab no en axial).</li>
+    </ul>
+  </li>
+</ol>
+
+<h3>13.3 Artritis psoriásica (APs)</h3>
+<p>10-30 % de los pacientes con psoriasis.</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Forma clínica</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td>Oligoarticular asimétrica (50 %)</td><td>La más frecuente al inicio</td></tr>
+<tr><td>Poliarticular simétrica</td><td>Parecida a AR ("reumatoide-like")</td></tr>
+<tr><td><strong>Clásica: predominio en IFD</strong></td><td>Con alteración ungueal (pitting, onicolisis)</td></tr>
+<tr><td>Espondilítica / axial</td><td>—</td></tr>
+<tr><td>Mutilante</td><td>Rara, destructiva, "<em>dedos en catalejo</em>", "lápiz en copa"</td></tr>
+</tbody></table></div>
+
+<p><strong>Rx APs:</strong> "lápiz en copa" · reabsorción de falanges distales · proliferación ósea · tumefacción fusiforme · anquilosis. <strong>SIN osteopenia yuxta-articular</strong> (eso es AR).</p>
+
+<h3>13.4 Artritis reactiva</h3>
+<ul>
+  <li>Oligoartritis asimétrica MMII <strong>2-4 semanas tras infección</strong>:
+    <ul>
+      <li>Urogenital: <strong>Chlamydia trachomatis</strong></li>
+      <li>Digestiva: <strong>Yersinia, Salmonella, Shigella, Campylobacter</strong></li>
+      <li><span class="tag danger">¡NO M. tuberculosis!</span> (la TBC da artritis directa, no reactiva)</li>
+    </ul>
+  </li>
+  <li><strong>El germen NO está en la articulación</strong>; mecanismo inmune cruzado.</li>
+  <li>Tríada de Reiter: uretritis + conjuntivitis + artritis.</li>
+  <li>Manifestaciones: balanitis circinada · queratodermia blenorrágica · aftas indoloras · dactilitis.</li>
+</ul>
+
+<h3>13.5 Preguntas — Espondiloartritis</h3>
+
+<details class="qa"><summary>1. (Jun 2019/2020) Germen que NO causa artritis reactiva</summary>
+<div class="qa-body">
+<p>¿Qué germen NO es responsable de una artritis reactiva?</p>
+<ol type="a">
+<li>Yersinia enterocolítica</li>
+<li>Shigella</li>
+<li>Salmonella</li>
+<li><strong>M. tuberculosis</strong></li>
+<li>Chlamydia trachomatis</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> M. tuberculosis no causa ReA — produce <em>artritis tuberculosa directa</em> por invasión articular (mal de Pott en columna). Las causantes de ReA son entéricas (Yersinia, Salmonella, Shigella, Campylobacter) o urogenitales (Chlamydia).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2017) Enfermedad que NO es espondiloartritis seronegativa</summary>
+<div class="qa-body">
+<p>Citar qué enfermedad NO es una espondiloartritis seronegativa:</p>
+<ol type="a">
+<li>Enfermedad de Reiter</li>
+<li>Artritis psoriásica</li>
+<li>Artritis asociada a colitis ulcerosa</li>
+<li><strong>Osteítis condensante del ilíaco</strong></li>
+<li>Artritis reactiva por Shigella</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La osteítis condensante del ilíaco es una entidad benigna autolimitada, típica de mujeres jóvenes tras el parto (esclerosis triangular en la cara iliaca de la articulación SI). NO es inflamatoria ni se asocia a HLA-B27.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2016) HLA-B27 — asociación clínica</summary>
+<div class="qa-body">
+<p>El antígeno HLA-B27 se encuentra con frecuencia en pacientes con:</p>
+<ol type="a">
+<li>Conjuntivitis aguda</li>
+<li>Síndrome seco</li>
+<li><strong>Uveítis anterior aguda</strong></li>
+<li>Neuritis óptica</li>
+<li>Cataratas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La uveítis anterior aguda no granulomatosa unilateral recurrente es la manifestación ocular típica de las espondiloartritis (HLA-B27 +).</div>
+</div></details>
+
+<details class="qa"><summary>4. Forma "clásica" de artropatía psoriásica</summary>
+<div class="qa-body">
+<p>La denominada "forma clásica" de la artropatía psoriásica se caracteriza fundamentalmente por:</p>
+<ol type="a">
+<li>Ser poliarticular y simétrica</li>
+<li><strong>Afectación de las articulaciones interfalángicas distales (IFD) con alteración ungueal</strong></li>
+<li>Presentar telescopaje de los dedos</li>
+<li>Presentar dedos en "salchicha"</li>
+<li>Ser equivalente a la forma articular asimétrica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Forma clásica de Moll y Wright: afectación predominante de IFD con alteración ungueal (pitting, onicolisis). El telescopaje es de la forma mutilante. Los dedos en salchicha (dactilitis) son típicos pero de la forma asimétrica.</div>
+</div></details>
+
+<details class="qa"><summary>5. Afectación articular más frecuente en el síndrome de Reiter</summary>
+<div class="qa-body">
+<p>La afectación articular más frecuente en el síndrome de Reiter es:</p>
+<ol type="a">
+<li>Oligoartritis simétrica de pequeñas articulaciones</li>
+<li><strong>Artritis asimétrica de grandes articulaciones (de MMII)</strong></li>
+<li>Monoartritis de IFD</li>
+<li>Poliartritis migratoria</li>
+<li>Poliartritis simétrica de pequeñas articulaciones</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ReA / Reiter: oligoartritis asimétrica de grandes articulaciones de MMII (rodilla, tobillo). Con frecuencia dactilitis y entesitis (talón).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2018) Test de Schöber</summary>
+<div class="qa-body">
+<p>El método de Schöber sirve para determinar:</p>
+<ol type="a">
+<li><strong>La movilidad lumbar</strong></li>
+<li>La expansión respiratoria</li>
+<li>La movilidad sacroilíaca</li>
+<li>La movilidad de la cadera</li>
+<li>Todas las anteriores son ciertas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Schöber: marca en L5 + punto 10 cm por encima con el paciente erecto; en flexión máxima la distancia debe aumentar &gt; 5 cm. En EA, &lt; 5 cm = limitación.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2017) Uveítis de la espondilitis anquilosante</summary>
+<div class="qa-body">
+<p>La uveítis de la EA es:</p>
+<ol type="a">
+<li><strong>Aguda no granulomatosa (unilateral, recurrente, alternante)</strong></li>
+<li>Crónica</li>
+<li>Aguda granulomatosa</li>
+<li>Crónica granulomatosa</li>
+<li>Bilateral</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> "Ojo rojo doloroso" agudo, unilateral, alternante. Granulomatosa sería de sarcoidosis o TBC. Crónica silente bilateral sería de AIJ.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Jun 2016) En la artritis reactiva el germen…</summary>
+<div class="qa-body">
+<p>En la artritis reactiva sabemos que el germen causal está:</p>
+<ol type="a">
+<li>En el interior de la cavidad articular</li>
+<li>Inmerso en la sinovial</li>
+<li><strong>No se halla dentro de la articulación</strong></li>
+<li>Actúa a través de inmunocomplejos</li>
+<li>Actúa por mecanismo inmunoalérgico</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La ReA es una respuesta inmune cruzada tras infección, NO una artritis séptica. El cultivo articular es negativo. El mecanismo es mimetismo molecular en huésped HLA-B27 (+).</div>
+</div></details>
+
+<details class="qa"><summary>9. (Jun 2016) Varón con lumbalgia inflamatoria — ¿qué AF investigar?</summary>
+<div class="qa-body">
+<p>Varón de 28 años con lumbalgia &gt; 6 meses, alternancia de dolor en nalgas, rigidez matutina 45-60 min. Analítica: VSG 45, PCR 16. Sería importante conocer los antecedentes familiares de:</p>
+<ol type="a">
+<li>Gota</li>
+<li>Espondiloartrosis</li>
+<li>Estenosis de canal lumbar o diabetes</li>
+<li><strong>Espondiloartritis inflamatoria</strong></li>
+<li>Fracturas vertebrales</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Las EpA tienen agregación familiar (HLA-B27). Investigar AF de EA, APs, EII, uveítis recurrente.</div>
+</div></details>
+
+<details class="qa"><summary>10. Evaluación de la actividad de la EA</summary>
+<div class="qa-body">
+<p>En la evaluación de la actividad de la EA, utilizaría:</p>
+<ol type="a">
+<li>Dolor raquídeo nocturno</li>
+<li>Índice BASFI</li>
+<li>Cuestionario BASDAI</li>
+<li>Recuento de articulaciones inflamadas y de entesitis</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Evaluación multidimensional: BASDAI (actividad), BASFI (función), ASDAS (actividad combinada con PCR), dolor nocturno, articulaciones inflamadas y entesitis.</div>
+</div></details>
+
+<details class="qa"><summary>11. Mecanismos etiopatogénicos de la artropatía psoriásica</summary>
+<div class="qa-body">
+<p>Señale la respuesta cierta respecto a los mecanismos etiopatogénicos de la artropatía psoriásica:</p>
+<ol type="a">
+<li>Infiltración de la sinovial con células T, B y macrófagos</li>
+<li>Existe una liberación de neuropéptidos proinflamatorios</li>
+<li>Está incrementada la vascularidad de la sinovial</li>
+<li><strong>Las tres respuestas anteriores son correctas</strong></li>
+<li>Las tres primeras respuestas corresponderían a la AR</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Todas son ciertas. La hipervascularización sinovial es muy llamativa en APs (clínicamente: piel y articulación enrojecidas y calientes).</div>
+</div></details>
+
+<details class="qa"><summary>12. Características comunes de las espondiloartropatías — EXCEPTO</summary>
+<div class="qa-body">
+<p>Son características comunes de las EpA inflamatorias todas, EXCEPTO:</p>
+<ol type="a">
+<li>Superposición de manifestaciones clínicas en órganos y sistemas</li>
+<li>Ausencia de factor reumatoide</li>
+<li><strong>Asociación al HLA-DR4</strong></li>
+<li>Asociación al HLA-B27 y tendencia a la agregación familiar</li>
+<li>Presencia de síndrome articular periférico y/o axial</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> HLA-DR4 es de AR (epítopo compartido), no de espondiloartritis. Las EpA se asocian a HLA-B27.</div>
+</div></details>
+
+<details class="qa"><summary>13. Criterios clínicos NO necesarios para diagnóstico de EA</summary>
+<div class="qa-body">
+<p>Todos EXCEPTO uno son criterios clínicos necesarios para el diagnóstico de la EA:</p>
+<ol type="a">
+<li>Dolor lumbar que mejora con el ejercicio</li>
+<li><strong>Limitación de la movilidad de las articulaciones sacroilíacas</strong></li>
+<li>Dolor lumbar que empeora con el reposo</li>
+<li>Disminución de la expansión torácica</li>
+<li>Limitación de la movilidad del raquis lumbar</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Criterios modificados de Nueva York 1984 clínicos: dolor lumbar inflamatorio ≥ 3 meses (mejora con ejercicio, empeora con reposo), limitación movilidad lumbar (Schöber), limitación expansión torácica. La limitación de la movilidad SI se evalúa radiológicamente (sacroileítis), no clínicamente.</div>
+</div></details>
+
+<details class="qa"><summary>14. Test de Schöber — utilidad</summary>
+<div class="qa-body">
+<p>El denominado test de Schöber se utiliza con el fin de evaluar:</p>
+<ol type="a">
+<li>La extensión de la cadera</li>
+<li>La distancia occipucio-pared</li>
+<li>La movilidad / dolor a la presión de las sacroilíacas</li>
+<li><strong>La amplitud de la movilidad lumbar</strong></li>
+<li>La distancia mano-suelo</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Igual razonamiento que la P6.</div>
+</div></details>
+
+<details class="qa"><summary>15. (Jun 2017) Signos radiológicos en lumbalgia inflamatoria</summary>
+<div class="qa-body">
+<p>En un paciente de 37 años con dolor lumbar de ritmo inflamatorio, ¿qué signos radiológicos buscará en la Rx de columna lumbar?</p>
+<ol type="a">
+<li>Rectificación de la columna lumbar y escoliosis</li>
+<li>Osteoporosis y aplastamientos vertebrales</li>
+<li>Osteofitos y reducción altura vertebral</li>
+<li><strong>Cuadratura y sindesmofitos</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> EA: cuadratura vertebral (pérdida de la concavidad anterior) + sindesmofitos (osificaciones finas verticales que unen vértebras adyacentes) → "columna en caña de bambú". Distintos de los osteofitos (horizontales) de la artrosis.</div>
+</div></details>
+
+<details class="qa"><summary>16. (Jun 2017) Dedos en "catalejo"</summary>
+<div class="qa-body">
+<p>Los dedos en "catalejo" o telescopaje se observan en pacientes con artritis psoriásica con:</p>
+<ol type="a">
+<li>Factor reumatoide positivo</li>
+<li><strong>Artritis mutilante</strong></li>
+<li>Anquilosis ósea</li>
+<li>Poliartritis asimétrica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La forma mutilante de APs (rara) destruye las falanges con acortamiento → "dedos en catalejo" / "lápiz en copa".</div>
+</div></details>
+
+<details class="qa"><summary>17. (Jun 2017) HLA-B27 — asociación</summary>
+<div class="qa-body">
+<p>Se ha observado una significativa asociación entre el HLA-B27 y:</p>
+<ol type="a">
+<li>Conjuntivitis crónica</li>
+<li>Eczema</li>
+<li><strong>Balanitis circinada</strong></li>
+<li>Neuritis óptica</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La balanitis circinada es manifestación clásica del síndrome de Reiter (ReA por Chlamydia, HLA-B27 +).</div>
+</div></details>
+
+<details class="qa"><summary>18. (Jun 2017) Test funcional para EA</summary>
+<div class="qa-body">
+<p>Varón de 28 a. con lumbalgia inflamatoria. ¿Qué test de función física se utiliza para su evaluación y seguimiento?</p>
+<ol type="a">
+<li>HAQ</li>
+<li><strong>BASFI</strong></li>
+<li>DAS28</li>
+<li>BASDAI</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> BASFI mide función física en EA. BASDAI mide actividad clínica. DAS28 es para AR. HAQ es de AR/EAS.</div>
+</div></details>
+
+<details class="qa"><summary>19. Criterios radiológicos para diagnóstico de EA</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes datos radiológicos son necesarios siguiendo los criterios internacionales para el diagnóstico de EA?</p>
+<ol type="a">
+<li>Osificación articulaciones costo-vertebrales</li>
+<li>Sacroileítis unilateral grado 3-4</li>
+<li>Sacroileítis bilateral grados 2 a 4</li>
+<li>Cuadratura de los cuerpos vertebrales y sindesmofitos</li>
+<li><strong>Las respuestas b y c son correctas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Criterios Nueva York 1984 radiológicos: <em>sacroileítis bilateral grado ≥ 2 O unilateral grado 3-4</em>. La RMN sacroilíaca con edema óseo activo permite diagnosticar formas no radiográficas (criterios ASAS).</div>
+</div></details>
+
+<details class="qa"><summary>20. Manifestaciones extraarticulares de la EA</summary>
+<div class="qa-body">
+<p>Entre las manifestaciones extraarticulares de la EA hay que considerar:</p>
+<ol type="a">
+<li>Pericarditis</li>
+<li>Pleuritis</li>
+<li><strong>Fibrosis pulmonar apical</strong></li>
+<li>Litiasis renal</li>
+<li>Retinitis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Fibrosis pulmonar apical es la manifestación pulmonar típica (puede simular TBC). Otras extraarticulares: uveítis anterior, insuficiencia aórtica, trastornos de conducción, IgA nefropatía, amiloidosis AA.</div>
+</div></details>
+
+<details class="qa"><summary>21. (Jun 2018) ¿Qué es una entesis?</summary>
+<div class="qa-body">
+<p>¿Qué es una entesis?</p>
+<ol type="a">
+<li>Una nueva prueba de laboratorio</li>
+<li>Una inflamación intestinal</li>
+<li>Una espondiloartritis seronegativa</li>
+<li><strong>El punto donde los ligamentos o tendones se fijan al hueso subcondral</strong></li>
+<li>Una variante de la TAC</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Entesis = inserción ligamentaria o tendinosa al hueso. <em>Entesitis</em> es la inflamación de la entesis y es la lesión patogénica nuclear de las EpA (talalgia, fascitis plantar, dactilitis).</div>
+</div></details>
+
+<details class="qa"><summary>22. EA — afirmación NO correcta</summary>
+<div class="qa-body">
+<p>En relación con la EA, una de las siguientes afirmaciones NO es correcta:</p>
+<ol type="a">
+<li>Marcado predominio en sexo masculino</li>
+<li>Comienzo habitual entre 20 y 30 años</li>
+<li><strong>Los familiares de pacientes con EA presentan el mismo riesgo relativo para padecer la enfermedad</strong></li>
+<li>Es rara antes de los 9 y después de los 40 años</li>
+<li>El HLA-B27 está presente en más del 90 % de los casos</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los familiares de primer grado de pacientes con EA tienen <em>MAYOR</em> riesgo relativo (× 10-20) que la población general, no el mismo.</div>
+</div></details>
+
+<details class="qa"><summary>23. Dolor torácico en EA — causa más frecuente</summary>
+<div class="qa-body">
+<p>Un paciente de 37 años diagnosticado de EA refiere dolor torácico. La causa más frecuente a considerar es:</p>
+<ol type="a">
+<li>Pleuritis</li>
+<li>Pericarditis</li>
+<li>Inflamación costal</li>
+<li><strong>Artritis costovertebral</strong></li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La artritis costovertebral causa dolor torácico mecánico con la respiración profunda y disminuye la expansión torácica. Es la causa más frecuente de dolor torácico en EA.</div>
+</div></details>
+
+<details class="qa"><summary>24. Rx artropatía psoriásica — EXCEPTO</summary>
+<div class="qa-body">
+<p>Son datos radiológicos característicos de la artropatía psoriásica todos, EXCEPTO:</p>
+<ol type="a">
+<li>Reabsorción de falanges distales</li>
+<li><strong>Presencia de osteoporosis yuxta-articular</strong></li>
+<li>Tumefacción fusiforme de partes blandas</li>
+<li>Imagen característica en "lápiz en copa"</li>
+<li>Proliferación ósea</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La APs cursa con <em>proliferación ósea</em> (no osteopenia). La osteopenia yuxta-articular es de AR.</div>
+</div></details>
+
+<details class="qa"><summary>25. Espondiloartropatía + EII — NO cierto</summary>
+<div class="qa-body">
+<p>NO es cierto que la espondiloartropatía que acompaña a la EII:</p>
+<ol type="a">
+<li>Es similar a la EA</li>
+<li><strong>Es modificable con la colectomía</strong></li>
+<li>No se modifica con la colectomía</li>
+<li>Es independiente de la extensión de la EII</li>
+<li>Es independiente de la actividad de la EII</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (NO cierta — en relación a la afectación axial).</strong> La forma <em>axial</em> es independiente de la EII y NO se modifica con colectomía. La forma <em>periférica tipo 1</em> sí mejora con la colectomía y es paralela a la actividad intestinal.</div>
+</div></details>
+
+<details class="qa"><summary>26. Hombre joven con lumbalgia + dactilitis + FR (−) + PCR ↑↑</summary>
+<div class="qa-body">
+<p>Hombre de 32 años, informático, consulta por dolor lumbar y glúteo asimétrico, predominio nocturno, inflamación de dedos de los pies, FR (−) y PCR &gt; 200. ¿Actitud más correcta?</p>
+<ol type="a">
+<li>Por edad y sexo, probable gota → iniciar alopurinol y colchicina</li>
+<li><strong>Preguntar por AF de psoriasis y solicitar HLA-B27, probable espondiloartritis</strong></li>
+<li>El tipo de dolor en raquis orienta a hernia discal, derivar a neurocirugía</li>
+<li>Iniciar metotrexato que es eficaz para el dolor de raquis y la inflamación</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Lumbalgia inflamatoria + dactilitis (dedos en salchicha) + FR (−) + PCR muy alta = espondiloartritis (probable APs si AF psoriasis o axial pura). MTX no actúa en axial (d falso). La hernia discal cursa con dolor mecánico irradiado.</div>
+</div></details>
+
+<details class="qa"><summary>27. (Jun 2018/2020) Diana NO efectiva en EA</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes bloqueos de dianas terapéuticas NO son efectivas en la EA?</p>
+<ol type="a">
+<li><strong>Anti-IL-6</strong></li>
+<li>Anti-TNF-α</li>
+<li>Anti-IL-17</li>
+<li>Anti-IL-12/23 (Anti-CD20 en convocatoria Jun 2020)</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Anti-IL-6 NO funciona en EA (ensayos negativos con tocilizumab). Funcionan: anti-TNF, anti-IL-17 (secukinumab, ixekizumab), JAKi. <em>Anti-IL-12/23 (ustekinumab) tampoco funciona en EA axial pura</em> (sí en APs). Anti-CD20 (rituximab) tampoco.</div>
+</div></details>
+
+<details class="qa"><summary>28. (Jun 2019) Paciente con Lasègue → cola de caballo</summary>
+<div class="qa-body">
+<p>Paciente de 31 años, mecánico, con dolor lumbar irradiado a MMII izq hasta planta. Lasègue (+), fuerzas y reflejos normales. Se le prescribe analgesia. Una semana después: debilidad en pierna izq, anestesia en zona genital e interna de muslos, retención urinaria, reflejos exaltados. ¿Pensaría en?</p>
+<ol type="a">
+<li>Lumborradiculalgia por hernia discal</li>
+<li>Espondiloartritis</li>
+<li><strong>Síndrome de cola de caballo</strong></li>
+<li>Fractura vertebral</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> <em>Anestesia en silla de montar + retención urinaria + déficit progresivo</em> = cola de caballo. <strong>EMERGENCIA neuroquirúrgica</strong>: RMN urgente + descompresión &lt; 48 h. Causa: hernia discal masiva central, tumor o absceso.</div>
+</div></details>
+
+<details class="qa"><summary>29. (Jun 2019) Joven con lumbalgia inflamatoria + HLA-B27 (+)</summary>
+<div class="qa-body">
+<p>Paciente de 32 años con lumbalgia que empeora con reposo, alternante, rigidez matutina, talalgia derecha y HLA-B27 (+). Le solicitaría en primer lugar:</p>
+<ol type="a">
+<li>Radiografía ósea de pelvis</li>
+<li><strong>RMN de sacroilíacas</strong></li>
+<li>VSG y PCR</li>
+<li>Calprotectina en sangre</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Sospecha alta de espondiloartritis axial. La RMN de sacroilíacas detecta edema óseo activo precoz (antes que la Rx muestre erosiones/esclerosis) — permite diagnóstico de EA no radiográfica (criterios ASAS).</div>
+</div></details>
+
+<details class="qa"><summary>30. (Jun 2019/2020) Hombre con dactilitis + lesiones eritemo-escamosas</summary>
+<div class="qa-body">
+<p>Hombre de 48 años con dolor y tumefacción en carpo derecho, rodillas y 3er dedo en "salchicha". EF: lesiones eritemo-escamosas en codo y zona interglútea. VSG 56, ácido úrico 7,9 mg/dL. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Artritis reumatoide</li>
+<li>Gota</li>
+<li>Espondilitis anquilosante</li>
+<li><strong>Artritis psoriásica</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Dactilitis + asimetría + lesiones psoriasiformes en codo e interglúteo (placas de psoriasis típicas) = APs.</div>
+</div></details>
+
+<details class="qa"><summary>31. (Jun 2019) Respuesta FALSA sobre EpA</summary>
+<div class="qa-body">
+<p>Señale la respuesta falsa:</p>
+<ol type="a">
+<li>La EA es la más frecuente dentro de las espondiloartritis</li>
+<li><strong>La artritis reactiva es una enfermedad infecciosa</strong></li>
+<li>En la artritis psoriásica los anticuerpos anticitrulinados son negativos</li>
+<li>El HLA-B27 se asocia con las artritis enteropáticas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La ReA es <em>POST</em>-infecciosa, no infecciosa. El germen no está en la articulación; el mecanismo es inmune cruzado.</div>
+</div></details>
+
+<details class="qa"><summary>32. (Jun 2019) Citoquina más implicada en entesitis</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes citoquinas están más implicadas en la entesitis de las EpA?</p>
+<ol type="a">
+<li>TNF-α</li>
+<li><strong>IL-23</strong></li>
+<li>IL-6</li>
+<li>IL-1</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Eje IL-23/IL-17 es central en la patogenia de las EpA (especialmente entesitis). De ahí la eficacia de los anti-IL-17 (secukinumab, ixekizumab) y anti-IL-23 (risankizumab, guselkumab) en APs y axial.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 14: Artrosis =============== -->
+<section class="card" id="t14">
+<h2 class="section-title"><span class="num">14</span>Artrosis (OA)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Enfermedad articular más prevalente.</strong> Mujer &gt; hombre.</li>
+    <li>Patogenia: degeneración del cartílago + respuesta del hueso subcondral y sinovial.</li>
+    <li><strong>Síntoma cardinal: DOLOR MECÁNICO.</strong> Rigidez matutina &lt; 30 min.</li>
+    <li>Localización: <em>IFD (Heberden), IFP (Bouchard), trapeciometacarpiana (rizartrosis), rodillas, caderas, columna</em>.</li>
+    <li>Tratamiento: <strong>peso, ejercicio, paracetamol/AINE</strong> → PTC en avanzada.</li>
+    <li><span class="tag danger">NUNCA</span> usar MTX, biológicos o corticoides sistémicos en OA.</li>
+  </ul>
+</div>
+
+<h3>14.1 Bioquímica del cartílago artrósico</h3>
+<ul>
+  <li><strong>Inicialmente</strong>: aumento de proliferación y actividad de condrocitos.</li>
+  <li>↓ colágeno tipo II, ↓ proteoglicanos, ↓ hidratación.</li>
+  <li>Mediadores: IL-1, TNF, PGE2, NO, MMPs, agrecanasas.</li>
+  <li><strong>TIMPs INHIBEN las MMPs</strong> (protectores, no degradadores).</li>
+</ul>
+
+<h3>14.2 Causas secundarias</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Endocrino</span><span class="v">Acromegalia · Cushing · hiperparatiroidismo</span></div>
+  <div class="kv"><span class="k">Metabólico</span><span class="v">Hemocromatosis (MCF 2-3) · ocronosis (alcaptonuria)</span></div>
+  <div class="kv"><span class="k">Otros</span><span class="v">Traumatismos · displasias · condrocalcinosis</span></div>
+  <div class="kv"><span class="k">NO causa OA</span><span class="v"><strong>Gota</strong> (es microcristalina, no degenerativa)</span></div>
+</div>
+
+<h3>14.3 Signos radiológicos típicos</h3>
+<div class="compare">
+  <div>
+    <h4>✔ Sí presentes en OA</h4>
+    <ul>
+      <li>Pinzamiento articular <strong>asimétrico</strong></li>
+      <li>Esclerosis subcondral</li>
+      <li>Osteofitos</li>
+      <li>Geodas / quistes subcondrales</li>
+    </ul>
+  </div>
+  <div>
+    <h4>✘ NO presentes en OA</h4>
+    <ul>
+      <li>Osteopenia yuxta-articular (eso es AR)</li>
+      <li>Sindesmofitos (eso es EpA)</li>
+      <li>Erosiones marginales (AR)</li>
+    </ul>
+  </div>
+</div>
+<p>Analítica normal (VSG, PCR normales).</p>
+
+<h3>14.4 Tratamiento — escalera</h3>
+<ol>
+  <li><strong>NO farmacológico (1ª línea):</strong> educación · <em>pérdida de peso</em> · ejercicio aeróbico y de fortalecimiento · calzado · ortesis · bastón.</li>
+  <li>Paracetamol · AINE tópicos u orales (con IBP si riesgo GI).</li>
+  <li>Opioides débiles (tramadol) puntuales.</li>
+  <li>SYSADOAs (condroitín, glucosamina, diacereína, AH oral) → <strong>modificadores SINTOMÁTICOS de acción lenta, NO estructurales</strong>.</li>
+  <li>Infiltraciones intraarticulares (corticoides, ácido hialurónico).</li>
+  <li><strong>Cirugía:</strong> osteotomías · <em>artroplastia (prótesis)</em>.</li>
+</ol>
+
+<h3>14.5 Preguntas — Artrosis</h3>
+
+<details class="qa"><summary>1. (Jun 2019) Mujer con OA nodular de manos — FALSA</summary>
+<div class="qa-body">
+<p>Mujer de 50 años con dolor y deformidad en IFD de ambas manos. EF: dolor + nódulos de Heberden. Diagnosticada de artrosis nodular de manos. Señale la respuesta FALSA:</p>
+<ol type="a">
+<li>La artrosis de manos es más frecuente en mujeres</li>
+<li>La artrosis de IFD tiene una clara historia familiar</li>
+<li><strong>Se debe realizar el diagnóstico diferencial con la AR</strong></li>
+<li>La artritis psoriásica y la gota también pueden afectar a las IFD</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (la marcada por el banco como falsa).</strong> El diferencial con AR ES posible pero la AR <em>RESPETA IFD</em> característicamente; el diferencial real es con APs y gota (que sí afectan IFD).</div>
+</div></details>
+
+<details class="qa"><summary>2. Varón con dolor IFP de manos + Rx típica</summary>
+<div class="qa-body">
+<p>Varón de 63 años con cuadro de dolor en varias IFP de ambas manos. Rx: disminución interlínea, esclerosis subcondral y osteofitosis. Analítica normal. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Artritis gotosa poliarticular</li>
+<li><strong>Artrosis de Bouchard</strong></li>
+<li>Panarteritis nodosa</li>
+<li>Osteoartropatía hipertrófica</li>
+<li>AR de inicio tardío</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Nódulos de Bouchard = artrosis nodular de IFP. (Heberden = IFD.) Rx típica de OA: pinzamiento, esclerosis, osteofitos.</div>
+</div></details>
+
+<details class="qa"><summary>3. Causa del dolor mecánico artrósico</summary>
+<div class="qa-body">
+<p>La causa del dolor de tipo mecánico que aparece en el síndrome artrósico puede estar motivado por:</p>
+<ol type="a">
+<li>Pequeña sinovitis</li>
+<li>Microfracturas del hueso subcondral</li>
+<li>Distensión capsular y espasmo muscular</li>
+<li>Hiperpresión medular</li>
+<li><strong>Todas las respuestas anteriores son correctas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> El dolor en OA es multifactorial: sinovitis secundaria, microfracturas subcondrales, distensión capsular, espasmo muscular, hiperpresión medular intraósea, sensibilización periférica y central.</div>
+</div></details>
+
+<details class="qa"><summary>4. Alteración FALSA del cartílago artrósico</summary>
+<div class="qa-body">
+<p>Indique cuál de las siguientes alteraciones del cartílago artrósico es FALSA:</p>
+<ol type="a">
+<li><strong>Existe una proliferación aumentada de condrocitos</strong></li>
+<li>La actividad de los condrocitos está aumentada</li>
+<li>Descenso de la cantidad de colágeno</li>
+<li>Disminución de la cantidad de proteoglicanos</li>
+<li>Descenso de la hidratación del cartílago</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Esta es la marcada por el banco como falsa. En realidad, en fases <em>iniciales</em> SÍ hay aumento de proliferación y actividad de los condrocitos (intentan reparar); en fases avanzadas hay apoptosis. Las demás (↓ colágeno tipo II, ↓ proteoglicanos, ↓ hidratación) son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Parc 2018) Síntoma más frecuente en OA</summary>
+<div class="qa-body">
+<p>El síntoma más frecuente de la artrosis es:</p>
+<ol type="a">
+<li><strong>Dolor</strong></li>
+<li>Rigidez matutina mayor de 60 minutos</li>
+<li>Fiebre</li>
+<li>Ninguno de los anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Dolor mecánico. La rigidez en OA es leve (&lt; 30 min, frecuentemente al iniciar movimiento). La fiebre no es de OA.</div>
+</div></details>
+
+<details class="qa"><summary>6. Tratamiento de primera línea en OA</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes tratamientos debe emplearse en primer lugar en la artrosis?</p>
+<ol type="a">
+<li><strong>Programas de ejercicios, actividad física, pérdida de peso, analgésicos</strong></li>
+<li>Antiinflamatorios, analgésicos opioides</li>
+<li>Infiltraciones con corticoides y/o ácido hialurónico</li>
+<li>Artroscopia</li>
+<li>Prótesis articular</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Pilar del tratamiento: educación + ejercicio + peso + analgésicos según necesidad. Los demás son escalones posteriores.</div>
+</div></details>
+
+<details class="qa"><summary>7. Elementos en la degradación del cartílago — EXCEPTO</summary>
+<div class="qa-body">
+<p>En la degradación del cartílago articular participan los siguientes elementos EXCEPTO:</p>
+<ol type="a">
+<li>El óxido nítrico</li>
+<li><strong>TIMPs (tissue inhibitor of MMPs)</strong></li>
+<li>Prostaglandinas</li>
+<li>Agrecanasas</li>
+<li>Citoquinas proinflamatorias</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Las TIMPs INHIBEN a las metaloproteasas, por lo tanto son PROTECTORAS. En la OA hay desequilibrio MMPs/TIMPs a favor de las MMPs.</div>
+</div></details>
+
+<details class="qa"><summary>8. Modificadores estructurales en OA</summary>
+<div class="qa-body">
+<p>De los fármacos utilizados en OA, ¿cuáles modifican la estructura en el momento actual?</p>
+<ol type="a">
+<li>Condroitín-sulfato</li>
+<li>Diacereína</li>
+<li>Sulfato de glucosamina</li>
+<li>Todos son modificadores de la estructura</li>
+<li><strong>Ninguno es considerado modificador de la estructura</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Los SYSADOAs son "modificadores SINTOMÁTICOS de acción lenta", NO modifican la estructura. Algunos estudios sugieren ligero efecto estructural con condroitín y glucosamina, pero no concluyente. No hay fármacos DMOADs ("disease-modifying") con evidencia sólida.</div>
+</div></details>
+
+<details class="qa"><summary>9. Signo radiológico NO característico de OA</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes signos radiológicos NO es característico de la artrosis?</p>
+<ol type="a">
+<li>Esclerosis subcondral</li>
+<li>Geodas</li>
+<li>Osteofitos</li>
+<li><strong>Osteopenia</strong></li>
+<li>Disminución del espacio articular</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> En OA NO hay osteopenia yuxta-articular (eso es AR). Los signos típicos son pinzamiento, esclerosis subcondral, osteofitos, geodas.</div>
+</div></details>
+
+<details class="qa"><summary>10. NO es causa secundaria de OA</summary>
+<div class="qa-body">
+<p>¿Cuál NO es causa secundaria de artrosis?</p>
+<ol type="a">
+<li>Acromegalia</li>
+<li>Hemocromatosis</li>
+<li>Síndrome de Cushing</li>
+<li><strong>Gota</strong></li>
+<li>Ocronosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La gota es una artropatía microcristalina inflamatoria, NO degenerativa. Las demás producen OA secundaria por alteración del cartílago (hemocromatosis depósito de hierro, ocronosis depósito de ácido homogentísico, acromegalia hipertrofia, Cushing alteración metabólica).</div>
+</div></details>
+
+<details class="qa"><summary>11. Varón con OA generalizada de IFD</summary>
+<div class="qa-body">
+<p>Varón de 56 años con dolor y aumento de volumen en varias IFD de manos. Rx: pinzamiento, esclerosis, pequeña osteofitosis. Analítica habitual normal. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Artritis gotosa poliarticular</li>
+<li><strong>Artrosis de Heberden</strong></li>
+<li>Panarteritis nodosa</li>
+<li>Osteoartropatía hipertrófica</li>
+<li>AR de inicio tardío</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> IFD = Heberden (artrosis nodular). IFP = Bouchard. La AR respeta IFD.</div>
+</div></details>
+
+<details class="qa"><summary>12. SYSADOAs en OA</summary>
+<div class="qa-body">
+<p>De los fármacos utilizados en OA, ¿cuáles actúan como modificadores SINTOMÁTICOS de acción lenta (SYSADOAs)?</p>
+<ol type="a">
+<li>Condroitín-sulfato</li>
+<li>Diacereína</li>
+<li>Sulfato de glucosamina</li>
+<li>Ácido hialurónico</li>
+<li><strong>Todos son modificadores de la sintomatología</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Todos son SYSADOAs (alivio sintomático lento, sin demostrar modificación estructural).</div>
+</div></details>
+
+<details class="qa"><summary>13. Rx OA — EXCEPTO</summary>
+<div class="qa-body">
+<p>Son datos radiológicos característicos de la artrosis todos, EXCEPTO:</p>
+<ol type="a">
+<li>Disminución del espacio articular</li>
+<li>Esclerosis ósea subcondral</li>
+<li><strong>Parasindesmofitos</strong></li>
+<li>Ausencia de osteoporosis yuxta-articular</li>
+<li>Eventuales geodas subcondrales</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Sindesmofitos / parasindesmofitos son osificaciones de las espondiloartritis (axiales) — finos y verticales, unen vértebras. NO aparecen en OA.</div>
+</div></details>
+
+<details class="qa"><summary>14. Síntoma más frecuente de OA</summary>
+<div class="qa-body">
+<p>¿Cuál es el síntoma más frecuente de la artrosis?</p>
+<ol type="a">
+<li>Tumefacción articular</li>
+<li>Deformidad</li>
+<li>Aumento de tamaño de la articulación</li>
+<li>Rigidez</li>
+<li><strong>Dolor mecánico</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> El dolor mecánico (con el uso, mejora con reposo) es el síntoma cardinal.</div>
+</div></details>
+
+<details class="qa"><summary>15. Eritema en articulación — NO sugiere OA</summary>
+<div class="qa-body">
+<p>La presencia de eritema en una articulación sugiere los siguientes diagnósticos, EXCEPTO:</p>
+<ol type="a">
+<li>Gota</li>
+<li>Pseudogota</li>
+<li>Artritis séptica</li>
+<li>Artritis por microcristales</li>
+<li><strong>Artrosis</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> La OA no produce eritema (no es inflamatoria sino degenerativa). El eritema sugiere artritis aguda inflamatoria (microcristalina, séptica).</div>
+</div></details>
+
+<details class="qa"><summary>16. (Parc 2019) Tratamiento que NO usar en OA</summary>
+<div class="qa-body">
+<p>De los siguientes tratamientos, ¿cuál NO utilizaría en la artrosis?</p>
+<ol type="a">
+<li>Paracetamol</li>
+<li>Infiltración intraarticular</li>
+<li>Ejercicios</li>
+<li><strong>Metotrexato</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> MTX no tiene papel en OA (no es enfermedad autoinmune sino degenerativa). Tampoco corticoides sistémicos crónicos ni biológicos.</div>
+</div></details>
+
+<details class="qa"><summary>17. (Jun 2019) Signos NO típicos de OA</summary>
+<div class="qa-body">
+<p>Son signos radiológicos típicos de artrosis todos, EXCEPTO:</p>
+<ol type="a">
+<li>Esclerosis subcondral</li>
+<li>Osteofitos</li>
+<li><strong>Sindesmofitos</strong></li>
+<li>Quistes subcondrales</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Sindesmofitos son de las espondiloartritis (EA). En OA hay osteofitos.</div>
+</div></details>
+
+<details class="qa"><summary>18. (Parc 2020) OA de rodillas — inicio de tratamiento</summary>
+<div class="qa-body">
+<p>Paciente con artrosis de rodillas con dolor mecánico sin limitación de actividades diarias, iniciaríamos tratamiento con:</p>
+<ol type="a">
+<li>Metotrexato a dosis de 10 mg semanales</li>
+<li>Remitirlo al traumatólogo para valoración de tratamiento ortopédico</li>
+<li><strong>Información de la enfermedad, ejercicios y analgésicos si precisa</strong></li>
+<li>Corticoides sistémicos vía oral</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tratamiento inicial en OA leve-moderada: educación + ejercicio + analgésicos (paracetamol o AINE tópicos). MTX y corticoides sistémicos NO en OA. Cirugía solo en fases avanzadas refractarias.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 15: Microcristalinas =============== -->
+<section class="card" id="t15">
+<h2 class="section-title"><span class="num">15</span>Artropatías microcristalinas</h2>
+
+<h3>15.1 Gota</h3>
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Varón mediano + mujer postmenopáusica</strong> (estrógenos uricosúricos).</li>
+    <li>Asociada a <strong>síndrome metabólico</strong>.</li>
+    <li>Frecuencia <em>↑ con la edad</em>.</li>
+    <li><strong>90 % primaria</strong> (hipoexcreción renal en 80-90 %); &lt; 10 % secundaria.</li>
+    <li>En humanos <strong>NO existe uricasa</strong> (transformaría úrico en alantoína).</li>
+    <li>Crisis: <strong>podagra</strong> (1ª MTF) en 50-75 % como debut.</li>
+    <li>Diagnóstico: <strong>artrocentesis</strong> + cristales en luz polarizada.</li>
+  </ul>
+</div>
+
+<h4>Cristales de urato monosódico</h4>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🔬</span>En microscopio de luz polarizada con compensador rojo</div>
+  <ul style="margin:6px 0">
+    <li><strong>Forma:</strong> agujas largas</li>
+    <li><strong>Birrefringencia NEGATIVA fuerte</strong></li>
+    <li><span class="tag warn">AMARILLO</span> cuando paralelo al eje del compensador</li>
+    <li><span class="tag">AZUL</span> cuando perpendicular</li>
+    <li>Intracelulares en PMN durante la crisis</li>
+  </ul>
+</div>
+
+<h4>Fármacos que inhiben secreción tubular de úrico (→ hiperuricemia)</h4>
+<p>AAS dosis bajas · <strong>etambutol</strong> · etanol · pirazinamida · diuréticos (furosemida, tiazidas) · ciclosporina · plomo.</p>
+
+<h4>Tratamiento de la gota</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Fase</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Crisis aguda</strong></td><td>AINE a dosis plenas + <strong>colchicina (más eficaz si precoz, &lt; 24 h)</strong> · corticoides orales o intraarticulares como alternativa · anti-IL-1 (anakinra, canakinumab) si refractaria. <span class="tag danger">NO iniciar hipouricemiantes durante la crisis.</span> Si ya los tomaba, NO suspenderlos. <strong>AAS contraindicado.</strong></td></tr>
+<tr><td>Profilaxis</td><td>Colchicina 0,5-1 mg/día (o AINE) durante los primeros 6 meses al iniciar hipouricemiante</td></tr>
+<tr><td><strong>Hipouricemiantes</strong> (objetivo &lt; 6 mg/dL, &lt; 5 si tofos)</td><td>
+<ul style="margin:0">
+<li><strong>Alopurinol</strong> (IXO; metabolito activo = oxipurinol) — 1ª línea</li>
+<li><strong>Febuxostat</strong> (IXO potente, formas oxidada y reducida) — 2ª línea o IR moderada</li>
+<li>Uricosúricos: <strong>probenecid, benzbromarona</strong>, lesinurad</li>
+<li>Pegloticasa (uricasa recombinante) — refractaria grave</li>
+</ul>
+</td></tr>
+</tbody></table></div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">⚠</span>Atención</div>
+  <p style="margin:0">El úrico sérico <strong>puede ser normal en hasta el 30 % durante la crisis</strong>. <em>Medirlo a las 2 semanas tras la resolución</em>. Por tanto "determinar úrico en las primeras 2 semanas tras la crisis" = <span class="tag danger">FALSO</span>.</p>
+</div>
+
+<h3>15.2 Condrocalcinosis (CCA) / Pirofosfato cálcico</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🔬</span>Cristales de pirofosfato cálcico (CPPD)</div>
+  <ul style="margin:6px 0">
+    <li><strong>Forma:</strong> rectangulares / romboidales</li>
+    <li><strong>Birrefringencia POSITIVA débil</strong></li>
+    <li><span class="tag">AZUL</span> cuando paralelo al eje</li>
+    <li><span class="tag warn">AMARILLO</span> cuando perpendicular</li>
+    <li>Se depositan en el <strong>medio del espesor del cartílago</strong> (no en la superficie)</li>
+  </ul>
+</div>
+
+<h4>Calcificaciones radiológicas típicas</h4>
+<ul>
+  <li><strong>Meniscos</strong> (la más frecuente)</li>
+  <li>Ligamento triangular del carpo</li>
+  <li>Sínfisis púbica</li>
+  <li>Cápsulas articulares, discos</li>
+</ul>
+
+<h4>Formas clínicas</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Asintomática</span><span class="v">La más frecuente (hallazgo radiológico)</span></div>
+  <div class="kv"><span class="k">Pseudogota</span><span class="v">Monoartritis aguda (rodilla la más típica)</span></div>
+  <div class="kv"><span class="k">Pseudo-OA</span><span class="v">Con brotes inflamatorios</span></div>
+  <div class="kv"><span class="k">Pseudo-AR</span><span class="v">Poliarticular crónica</span></div>
+  <div class="kv"><span class="k">Pseudoneuropática</span><span class="v">Artropatía destructiva</span></div>
+</div>
+
+<h4>Diagnóstico etiológico en jóvenes</h4>
+<p>Buscar: <strong>hemocromatosis</strong> (ferritina, IST) · <strong>hiperparatiroidismo</strong> (calcemia, P, PTH) · <strong>hipomagnesemia</strong> · <strong>hipofosfatasia</strong> (FA baja) · <strong>hipotiroidismo</strong>. <span class="tag danger">NO Cushing</span> (cortisol y ACTH no aportan).</p>
+
+<h3>15.3 Hidroxiapatita</h3>
+<p>Cristales pequeños no birrefringentes (tinción rojo de alizarina). <strong>"Hombro de Milwaukee"</strong>: mujer mayor con artropatía rápidamente destructiva del hombro + calcificaciones peri-articulares.</p>
+
+<h3>15.4 Preguntas — Microcristalinas</h3>
+
+<details class="qa"><summary>1. Varón con OA + IR + episodios agudos en IFD</summary>
+<div class="qa-body">
+<p>Varón de 57/75 años con OA primaria generalizada e insuficiencia renal leve/moderada acude por episodios agudos de dolor e inflamación en IFD de manos. El diagnóstico más probable es:</p>
+<ol type="a">
+<li>Artrosis erosiva de manos</li>
+<li>Artrosis nodular de Heberden</li>
+<li>AR senil</li>
+<li><strong>Gota</strong></li>
+<li>Artropatía microcristalina por hidroxiapatita</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> En mujeres ancianas con OA nodular + IR (que retiene urato) + brotes agudos sobre IFD ya artrósicas → gota. Frecuente en mujeres en tratamiento con diuréticos.</div>
+</div></details>
+
+<details class="qa"><summary>2. Forma de presentación más frecuente de la CCA</summary>
+<div class="qa-body">
+<p>La forma clínica de presentación más frecuente de la artropatía por depósito de pirofosfato cálcico es como:</p>
+<ol type="a">
+<li>Pseudogota</li>
+<li>Pseudopoliartritis reumatoide</li>
+<li><strong>Forma artrósica</strong></li>
+<li>Forma pseudoneuropática</li>
+<li>Forma latente</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La forma pseudo-OA (artrosis con brotes inflamatorios) es la presentación sintomática más frecuente. La latente (asintomática, hallazgo radiológico) es la más prevalente globalmente.</div>
+</div></details>
+
+<details class="qa"><summary>3. Crisis gotosa aguda — EXCEPTO</summary>
+<div class="qa-body">
+<p>Ante un caso de artritis gotosa aguda, su actitud terapéutica está basada en las siguientes afirmaciones, EXCEPTO:</p>
+<ol type="a">
+<li>La colchicina es más eficaz si se administra precozmente</li>
+<li>Una alternativa a la colchicina y los AINE es emplear glucocorticoides a dosis bajas</li>
+<li><strong>Si existe hiperuricemia asociada debe iniciarse tratamiento con alopurinol sin esperar a la resolución del ataque agudo</strong></li>
+<li>Los AINE deben mantenerse hasta 2-3 días después de remitir el ataque</li>
+<li>Se evitará el empleo de AAS por su efecto hiperuricemiante</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> <em>NUNCA iniciar hipouricemiantes durante la crisis aguda</em> (paradoja, pueden prolongarla por movilización de cristales). Si ya los tomaba, NO suspenderlos. Las demás son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>4. Erosiones intra y extraarticulares con halo escleroso</summary>
+<div class="qa-body">
+<p>Varón de 50 años con Rx bilateral de manos: erosiones intra y extraarticulares bien delimitadas con halo escleroso y reborde afilado en la 2ª MCF derecha. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Artritis reumatoide de inicio reciente</li>
+<li>Artropatía psoriásica</li>
+<li><strong>Artropatía gotosa</strong></li>
+<li>Síndrome de Reiter</li>
+<li>Artropatía de Jaccoud</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Erosiones <em>extraarticulares</em> con halo escleroso y reborde "saltado" (overhanging edge) son típicas de la gota tofácea crónica.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2017) Tratamiento de la gota</summary>
+<div class="qa-body">
+<p>En el tratamiento de la gota:</p>
+<ol type="a">
+<li><strong>La colchicina se utiliza en la fase aguda</strong></li>
+<li>Denosumab se utiliza en la prevención de recurrencias</li>
+<li>Los corticoides están contraindicados</li>
+<li>El alopurinol junto con la colchicina está indicado en el tratamiento de la crisis aguda</li>
+<li>El febuxostat es un inhibidor de la xantino-reductasa</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Colchicina en fase aguda (precoz, &lt; 24 h). Denosumab es para osteoporosis (no gota). Corticoides SÍ se usan en crisis aguda (alternativa a AINE/colchicina). NO iniciar alopurinol en crisis aguda. Febuxostat inhibe la xantino-OXIDASA (no reductasa).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2019) Paciente postoperatorio con podagra previa</summary>
+<div class="qa-body">
+<p>Paciente de 75 años con episodios transitorios de dolor en 1er dedo del pie derecho que, en su 2º día postoperatorio por colecistitis no complicada, desarrolla dolor y signos inflamatorios en rodillas y tobillo derecho. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Polimialgia reumática</li>
+<li><strong>Artritis microcristalina</strong></li>
+<li>Artritis séptica</li>
+<li>AR de debut</li>
+<li>Agudización de artrosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Antecedente de podagra (gota) + postoperatorio (factor desencadenante clásico: deshidratación, fluidos, cambios en la uricemia) → recidiva gotosa. Confirmar siempre con artrocentesis.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2016) Obligatorio en este paciente</summary>
+<div class="qa-body">
+<p>En el paciente anterior (75 a. con podagra previa y monoartritis postoperatoria), es OBLIGATORIO realizar:</p>
+<ol type="a">
+<li><strong>Artrocentesis y estudio de líquido sinovial (microcristales y gérmenes)</strong></li>
+<li>Determinación de FR y anti-CCP</li>
+<li>Niveles de calcio</li>
+<li>Estudio de coagulación</li>
+<li>ANA</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Ante toda monoartritis aguda: <em>artrocentesis es obligatoria</em> (descartar séptica + identificar cristales). NUNCA asumir gota sin confirmar.</div>
+</div></details>
+
+<details class="qa"><summary>8. Causa muy rara de gota secundaria</summary>
+<div class="qa-body">
+<p>Indique cuál de las afecciones reseñadas sería muy raro que determinaran un cuadro de gota secundaria:</p>
+<ol type="a">
+<li>Síndromes mieloproliferativos</li>
+<li><strong>Síndrome de Cushing</strong></li>
+<li>Síndrome de Lesch-Nyhan</li>
+<li>Enfermedad de Paget poliostótica</li>
+<li>Hiperparatiroidismo</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cushing NO es causa habitual de gota. Las verdaderas son: síndromes mieloproliferativos (alta producción de purinas), Lesch-Nyhan (déficit de HGPRT), Paget poliostótica (alto remodelado), hiperparatiroidismo.</div>
+</div></details>
+
+<details class="qa"><summary>9. Calcificaciones por pirofosfato cálcico</summary>
+<div class="qa-body">
+<p>Las típicas calcificaciones debidas a la precipitación de cristales de pirofosfato cálcico se localizan principalmente en:</p>
+<ol type="a">
+<li>Sínfisis púbica</li>
+<li>Ligamento triangular del carpo</li>
+<li>Meniscos</li>
+<li><strong>Las tres respuestas anteriores son correctas</strong></li>
+<li>A nivel del calcáneo</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Localizaciones clásicas: meniscos (la más típica radiológicamente), ligamento triangular del carpo, sínfisis púbica, cápsulas, discos.</div>
+</div></details>
+
+<details class="qa"><summary>10. (Jun 2017) Sobre la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li>La colchicina reduce de forma marcada la concentración de ácido úrico en suero</li>
+<li><strong>Los microcristales examinados en el líquido sinovial en las crisis agudas con luz polarizada y compensador rojo son azules cuando están alineados de forma perpendicular al eje del compensador</strong></li>
+<li>La benzbromarona es un potente inhibidor de la xantina oxidasa</li>
+<li>El febuxostat es un potente uricosúrico</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Urato monosódico: birrefringencia negativa → <em>AMARILLO paralelo / AZUL perpendicular</em> al eje. Colchicina NO baja el úrico. Benzbromarona es <em>uricosúrico</em> (no IXO). Febuxostat es <em>IXO potente</em> (no uricosúrico).</div>
+</div></details>
+
+<details class="qa"><summary>11. (Jun 2017) En la condrocalcinosis — CIERTO</summary>
+<div class="qa-body">
+<p>En la condrocalcinosis articular es cierto que:</p>
+<ol type="a">
+<li>La calcemia, fosfatemia y PTH no aportan al diagnóstico etiológico</li>
+<li>Cortisol y ACTH son los que más aportan en el diagnóstico etiológico</li>
+<li>Los cristales son fuertemente birrefringentes</li>
+<li><strong>El naproxeno puede ser útil en el tratamiento de los episodios agudos</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> AINE (naproxeno), colchicina o corticoides son útiles en pseudogota. Los cristales son <em>débilmente</em> birrefringentes (positivos). Calcemia/P/PTH SÍ son importantes (descartar hiperparatiroidismo). Cortisol/ACTH no son útiles (Cushing no se asocia a CCA).</div>
+</div></details>
+
+<details class="qa"><summary>12. (Jun 2017) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li>Al inicio de la enfermedad las crisis agudas son habitualmente oligoarticulares</li>
+<li><strong>Desde el punto de vista epidemiológico hay un incremento de su frecuencia con la edad</strong></li>
+<li>Los cristales que se depositan en las articulaciones son débilmente birrefringentes</li>
+<li>Para el diagnóstico, la determinación de ácido úrico debe realizarse de forma inmediata, en las primeras dos semanas tras la crisis aguda</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Las crisis iniciales suelen ser <em>monoarticulares</em> (podagra). Los cristales son <em>fuertemente</em> birrefringentes (negativos). El ácido úrico debe medirse <em>tras la resolución</em> (en crisis puede ser normal).</div>
+</div></details>
+
+<details class="qa"><summary>13. (Jun 2016) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li>Los cristales que se depositan en las articulaciones son de ácido úrico</li>
+<li>Al inicio de la enfermedad las crisis agudas son habitualmente oligoarticulares</li>
+<li>Desde el punto de vista epidemiológico hay un descenso de su frecuencia con la edad</li>
+<li><strong>Los cristales que se depositan en las articulaciones son fuertemente birrefringentes</strong></li>
+<li>Todas las respuestas anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Los cristales son de <em>urato monosódico</em> (no ácido úrico libre), fuertemente birrefringentes negativos. Crisis iniciales monoarticulares. Frecuencia AUMENTA con la edad.</div>
+</div></details>
+
+<details class="qa"><summary>14. (Jun 2016) Condrocalcinosis — estudio que MENOS aporta</summary>
+<div class="qa-body">
+<p>En la condrocalcinosis articular, el estudio analítico que MENOS aporta en el diagnóstico etiológico es:</p>
+<ol type="a">
+<li>Calcemia, fosfatemia</li>
+<li><strong>Cortisol, ACTH</strong></li>
+<li>TSH, PTH</li>
+<li>Magnesio, hierro, ferritina</li>
+<li>Fosfatasa alcalina</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cushing no causa CCA. SÍ buscar: hiperparatiroidismo (Ca/P/PTH), hipotiroidismo (TSH), hipomagnesemia (Mg), hemocromatosis (hierro/ferritina), hipofosfatasia (FA baja).</div>
+</div></details>
+
+<details class="qa"><summary>15. (Jun 2016) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li>El ácido úrico debe medirse inmediatamente en las primeras 2 semanas tras la crisis</li>
+<li>Es más frecuente en mujeres que en varones, sobre todo postmenopausia</li>
+<li>La benzbromarona es un potente inhibidor de la xantino oxidasa</li>
+<li><strong>Los microcristales en líquido sinovial con luz polarizada y compensador rojo son amarillos cuando están alineados paralelos al eje</strong></li>
+<li>El febuxostat es un fármaco fundamentalmente uricosúrico</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Urato monosódico: AMARILLO paralelo (birrefringencia negativa fuerte). Más frecuente en <em>varones</em>; en mujeres aparece tras menopausia. Benzbromarona = uricosúrico. Febuxostat = IXO.</div>
+</div></details>
+
+<details class="qa"><summary>16. CPPD — localización más frecuente</summary>
+<div class="qa-body">
+<p>El depósito de pirofosfato cálcico produce calcificaciones que se observan en. Señale la localización más frecuente:</p>
+<ol type="a">
+<li><strong>Ligamento triangular del carpo</strong></li>
+<li>Discos intervertebrales</li>
+<li>Tendón de Aquiles</li>
+<li>Cápsula articular</li>
+<li>Acetábulo de la cadera</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> En el banco UGR la respuesta marcada es ligamento triangular del carpo (muy típica en Rx de muñeca). Meniscos es también de las más frecuentes (pero no está entre las opciones).</div>
+</div></details>
+
+<details class="qa"><summary>17. Inhibidores de la secreción tubular de ácido úrico</summary>
+<div class="qa-body">
+<p>Indicar las sustancias que inhiben la secreción tubular de ácido úrico:</p>
+<ol type="a">
+<li>Salicilatos</li>
+<li>Etambutol</li>
+<li>Etanol</li>
+<li>Furosemida</li>
+<li><strong>Todo lo anterior</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Todos producen hiperuricemia por inhibir la secreción tubular: AAS bajas dosis, etambutol, etanol, diuréticos (tiazidas, furosemida), pirazinamida, ciclosporina, plomo.</div>
+</div></details>
+
+<details class="qa"><summary>18. Mujer con artropatía rápidamente destructiva de hombro</summary>
+<div class="qa-body">
+<p>Mujer de 64 años con artropatía rápidamente destructiva de hombro derecho y calcificaciones de partes blandas a este nivel. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Urato monosódico</li>
+<li>Pirofosfato cálcico</li>
+<li><strong>Hidroxiapatita</strong></li>
+<li>Oxalato cálcico</li>
+<li>Ocronosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> "Hombro de Milwaukee": artropatía destructiva del hombro en mujer mayor con depósito de hidroxiapatita. Cristales pequeños, no birrefringentes, tinción con rojo de alizarina.</div>
+</div></details>
+
+<details class="qa"><summary>19. Artritis gotosa — afirmación FALSA</summary>
+<div class="qa-body">
+<p>En cuanto a la artritis gotosa, indicar la afirmación FALSA:</p>
+<ol type="a">
+<li><strong>El alcohol alivia el dolor</strong></li>
+<li>Aumentan el dolor los alimentos ricos en purinas</li>
+<li>50-75 % de los casos desarrollan podagra</li>
+<li>Son trastornos asociados a la obesidad, dislipemia y arteriosclerosis</li>
+<li>La afectación renal puede expresarse como litiasis renal</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El alcohol EMPEORA la gota (cerveza, licores especialmente; el vino menos). Aumenta la producción y disminuye la excreción de úrico. Las demás son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>20. NO asociada a condrocalcinosis</summary>
+<div class="qa-body">
+<p>Todas menos una de las siguientes situaciones patológicas pueden asociarse a CCA:</p>
+<ol type="a">
+<li><strong>Hipermagnesemia</strong></li>
+<li>Hipomagnesemia</li>
+<li>Hiperuricemia</li>
+<li>Hiperparatiroidismo</li>
+<li>Hemocromatosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Es la <em>HIPOmagnesemia</em> la que se asocia a CCA. Las demás (hiperuricemia, hiperparatiroidismo, hemocromatosis) son causas reconocidas.</div>
+</div></details>
+
+<details class="qa"><summary>21. Gota — EXCEPTO</summary>
+<div class="qa-body">
+<p>Respecto a la gota, lo que sigue es cierto EXCEPTO:</p>
+<ol type="a">
+<li>Es una enfermedad metabólica que afecta a varones de edad media</li>
+<li><strong>El 90 % de los casos es de causa secundaria</strong></li>
+<li>En su patogenia el ácido úrico es el producto terminal de las purinas</li>
+<li>El ácido úrico se excreta por el riñón</li>
+<li>De las formas de hiperuricemia asintomática el 5 % desarrolla gota</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> El 90 % de la gota es <em>primaria</em> (hipoexcreción renal en 80-90 %). Solo &lt; 10 % es secundaria.</div>
+</div></details>
+
+<details class="qa"><summary>22. Fármaco SIN acción hipouricemiante</summary>
+<div class="qa-body">
+<p>Señale cuál de los fármacos reseñados carece de acción hipouricemiante:</p>
+<ol type="a">
+<li>Alopurinol</li>
+<li><strong>Denosumab</strong></li>
+<li>Febuxostat</li>
+<li>Benzbromarona</li>
+<li>Rasburicasa</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Denosumab es anti-RANKL antiosteoporótico, no hipouricemiante. Los demás: alopurinol/febuxostat (IXO), benzbromarona (uricosúrico), rasburicasa (uricasa recombinante, lisis tumoral).</div>
+</div></details>
+
+<details class="qa"><summary>23. Hiperuricémico con alopurinol que tiene crisis aguda</summary>
+<div class="qa-body">
+<p>Paciente hiperuricémico con 100 mg de alopurinol/día acude por dolor y signos inflamatorios en rodilla. Artrocentesis: cristales intracelulares con birrefringencia negativa. ¿Actitud terapéutica?</p>
+<ol type="a">
+<li><strong>(Respuesta según banco UGR: a) Suspender alopurinol e iniciar tratamiento con colchicina</strong></li>
+<li>Suspender alopurinol y comenzar con AINE</li>
+<li>Añadir un AINE hasta que la crisis remita (RESPUESTA CORRECTA EN LA PRÁCTICA ACTUAL)</li>
+<li>Aumentar la dosis de alopurinol a 300 mg/día</li>
+<li>Sustituir el alopurinol por un uricosúrico</li>
+</ol>
+<div class="answer"><strong>Banco: a.</strong> En realidad la respuesta clínica correcta es <strong>c</strong>: añadir AINE (o colchicina) y NO SUSPENDER el alopurinol durante la crisis si ya lo tomaba (suspenderlo podría prolongar la crisis por cambio brusco de la uricemia). Las guías actuales coinciden en mantener el alopurinol. Aprende ambas posturas — para el examen UGR la respuesta marcada es a.</div>
+</div></details>
+
+<details class="qa"><summary>24. (Jun 2018) Sobre la gota — CIERTO</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>La gota es una afección inflamatoria por acúmulo de cristales de ácido úrico en articulaciones y tejidos</li>
+<li>La prevalencia de la gota aumenta con la edad</li>
+<li>En el ser humano la uricasa metaboliza el paso de hipoxantina a xantina</li>
+<li><strong>Todas las respuestas anteriores son correctas</strong> (en el banco; con matiz en c)</li>
+</ol>
+<div class="answer"><strong>Respuesta del banco: d.</strong> Las opciones a y b son ciertas. La opción c es <em>falsa</em> (en humanos NO existe uricasa; la xantina oxidasa transforma hipoxantina → xantina → ácido úrico). Por lo tanto, en rigor la respuesta debería ser "a y b son correctas", pero el banco marca d.</div>
+</div></details>
+
+<details class="qa"><summary>25. (Jun 2018) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota:</p>
+<ol type="a">
+<li>Los microcristales se depositan principalmente en el interior del cartílago articular</li>
+<li>La benzbromarona es potente inhibidor de la xantino-oxidasa</li>
+<li><strong>El febuxostat es un inhibidor de la xantino-oxidasa</strong></li>
+<li>Las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Febuxostat = IXO. Los cristales se depositan en la <em>superficie</em> del cartílago y en el líquido sinovial (no en el espesor — eso es CPPD). Benzbromarona = uricosúrico.</div>
+</div></details>
+
+<details class="qa"><summary>26. (Jun 2018) Microcristales azules paralelos al eje</summary>
+<div class="qa-body">
+<p>Paciente de 58 a. con monoartritis de rodilla derecha. Artrocentesis: cristales de color azul cuando están alineados de forma paralela al eje del compensador rojo. ¿De qué cristales se trata?</p>
+<ol type="a">
+<li><strong>Pirofosfato cálcico</strong></li>
+<li>Hidroxiapatita</li>
+<li>Urato monosódico</li>
+<li>Ninguno</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> AZUL paralelo = birrefringencia POSITIVA débil = pirofosfato cálcico (CPPD). El urato monosódico es AMARILLO paralelo (negativa fuerte).</div>
+</div></details>
+
+<details class="qa"><summary>27. (Jun 2018) Condrocalcinosis — CIERTO</summary>
+<div class="qa-body">
+<p>En la condrocalcinosis articular (CCA):</p>
+<ol type="a">
+<li>En los brotes el líquido sinovial suele ser de tipo mecánico</li>
+<li><strong>La hipofosfatasia se asocia con la CCA</strong></li>
+<li>Los cristales son fuertemente birrefringentes</li>
+<li>La calcemia, fosfatemia y PTH no aportan al diagnóstico etiológico</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Hipofosfatasia (déficit de FA, mineralización defectuosa) se asocia a CCA. Líquido en brotes es <em>inflamatorio</em>. Cristales <em>débilmente</em> birrefringentes (positivos). Ca/P/PTH SÍ aportan (hiperparatiroidismo).</div>
+</div></details>
+
+<details class="qa"><summary>28. (Jun 2018) Heberden de manos — correcta</summary>
+<div class="qa-body">
+<p>Mujer con artrosis nodular de manos (Heberden). Señale la respuesta correcta:</p>
+<ol type="a">
+<li>La artrosis de manos es más frecuente en hombres</li>
+<li>El tratamiento es metotrexato</li>
+<li><strong>La artritis psoriásica y la gota también pueden afectar a las IFD</strong></li>
+<li>La artrosis de IFD está producida por una sinovitis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La AR respeta IFD, pero APs (forma clásica) y gota pueden afectar IFD → diagnóstico diferencial importante. OA es más frecuente en mujeres. NO se trata con MTX. No es por sinovitis (es degenerativa).</div>
+</div></details>
+
+<details class="qa"><summary>29. (Parc 2019) CIERTO — gota/Paget/CCA</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>En la CCA los cristales de pirofosfato se depositan en la superficie del cartílago</li>
+<li><strong>La fosfatasa alcalina es un buen marcador para controlar la actividad de la enfermedad de Paget</strong></li>
+<li>Denosumab es antiosteoporótico dirigido frente a la osteoprotegerina</li>
+<li>Todas las respuestas anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> FA es el marcador clave de actividad y respuesta en Paget. CCA: cristales en el <em>espesor</em> del cartílago (no superficie). Denosumab actúa contra <em>RANK-L</em> (no osteoprotegerina, que es el antagonista natural).</div>
+</div></details>
+
+<details class="qa"><summary>30. (Parc 2019) Oxipurinol y alopurinol</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>Oxipurinol es el metabolito activo del alopurinol</strong></li>
+<li>La uricasa en el ser humano transforma la hipoxantina en xantina</li>
+<li>Lesinurad es un potente inhibidor de la xantino oxidasa</li>
+<li>Las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Alopurinol → metabolito activo OXIPURINOL (vida media larga). En humanos NO hay uricasa. Lesinurad es <em>uricosúrico</em> (no IXO).</div>
+</div></details>
+
+<details class="qa"><summary>31. (Jun 2019) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li>Los microcristales en líquido sinovial son amarillos cuando perpendiculares al eje del compensador</li>
+<li><strong>Los microcristales que se depositan en las articulaciones son de urato monosódico</strong></li>
+<li>El ácido úrico debe medirse de forma inmediata en las primeras 2 semanas tras la crisis aguda</li>
+<li>Las respuestas a y b son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cristales de urato monosódico, amarillos PARALELOS (no perpendiculares). El úrico se mide tras la resolución, no inmediatamente.</div>
+</div></details>
+
+<details class="qa"><summary>32. (Jun 2019) CIERTO sobre Paget/denosumab/CCA</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>En la CCA los cristales se depositan en la superficie del cartílago articular</li>
+<li>La fosfatasa alcalina es un buen marcador para controlar Paget</li>
+<li><strong>Denosumab es antiosteoporótico dirigido frente al RANK-L</strong></li>
+<li>Todas las respuestas anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Denosumab = anticuerpo anti-RANKL (bloquea diferenciación osteoclástica). FA es buen marcador de Paget (la opción b también es cierta).</div>
+</div></details>
+
+<details class="qa"><summary>33. (Jun 2019) Benzbromarona, uricasa, febuxostat</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>Benzbromarona es un fármaco uricosúrico</li>
+<li>La uricasa en el ser humano transforma la xantina en alantoína</li>
+<li>Febuxostat inhibe las formas oxidada y reducida de la xantina oxidasa</li>
+<li><strong>Las respuestas a y c son correctas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Benzbromarona = uricosúrico. Febuxostat inhibe ambas formas de XO (más potente que alopurinol). En humanos NO hay uricasa.</div>
+</div></details>
+
+<details class="qa"><summary>34. (Parc 2020) CCA — CIERTO</summary>
+<div class="qa-body">
+<p>En la CCA es cierto que:</p>
+<ol type="a">
+<li>Cortisol y ACTH son los estudios analíticos que más aportan</li>
+<li>Los cristales de urato monosódico se depositan en el espesor del cartílago</li>
+<li><strong>Las determinaciones de calcemia, fosfatemia y PTH son importantes en el diagnóstico etiológico</strong></li>
+<li>Los cristales son fuertemente birrefringentes</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Ca/P/PTH son clave (descartar hiperparatiroidismo). En CCA se depositan cristales de <em>pirofosfato</em> (no urato). Cortisol/ACTH no aportan. Cristales <em>débilmente</em> birrefringentes.</div>
+</div></details>
+
+<details class="qa"><summary>35. (Parc 2020) En la gota — CIERTO</summary>
+<div class="qa-body">
+<p>En la gota es cierto que:</p>
+<ol type="a">
+<li><strong>Febuxostat es un inhibidor de la xantino oxidasa</strong></li>
+<li>Los microcristales con luz polarizada son débilmente birrefringentes</li>
+<li>El ácido úrico debe medirse de forma inmediata en las primeras 2 semanas tras la crisis</li>
+<li>La benzbromarona es un potente inhibidor de la forma reducida de la xantina oxidasa</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Febuxostat = IXO. Los cristales de urato son <em>fuertemente</em> birrefringentes (negativos). Benzbromarona = uricosúrico (no IXO). El úrico se mide tras la resolución.</div>
+</div></details>
+
+<details class="qa"><summary>36. (Parc 2020) CIERTO general</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>La gota es más frecuente en la mujer premenopáusica que en la posmenopáusica</li>
+<li>En la gota los microcristales de pirofosfato cálcico son fuertemente birrefringentes</li>
+<li>La inflamación de 3 articulaciones la calificamos como poliartritis</li>
+<li><strong>El dolor de tipo ritmo mecánico suele mejorar con el reposo</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La gota es más frecuente en mujeres POSTmenopáusicas (los estrógenos son uricosúricos). En gota los cristales son de URATO (no pirofosfato). Poliartritis = ≥ 5 articulaciones (3 articulaciones = oligoartritis).</div>
+</div></details>
+
+<details class="qa"><summary>37. (Parc 2020) Lesinurad, oxipurinol, uricasa, CCA</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>Lesinurad es un uricosúrico</strong></li>
+<li>Oxipurinol es el metabolito activo del febuxostat</li>
+<li>La uricasa en el ser humano transforma la hipoxantina en xantina</li>
+<li>En la CCA los cristales de pirofosfato cálcico se depositan en la superficie del cartílago articular</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Lesinurad = uricosúrico (suele combinarse con IXO). Oxipurinol es metabolito del <em>alopurinol</em> (no del febuxostat). En humanos NO hay uricasa. CPPD se deposita en el <em>espesor</em> del cartílago.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 16: Autoinflamatorios =============== -->
+<section class="card" id="t16">
+<h2 class="section-title"><span class="num">16</span>Síndromes autoinflamatorios (SAI)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Enfermedades por <strong>disregulación de la inmunidad INNATA</strong> (las EAS son adaptativas).</li>
+    <li>Hiperactivación del <strong>inflamasoma</strong> → liberación de IL-1β e IL-18.</li>
+    <li><strong>NO autoanticuerpos · NO asociación a HLA-II · NO predominio femenino claro.</strong></li>
+    <li><strong>Citoquina clave: IL-1β</strong> (no la IL-17).</li>
+    <li>Cursan con <em>brotes febriles recurrentes</em> · complicación temible: <strong>amiloidosis AA</strong>.</li>
+  </ul>
+</div>
+
+<h3>16.1 Entidades monogénicas principales</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Entidad</th><th>Gen / herencia</th><th>Clínica</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>FMF</strong> (Fiebre Mediterránea Familiar)</td><td><strong>MEFV (pirina) · AR</strong></td><td>Crisis de 1-3 días · fiebre + <em>peritonitis</em> + sinovitis + eritema erisipeloide · mediterráneos</td><td><strong>COLCHICINA</strong> diaria (previene crisis y amiloidosis) · anakinra/canakinumab si refractario</td></tr>
+<tr><td><strong>TRAPS</strong></td><td>TNFRSF1A · <strong>AD</strong></td><td>Crisis prolongadas (1-3 sem) · fiebre + dolor abdominal + mialgias migratorias + eritema centrífugo + edema periorbitario</td><td>Corticoides + <em>anti-IL-1 (anakinra)</em>. <span class="tag danger">¡Infliximab puede empeorarlo!</span></td></tr>
+<tr><td><strong>MKD / HIDS</strong></td><td>MVK · AR</td><td>Lactante: fiebre + adenopatías cervicales + diarrea + aftas. IgD elevada (no específica). Aciduria mevalónica en crisis</td><td>Anti-IL-1 (canakinumab)</td></tr>
+<tr><td><strong>CAPS</strong> (criopirinopatías)</td><td><strong>NLRP3 (criopirina) · AD</strong></td><td>Espectro: <em>FCAS</em> (leve) → <em>MWS</em> (+ sordera + amiloidosis) → <strong>CINCA/NOMID</strong> (más grave): meningitis aséptica + artropatía deformante + sordera + retraso mental</td><td>Anti-IL-1 (canakinumab, anakinra, rilonacept)</td></tr>
+<tr><td>PFAPA</td><td>Poligénica</td><td>Niño: fiebre periódica + adenopatías + faringitis + aftas. Responde a prednisona dosis única</td><td>Corticoide aborta el episodio · amigdalectomía curativa</td></tr>
+<tr><td>Still del adulto</td><td>Poligénica</td><td>Mujer joven: fiebre cotidiana + exantema asalmonado + poliartritis + odinofagia + <em>ferritina ↑↑</em> + leucocitosis</td><td>AINE → corticoides → MTX → anti-IL-1 o tocilizumab. Cuidado con <strong>SAM</strong></td></tr>
+<tr><td>Reumatismo palindrómico</td><td>—</td><td>Brotes de sinovitis recurrente de pocos días, mono al inicio. Puede evolucionar a AR</td><td>HCQ, colchicina, MTX</td></tr>
+</tbody></table></div>
+
+<h3>16.2 Preguntas — Autoinflamatorios</h3>
+
+<details class="qa"><summary>1. (Jun 2017) Reumatismo palindrómico</summary>
+<div class="qa-body">
+<p>El reumatismo palindrómico se caracteriza por:</p>
+<ol type="a">
+<li>Brotes agudos de tendinitis de repetición</li>
+<li>Artralgias erráticas y frecuentes</li>
+<li>Artritis acompañada de eritema nodoso</li>
+<li><strong>Brotes de sinovitis de repetición, de unos días de duración</strong></li>
+<li>Artritis en manos y sacroilíacas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Reumatismo palindrómico: brotes agudos de sinovitis (monoarticular al inicio) de pocas horas-días, autolimitados, sin secuelas. Puede evolucionar a AR (~30 %). Tratamiento: HCQ, colchicina, MTX.</div>
+</div></details>
+
+<details class="qa"><summary>2. Reumatismo palindrómico — INCORRECTA</summary>
+<div class="qa-body">
+<p>Una de las siguientes afirmaciones en relación con el reumatismo palindrómico es INCORRECTA:</p>
+<ol type="a">
+<li>Los primeros episodios son monoarticulares</li>
+<li>Muestran habitualmente edema doloroso con fóvea</li>
+<li><strong>Muestran impotencia funcional muy marcada</strong></li>
+<li>En ocasiones los ataques son periarticulares</li>
+<li>El 10 % de los casos se acompaña de fiebre</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La impotencia funcional suele ser <em>leve</em> en el palindrómico (a diferencia de otras artritis agudas como la gota o séptica). Las demás son ciertas.</div>
+</div></details>
+
+<details class="qa"><summary>3. Varón joven con fiebre + serositis + responde a colchicina</summary>
+<div class="qa-body">
+<p>Varón de 16 años con episodios febriles de 39,5 ºC de 2-3 días que se acompañan de dolor abdominal, pericarditis y artritis en tobillo derecho con lesiones cutáneas pretibiales tipo erisipeloide. Edemas en piernas con proteinuria en rango nefrótico. Responde a colchicina. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Artritis idiopática juvenil forma oligoarticular</li>
+<li>Hidrartrosis intermitente</li>
+<li>Síndrome de fiebre periódica asociada al TNF-TRAPS</li>
+<li><strong>Fiebre Mediterránea Familiar</strong></li>
+<li>Síndrome CINCA</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> FMF: crisis de 1-3 días con <em>fiebre + serositis (peritonitis, pericarditis, pleuritis) + sinovitis + eritema erisipeloide</em>. Mediterráneos. Excelente respuesta a colchicina. Proteinuria nefrótica = amiloidosis AA (complicación temible). Herencia AR (gen MEFV).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2018) En los SAI</summary>
+<div class="qa-body">
+<p>En los síndromes autoinflamatorios:</p>
+<ol type="a">
+<li>Es frecuente la presencia de ANA</li>
+<li>Se asocian con frecuencia a los antígenos HLA de clase II</li>
+<li><strong>La hiperactividad del sistema inmune innato juega un papel preponderante</strong></li>
+<li>La IL-17 es la citoquina más frecuentemente implicada</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> SAI = inmunidad <em>INNATA</em> (no adaptativa). NO autoanticuerpos. NO HLA-II. La citoquina clave es <em>IL-1β</em> (no IL-17).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2018) Los CAPS</summary>
+<div class="qa-body">
+<p>Los CAPS:</p>
+<ol type="a">
+<li>Se deben a mutación homocigota o heterocigota en el gen de la mevalonato cinasa</li>
+<li>La FMF es la enfermedad más frecuente dentro de los CAPS</li>
+<li><strong>El síndrome CINCA es el fenotipo más grave</strong></li>
+<li>Todas las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> CAPS = criopirinopatías (gen NLRP3, AD). Espectro: FCAS (leve) → MWS (+ sordera + amiloidosis) → CINCA/NOMID (más grave, neonatal). La FMF NO es CAPS (es del gen MEFV). MKD/HIDS es por mevalonato cinasa.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2018) Sobre la FMF</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>La amiloidosis asociada a la FMF es la amiloidosis AA</strong></li>
+<li>La afectación del peritoneo es muy infrecuente en la FMF</li>
+<li>La FMF es un trastorno autosómico dominante</li>
+<li>Las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Amiloidosis AA (inflamación crónica → depósito de SAA). La peritonitis es MUY frecuente en FMF (1-3 días, dolor abdominal grave). La FMF es autosómica RECESIVA (no AD).</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2018) Sobre el TRAPS</summary>
+<div class="qa-body">
+<p>En TRAPS es cierto que:</p>
+<ol type="a">
+<li>Se hereda de forma autosómica recesiva con penetrancia incompleta</li>
+<li>No se ha descrito la amiloidosis AA</li>
+<li><strong>En algunos pacientes se ha observado una exacerbación de los signos inflamatorios después de la administración de infliximab</strong></li>
+<li>Niveles plasmáticos elevados de IgD durante los episodios febriles y en condiciones basales son un rasgo distintivo</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Infliximab puede paradójicamente empeorar TRAPS. TRAPS es autosómica DOMINANTE (no recesiva). SÍ se ha descrito amiloidosis AA (25 %). IgD elevada es de HIDS/MKD, no TRAPS.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Jun 2019) Canakinumab y CAPS</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>Canakinumab es útil en el tratamiento de los síndromes periódicos asociados a criopirina (CAPS)</strong></li>
+<li>Canakinumab es antagonista recombinante de los receptores de IL-1</li>
+<li>En el TRAPS el agente biológico más indicado es infliximab</li>
+<li>Todas las anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Canakinumab = anti-IL-1β (anticuerpo monoclonal, no antagonista del receptor — eso es anakinra). Eficaz en CAPS, FMF, TRAPS, HIDS, Still. En TRAPS NO se usa infliximab (puede empeorarlo); se usa anti-IL-1.</div>
+</div></details>
+
+<details class="qa"><summary>9. (Jun 2019) Sobre los SAI</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>En los SAI la presencia de autoanticuerpos es frecuente</li>
+<li>Los SAI suelen tener asociación con los antígenos HLA de clase II</li>
+<li><strong>Ninguna de las respuestas anteriores es correcta</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Ambas a y b son FALSAS. Los SAI no tienen autoanticuerpos (inmunidad innata) ni asociación HLA-II.</div>
+</div></details>
+
+<details class="qa"><summary>10. (Jun 2020) Sobre los SAI</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>Los SAI suelen tener asociación con HLA de clase II</li>
+<li>En los SAI IL-17 es la citoquina más importante desde el punto de vista patogénico</li>
+<li><strong>En los SAI la presencia de autoanticuerpos es muy infrecuente</strong></li>
+<li>Ninguna respuesta es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> SAI: inmunidad innata → NO autoanticuerpos, NO HLA-II, citoquina clave IL-1β (no IL-17).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 17: Metabolismo óseo =============== -->
+<section class="card" id="t17">
+<h2 class="section-title"><span class="num">17</span>Enfermedades del metabolismo óseo</h2>
+
+<h3>17.1 Fisiología fosfo-cálcica</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🧪</span>Hormonas clave</div>
+  <ul style="margin:6px 0">
+    <li><strong>PTH:</strong> ↑ Ca²⁺ y ↓ P · estimula osteoclastos y osteoblastos (resorción a dosis altas; <em>anabólica a dosis bajas intermitentes</em> = teriparatida).</li>
+    <li><strong>Vitamina D (calcitriol):</strong> ↑ absorción intestinal de Ca²⁺ y P · <strong>activación renal: 25-OH-D3 → 1,25-(OH)₂-D3 (1α-hidroxilasa renal)</strong>.</li>
+    <li><strong>Calcitonina:</strong> ↓ Ca²⁺ (inhibe osteoclastos). Poca relevancia clínica.</li>
+  </ul>
+</div>
+
+<h3>17.2 Osteoporosis (OP)</h3>
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Disminución de masa ósea por unidad de volumen</strong> + deterioro microarquitectural.</li>
+    <li>Fracturas más frecuentes: <strong>vértebras (D8-L1), cuello femoral, muñeca (Colles)</strong>.</li>
+    <li>Vertebrales: <strong>2/3 asintomáticas</strong>.</li>
+    <li>Causas medicamentosas: <strong>glucocorticoides, heparina, anticonvulsivantes, inhibidores aromatasa, agonistas GnRH, MTX altas dosis</strong>. <span class="tag ok">Los estrógenos NO producen OP, la previenen.</span></li>
+  </ul>
+</div>
+
+<h4>Densitometría — T-score y Z-score</h4>
+<div class="kv-grid">
+  <div class="kv"><span class="k">T-score</span><span class="v">Comparación con la mejor masa ósea adulta joven sana del mismo sexo</span></div>
+  <div class="kv"><span class="k">Z-score</span><span class="v">Comparación con la media para edad y sexo</span></div>
+</div>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Categoría OMS</th><th>T-score</th></tr></thead>
+<tbody>
+<tr><td>Normal</td><td>&gt; –1</td></tr>
+<tr><td><strong>Osteopenia</strong></td><td>Entre –1 y –2,5</td></tr>
+<tr><td><strong>Osteoporosis</strong></td><td>≤ –2,5</td></tr>
+<tr><td><strong>Osteoporosis establecida (severa)</strong></td><td>≤ –2,5 + <em>fractura por fragilidad</em></td></tr>
+</tbody></table></div>
+
+<h4>Tratamiento</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Línea</th><th>Fármacos</th><th>Notas</th></tr></thead>
+<tbody>
+<tr><td>Base</td><td>Calcio 1.000-1.200 mg/d + <strong>vitamina D ≥ 800 UI/d</strong> + ejercicio + caídas</td><td>200-300 UI insuficiente</td></tr>
+<tr><td>Antirresortivos</td><td><strong>Bifosfonatos</strong> (alendronato, risedronato semanal · ibandronato mensual · <em>zoledrónico iv anual</em>) · <strong>Denosumab</strong> (anti-RANKL, sc/6 m) · <strong>Raloxifeno</strong> (SERM)</td><td>Vacaciones tras 5 a. orales / 3 a. iv. <strong>NO suspender denosumab bruscamente</strong> (rebote)</td></tr>
+<tr><td>Osteoformadores</td><td><strong>Teriparatida</strong> (<em>fragmento 1-34</em> de PTH humana) sc diaria, máx. 24 m</td><td>Anabólico predominante</td></tr>
+<tr><td>Otros</td><td>Romosozumab (anti-esclerostina) · Bazedoxifeno (SERM, NO bifosfonato)</td><td>—</td></tr>
+</tbody></table></div>
+
+<h3>17.3 Osteomalacia</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Definición</span><span class="v">Defecto de mineralización → ↑ osteoide no mineralizado. En niños = <em>raquitismo</em></span></div>
+  <div class="kv"><span class="k">Causa más frecuente</span><span class="v">Déficit de vitamina D · déficit de fósforo</span></div>
+  <div class="kv"><span class="k">Clínica</span><span class="v">Dolor óseo difuso · debilidad muscular proximal · fracturas</span></div>
+  <div class="kv"><span class="k">Laboratorio</span><span class="v"><strong>↓ Ca · ↓ P · ↑ FA · ↑ PTH · ↓ 25-OH-D</strong></span></div>
+  <div class="kv"><span class="k">Radiología</span><span class="v"><strong>Líneas de Looser-Milkman (pseudofracturas)</strong></span></div>
+  <div class="kv"><span class="k">Tratamiento</span><span class="v"><strong>Vitamina D</strong> + calcio + corregir causa</span></div>
+</div>
+
+<h3>17.4 Enfermedad de Paget</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Concepto</span><span class="v">Trastorno del remodelado: hiperactividad osteoclástica + osteoformación desorganizada → hueso aumentado pero débil</span></div>
+  <div class="kv"><span class="k">Edad</span><span class="v">&gt; 50 años · forma <em>monostótica</em> &gt; poliostótica</span></div>
+  <div class="kv"><span class="k">Localizaciones</span><span class="v"><strong>Pelvis (más frecuente) · fémur · tibia · vértebras · cráneo</strong></span></div>
+  <div class="kv"><span class="k">Clínica</span><span class="v"><em>Asintomática en la mayoría</em> · dolor · deformidades (<strong>tibia en sable</strong> con incurvación anterior) · sordera · IC de alto gasto</span></div>
+  <div class="kv"><span class="k">Diagnóstico</span><span class="v"><strong>↑ Fosfatasa alcalina</strong> (marcador de actividad) · hidroxiprolinuria · piridinolinas. <strong>Gammagrafía ósea</strong> para diagnóstico precoz y extensión</span></div>
+  <div class="kv"><span class="k">Complicación temible</span><span class="v"><strong>Sarcoma óseo</strong> en &lt; 1 % → sospechar si aumento súbito de dolor + ↑↑ FA y VSG</span></div>
+  <div class="kv"><span class="k">Tratamiento</span><span class="v"><strong>Ácido zoledrónico iv</strong> (una dosis suele controlarlo) · pamidronato · risedronato</span></div>
+</div>
+
+<h3>17.5 Preguntas — Metabolismo óseo</h3>
+
+<details class="qa"><summary>1. (Jun 2017) Definición cuantitativa de osteoporosis</summary>
+<div class="qa-body">
+<p>La osteoporosis, desde el punto de vista cuantitativo, se define como:</p>
+<ol type="a">
+<li>La presencia de fracturas patológicas</li>
+<li><strong>La disminución de masa ósea por unidad de volumen</strong></li>
+<li>La disminución de la cantidad de calcio por unidad de volumen</li>
+<li>La disminución de la resistencia mecánica del hueso</li>
+<li>La disminución de la masa ósea por unidad de resistencia</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> OP cuantitativamente = ↓ masa ósea/volumen. Cualitativamente: deterioro de la microarquitectura. Ambos producen ↑ fragilidad y riesgo de fractura.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2017) Factor determinante en osteomalacia</summary>
+<div class="qa-body">
+<p>Uno de los factores que juegan un papel determinante en el desarrollo de una osteomalacia es:</p>
+<ol type="a">
+<li>Déficit de magnesio</li>
+<li><strong>Déficit de parathormona (PTH)</strong></li>
+<li>Déficit de fósforo</li>
+<li>Déficit de carbonatos</li>
+<li>Déficit de flúor</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (clave del banco).</strong> En realidad las causas más frecuentes son <em>déficit de vitamina D y fósforo</em>. El déficit de PTH (hipoparatiroidismo) no causa osteomalacia típicamente. Esta pregunta es controvertida; la respuesta marcada por el banco es b, pero las opciones correctas serían el déficit de fósforo o vitamina D.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2017) Fármaco que NO produce osteoporosis</summary>
+<div class="qa-body">
+<p>Citar qué fármaco NO produce osteoporosis:</p>
+<ol type="a">
+<li>Heparina</li>
+<li>Metotrexato</li>
+<li>Prednisona</li>
+<li><strong>Estrógenos</strong></li>
+<li>Triamcinolona</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Los estrógenos PREVIENEN la OP (su déficit en menopausia es la causa de OP postmenopáusica). Los demás son osteopenizantes: corticoides (los más clásicos), heparina prolongada, MTX a altas dosis (oncológicas).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2017) Imagen más útil en Paget</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes técnicas de imagen es más útil en el diagnóstico precoz y para evaluar la extensión de la enfermedad de Paget?</p>
+<ol type="a">
+<li>Radiografía simple</li>
+<li>Resonancia nuclear magnética</li>
+<li>Tomografía axial computorizada</li>
+<li><strong>Gammagrafía ósea</strong></li>
+<li>Densitometría ósea</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Gammagrafía con Tc-99m: la prueba más sensible para detectar focos paget activos y evaluar extensión. La Rx detecta cambios estructurales pero tardíos.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2017) Líneas de Looser-Milkman</summary>
+<div class="qa-body">
+<p>En un estudio radiológico, las líneas de Looser-Milkman representan:</p>
+<ol type="a">
+<li>Las fracturas de una osteoporosis</li>
+<li>Las zonas de resorción ósea en un paciente con hipertiroidismo</li>
+<li>Son típicas de la enfermedad ósea de Paget</li>
+<li><strong>Son pseudofracturas en los pacientes con osteomalacia</strong></li>
+<li>Son propias de la osteonecrosis de la cabeza femoral</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Líneas de Looser-Milkman = pseudofracturas (líneas radiotransparentes perpendiculares a la cortical, simétricas), patognomónicas de osteomalacia. Aparecen en zonas de carga (pelvis, fémur proximal, escápula).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2016) Hormonas del metabolismo fosfo-cálcico</summary>
+<div class="qa-body">
+<p>Las dos hormonas fundamentales en el metabolismo fosfo-cálcico son:</p>
+<ol type="a">
+<li>Calcitonina y ACTH</li>
+<li><strong>Parathormona (PTH) y vitamina D</strong></li>
+<li>Vitamina D y calcitonina</li>
+<li>PTH y calcitonina</li>
+<li>ACTH y PTH</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> PTH y vitamina D (calcitriol) son los dos pilares. Calcitonina tiene papel menor en humanos.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2016) Paget con ↑ temperatura local en muslo</summary>
+<div class="qa-body">
+<p>Un paciente diagnosticado de Paget presenta un aumento de temperatura local a nivel del muslo izquierdo. Se debe con mayor probabilidad a:</p>
+<ol type="a">
+<li><strong>Fase activa de la enfermedad que afecta al fémur izquierdo</strong></li>
+<li>Existencia de un sarcoma óseo en el fémur izquierdo</li>
+<li>Otra patología cutánea asociada</li>
+<li>Consolidación de una fractura en la diáfisis femoral izquierda</li>
+<li>Calcificaciones en la vena femoral que dificultan el retorno venoso</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El hueso con Paget activo tiene gran hipervascularización → aumento de temperatura local. El sarcoma es complicación rara (&lt; 1 %) — sospechar si hay <em>aumento súbito de dolor + ↑↑ FA y VSG</em>.</div>
+</div></details>
+
+<details class="qa"><summary>8. Fármaco antirresortivo + osteoformador (mixto)</summary>
+<div class="qa-body">
+<p>Solo uno de los fármacos utilizados en el tratamiento de la osteoporosis tiene un mecanismo de acción MIXTO (antirresortivo y osteoformador):</p>
+<ol type="a">
+<li>Raloxifeno</li>
+<li><strong>Ranelato de estroncio</strong></li>
+<li>Ibandronato</li>
+<li>Teriparatida</li>
+<li>Risedronato</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Ranelato de estroncio (retirado en muchos países por riesgo CV) tenía mecanismo dual. Teriparatida es predominantemente <em>osteoformador</em> (no mixto). Romosozumab (más moderno) también tiene efecto dual.</div>
+</div></details>
+
+<details class="qa"><summary>9. La osteomalacia se caracteriza por</summary>
+<div class="qa-body">
+<p>La osteomalacia se caracteriza por:</p>
+<ol type="a">
+<li>Reducción del volumen óseo</li>
+<li>Reducción de los osteoblastos</li>
+<li>Aumento de los osteoclastos</li>
+<li><strong>Aumento del volumen osteoide</strong></li>
+<li>Aumento de la calcificación</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Osteomalacia = defecto de mineralización → el osteoide se acumula sin mineralizar. La reducción del volumen óseo es de OP. La calcificación está disminuida (no aumentada).</div>
+</div></details>
+
+<details class="qa"><summary>10. Radiología simple en osteoporosis</summary>
+<div class="qa-body">
+<p>Señale la respuesta correcta en relación a la utilidad de la radiología simple en la osteoporosis:</p>
+<ol type="a">
+<li>Solo es sensible a variaciones de la densidad ósea superior al 30 %</li>
+<li>En columna es útil para el diagnóstico y grado de fractura</li>
+<li>Permite ver la evolución o la aparición de nuevos acuñamientos</li>
+<li><strong>Todas las respuestas anteriores son correctas</strong></li>
+<li>Solo las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La Rx tiene baja sensibilidad (cambios visibles solo cuando hay &gt; 30 % pérdida), pero es útil para detectar y graduar fracturas vertebrales y seguimiento de nuevos acuñamientos.</div>
+</div></details>
+
+<details class="qa"><summary>11. Sobre la osteoporosis — correcta</summary>
+<div class="qa-body">
+<p>Señale la afirmación correcta en relación con la osteoporosis:</p>
+<ol type="a">
+<li>Los pacientes con osteoporosis padecen frecuentemente dolor óseo</li>
+<li>El dolor brusco no está asociado a la presencia de una osteoporosis</li>
+<li>La localización más frecuente de las fracturas vertebrales es D4-D5</li>
+<li><strong>La localización más frecuente de las fracturas osteoporóticas es: vértebras, cuello femoral y muñeca</strong></li>
+<li>El dolor dorsal con irradiación metamérica no se asocia a la osteoporosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Las 3 fracturas típicas de OP. Las vértebras predominan en la <em>transición dorsolumbar (D8-L1)</em>, no D4-D5. El dolor brusco SÍ ocurre tras flexión brusca (acuñamiento agudo). La OP en sí no produce dolor crónico óseo difuso.</div>
+</div></details>
+
+<details class="qa"><summary>12. (Jun 2016) Localización de la enfermedad de Paget</summary>
+<div class="qa-body">
+<p>Respecto a la localización de la enfermedad de Paget, es cierto que:</p>
+<ol type="a">
+<li>La forma de presentación más común es la monostótica</li>
+<li>En la forma poliostótica, se afecta con mayor frecuencia la tibia</li>
+<li><strong>Los huesos largos de la extremidad inferior suelen incurvarse hacia delante</strong></li>
+<li>El húmero, al no ser un hueso de carga, no suele deformarse</li>
+<li>Todas las afirmaciones son falsas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> "Tibia en sable" = incurvación <em>anterior</em>. El fémur se incurva lateralmente. Forma más común: poliostótica (no monostótica). Localización más frecuente: <em>pelvis</em> (no tibia). Húmero sí puede deformarse.</div>
+</div></details>
+
+<details class="qa"><summary>13. DXA T −1,2 lumbar y −2,3 cadera</summary>
+<div class="qa-body">
+<p>Mujer de 54 años, sin antecedentes ni factores de riesgo. DXA: T-score −1,2 lumbar y −2,3 cadera. Con esta densitometría presenta:</p>
+<ol type="a">
+<li><strong>Osteopenia</strong></li>
+<li>Es compatible con la normalidad para su edad</li>
+<li>Osteoporosis</li>
+<li>Osteoporosis establecida</li>
+<li>Osteomalacia</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Cadera T −2,3 (entre −1 y −2,5) = osteopenia. Se categoriza por el T-score más bajo (en este caso cadera).</div>
+</div></details>
+
+<details class="qa"><summary>14. Tratamiento de la osteomalacia</summary>
+<div class="qa-body">
+<p>El tratamiento fundamental de la osteomalacia consiste en administrar:</p>
+<ol type="a">
+<li>Estrógenos</li>
+<li>Bifosfonatos</li>
+<li>Calcio</li>
+<li><strong>Vitamina D</strong></li>
+<li>Parathormona</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Vitamina D + calcio + corregir causa subyacente. Los bifosfonatos están CONTRAINDICADOS en osteomalacia (empeoran la mineralización).</div>
+</div></details>
+
+<details class="qa"><summary>15. Analítica en osteoporosis</summary>
+<div class="qa-body">
+<p>En una paciente de 71 años con osteoporosis, en el análisis de laboratorio lo habitual es encontrar:</p>
+<ol type="a">
+<li>Calcemia elevada y fósforo normal</li>
+<li>Calcemia baja y fósforo elevado</li>
+<li><strong>Calcio normal y fósforo normal</strong></li>
+<li>Calcio y fósforo disminuidos</li>
+<li>Calcio normal y fósforo disminuido</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> En OP primaria, Ca y P son NORMALES (y FA normal). Si hay alteraciones, sospechar OP secundaria (osteomalacia, hiperparatiroidismo, mieloma, etc.).</div>
+</div></details>
+
+<details class="qa"><summary>16. Datos biológicos en Paget</summary>
+<div class="qa-body">
+<p>Los datos biológicos sugerentes de enfermedad de Paget son:</p>
+<ol type="a">
+<li>Valores altos de fosfatasa alcalina</li>
+<li>Aumento de hidroxiprolinuria</li>
+<li>Incremento de piridinolinas</li>
+<li><strong>Las tres anteriores son correctas</strong></li>
+<li>Solo las respuestas a y b son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Todos son marcadores de alto recambio óseo (formación: FA; resorción: hidroxiprolinuria, piridinolinas, telopéptidos CTX/NTX). El Ca y P son normales en Paget.</div>
+</div></details>
+
+<details class="qa"><summary>17. La osteoporosis se define por</summary>
+<div class="qa-body">
+<p>La osteoporosis se define por:</p>
+<ol type="a">
+<li><strong>Reducción del volumen óseo</strong></li>
+<li>Reducción de los osteoblastos</li>
+<li>Aumento de los osteoclastos</li>
+<li>Aumento del volumen osteoide</li>
+<li>Aumento de la calcificación</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> OP = pérdida de masa ósea. El aumento de osteoide es de osteomalacia.</div>
+</div></details>
+
+<details class="qa"><summary>18. PTH en el hueso</summary>
+<div class="qa-body">
+<p>En el hueso, la parathormona (PTH):</p>
+<ol type="a">
+<li>Estimula los osteocitos e inhibe los osteoclastos</li>
+<li>Inhibe los osteoclastos y estimula los osteoblastos</li>
+<li>Inhibe osteocitos y osteoclastos</li>
+<li><strong>Estimula los osteoclastos y los osteoblastos</strong></li>
+<li>Estimula los osteoclastos e inhibe los osteoblastos</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La PTH estimula a ambos. A dosis altas continuas predomina el efecto resortivo (osteoclastos). A dosis bajas intermitentes predomina el anabólico (osteoblastos) — base de la teriparatida.</div>
+</div></details>
+
+<details class="qa"><summary>19. Fracturas vertebrales osteoporóticas — correcta</summary>
+<div class="qa-body">
+<p>¿Cuál es correcta en relación con las fracturas vertebrales osteoporóticas?</p>
+<ol type="a">
+<li>Son asintomáticas en 2/3 partes de los casos</li>
+<li>Cursan con dolor agudo tras flexión brusca</li>
+<li>Muestran dolor sordo agravado con los movimientos</li>
+<li><strong>Todas las anteriores son correctas</strong></li>
+<li>Solo las respuestas b y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> 2/3 son asintomáticas (hallazgo casual). Sintomáticas: dolor agudo tras flexión brusca (acuñamiento) o dolor sordo crónico con los movimientos. El dolor con irradiación metamérica no es típico (sospechar otra causa).</div>
+</div></details>
+
+<details class="qa"><summary>20. Manifestaciones clínicas en Paget</summary>
+<div class="qa-body">
+<p>La enfermedad de Paget desarrolla manifestaciones clínicas:</p>
+<ol type="a">
+<li>En todos los casos</li>
+<li>Es sintomática en los ancianos</li>
+<li><strong>Es asintomática en la mayoría de casos</strong></li>
+<li>Es un hallazgo casual en un 20 % de pacientes</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> 70-90 % de los pacientes con Paget son asintomáticos (hallazgo casual con ↑ FA aislada). Sintomáticos: dolor, deformidades, sordera, IC alto gasto, fracturas.</div>
+</div></details>
+
+<details class="qa"><summary>21. Fractura típica de osteoporosis postmenopáusica</summary>
+<div class="qa-body">
+<p>Indique una fractura típica de la osteoporosis posmenopáusica:</p>
+<ol type="a">
+<li>Clavícula</li>
+<li>Maleolar</li>
+<li><strong>Colles</strong></li>
+<li>Metacarpo</li>
+<li>Rodilla</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Fractura de Colles (radio distal por caída con mano extendida) es muy típica de OP postmenopáusica (60 años). Vertebrales (65 años) y de cuello femoral (75 años) son las otras.</div>
+</div></details>
+
+<details class="qa"><summary>22. Paget con ↑ dolor súbito + ↑ FA y VSG</summary>
+<div class="qa-body">
+<p>Paciente de 80 años con Paget de &gt; 15 años con aumento brusco del dolor femoral y elevación súbita de FA y VSG. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>La presencia de nuevo foco de enfermedad</strong></li>
+<li>Osteomielitis</li>
+<li>Osteomalacia</li>
+<li>Sarcoma óseo</li>
+<li>Nueva deformidad ósea</li>
+</ol>
+<div class="answer"><strong>Respuesta del banco: a.</strong> Pero en la práctica clínica: <em>aumento súbito de dolor + ↑↑ FA en Paget de larga evolución → SOSPECHAR SARCOMA ÓSEO</em>. El banco UGR marca a (nuevo foco más frecuente, sí; pero el sarcoma es la complicación temible que hay que descartar).</div>
+</div></details>
+
+<details class="qa"><summary>23. Conversión 25-OH-D3 → 1,25-(OH)₂-D3</summary>
+<div class="qa-body">
+<p>La transformación de la 25-OH-D3 en 1,25-(OH)₂-D3 tiene lugar en:</p>
+<ol type="a">
+<li>Hígado</li>
+<li>Piel</li>
+<li><strong>Riñón</strong></li>
+<li>Intestino</li>
+<li>Hueso</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> 1α-hidroxilasa renal convierte el 25-OH-D3 (calcidiol, forma de almacenamiento) en 1,25-(OH)₂-D3 (calcitriol, forma activa). El hígado hace la 25-hidroxilación. La piel sintetiza el colecalciferol a partir del 7-dehidrocolesterol bajo UV.</div>
+</div></details>
+
+<details class="qa"><summary>24. (Jun 2018) Tratamiento de osteoporosis</summary>
+<div class="qa-body">
+<p>En el tratamiento de la osteoporosis:</p>
+<ol type="a">
+<li>Etidronato es el bifosfonato más utilizado</li>
+<li>Bazedoxifeno es un bifosfonato de administración mensual</li>
+<li>La dosis de vitamina D más habitualmente recomendada es de 200-300 UI/día</li>
+<li><strong>Teriparatida es el fragmento recombinante 1-34 de la PTH humana</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Teriparatida = fragmento 1-34 recombinante de PTH humana. Etidronato es antiguo, en desuso. Bazedoxifeno es SERM (no bifosfonato). Vitamina D recomendada: 800-1.000 UI/día (200-300 es insuficiente).</div>
+</div></details>
+
+<details class="qa"><summary>25. (Jun 2019) Tibia en sable y mevalonato cinasa</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>La "tibia en sable" se puede dar en la enfermedad de Paget</strong></li>
+<li>La degeneración sarcomatosa es una complicación muy frecuente de Paget</li>
+<li>La linfadenopatía cervical es hallazgo frecuente en la fiebre periódica asociada a déficit de mevalonato cinasa</li>
+<li>Las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: d (a y c correctas).</strong> Tibia en sable es típica del Paget. Adenopatías cervicales son frecuentes en MKD/HIDS (déficit de mevalonato cinasa). El sarcoma en Paget es raro (&lt; 1 %, no frecuente).</div>
+</div></details>
+
+<details class="qa"><summary>26. (Jun 2019) Analítica en osteomalacia</summary>
+<div class="qa-body">
+<p>En la analítica de la osteomalacia, lo que más frecuentemente encontramos es:</p>
+<ol type="a">
+<li><strong>Hipocalcemia, hipofosfatemia y aumento de la fosfatasa alcalina</strong></li>
+<li>Hipocalcemia, hiperfosfatemia y aumento de la FA</li>
+<li>Hipercalcemia, hipofosfatemia y aumento de la FA</li>
+<li>Hipercalcemia, hiperfosfatemia y aumento de la FA</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Patrón típico: ↓ Ca + ↓ P + ↑ FA + ↑ PTH (hiperparatiroidismo secundario) + ↓ 25-OH-D.</div>
+</div></details>
+
+<details class="qa"><summary>27. (Jun 2019) Zoledrónico, teriparatida, raloxifeno</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>La infusión de ácido zoledrónico es útil en el tratamiento de Paget</strong></li>
+<li>Teriparatida es el fragmento recombinante 1-84 de la PTH humana</li>
+<li>Raloxifeno es un bifosfonato que se administra de forma semanal</li>
+<li>Las respuestas a y b son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Zoledrónico iv (1 dosis) es de elección en Paget. Teriparatida es el fragmento <em>1-34</em> (no 1-84). Raloxifeno es <em>SERM</em> oral diario (no bifosfonato).</div>
+</div></details>
+
+<details class="qa"><summary>28. (Jun 2019) T-score y Z-score</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>El Z-score, en DXA, representa la comparación del paciente con la mejor masa ósea para su edad y sexo</li>
+<li>El T-score, en DXA, representa la comparación del paciente con la media de masa ósea normal para su edad y sexo</li>
+<li><strong>Los valores de T-score y Z-score se suelen expresar como desviaciones estándar</strong></li>
+<li>Todas las respuestas anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Ambos en DE. <em>T-score</em>: compara con la <strong>mejor masa ósea adulta joven sana</strong> (no con la edad). <em>Z-score</em>: compara con la <strong>media de su edad y sexo</strong>.</div>
+</div></details>
+
+<details class="qa"><summary>29. (Jun 2019) Paciente con aplastamientos vertebrales + DXA</summary>
+<div class="qa-body">
+<p>Paciente de 68 años con aplastamientos vertebrales D11 y L1. DXA: Z-score −2,5 y T-score −2,8. Desde el punto de vista densitométrico, tiene:</p>
+<ol type="a">
+<li>Osteopenia</li>
+<li><strong>Osteoporosis establecida</strong></li>
+<li>Osteoporosis</li>
+<li>Osteomalacia</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> T ≤ −2,5 + fractura por fragilidad = osteoporosis ESTABLECIDA (severa). Tratamiento intensivo (teriparatida o romosozumab + después antirresortivo).</div>
+</div></details>
+
+<details class="qa"><summary>30. (Jun 2020) Paget, denosumab, bazedoxifeno</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>La fosfatasa alcalina NO es un buen marcador para controlar Paget</li>
+<li>Denosumab es un fármaco antiosteoporótico dirigido contra la osteoprotegerina</li>
+<li>Bazedoxifeno es un bifosfonato</li>
+<li><strong>Ninguna respuesta es correcta</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> FA SÍ es buen marcador en Paget. Denosumab actúa contra <em>RANK-L</em> (no osteoprotegerina). Bazedoxifeno es <em>SERM</em>. Por tanto las tres son falsas.</div>
+</div></details>
+
+<details class="qa"><summary>31. (Jun 2020) Sarcoma, tibia, osteomalacia</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li>La degeneración sarcomatosa es una complicación muy frecuente de Paget</li>
+<li>En la analítica de osteomalacia encontramos hipocalcemia, hipofosfatemia y aumento de FA</li>
+<li>La tibia en sable se puede dar en Paget</li>
+<li><strong>La tibia en sable se puede dar en Paget Y en osteomalacia encontramos hipocalcemia, hipofosfatemia y aumento de FA</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Combinación correcta. El sarcoma en Paget es raro (no frecuente).</div>
+</div></details>
+
+<details class="qa"><summary>32. (Jun 2020) Zoledrónico, teriparatida, raloxifeno</summary>
+<div class="qa-body">
+<p>Es cierto que:</p>
+<ol type="a">
+<li><strong>La infusión de ácido zoledrónico es útil en el tratamiento de Paget</strong></li>
+<li>La teriparatida es el fragmento recombinante 1-84 de la PTH humana</li>
+<li>Raloxifeno es un bifosfonato que se administra de forma semanal</li>
+<li>Todas las respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Igual que P27. Teriparatida 1-34 (no 1-84). Raloxifeno SERM (no bifosfonato).</div>
+</div></details>
+
+<details class="qa"><summary>33. (Jun 2020) DXA T −2,5 femoral y −3,2 lumbar sin fracturas</summary>
+<div class="qa-body">
+<p>Paciente de 68 años SIN aplastamientos vertebrales. DXA: T-score −2,5 en cuello femoral y −3,2 en columna lumbar. Desde el punto de vista densitométrico:</p>
+<ol type="a">
+<li>Osteopenia</li>
+<li><strong>Osteoporosis</strong></li>
+<li>Osteoporosis establecida</li>
+<li>Ninguna de las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> T ≤ −2,5 SIN fractura = osteoporosis (no establecida). Tratamiento antirresortivo de primera línea (bifosfonatos / denosumab).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 18: Vasculares-Miscelánea =============== -->
+<section class="card" id="t18">
+<h2 class="section-title"><span class="num">18</span>Patologías reumáticas vasculares y miscelánea</h2>
+
+<h3>18.1 Osteonecrosis aséptica (NAV)</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🩸</span>Causas (DIVO)</div>
+  <ul style="margin:6px 0">
+    <li><strong>Traumatismos</strong> (fractura cuello femoral)</li>
+    <li><strong>Corticoides</strong> (causa no traumática más frecuente)</li>
+    <li>Alcohol crónico</li>
+    <li>LES, SAF</li>
+    <li>Anemia falciforme</li>
+    <li>Enfermedad de los buzos (descompresión)</li>
+    <li>Quimio/radioterapia, leucemia, gota, Gaucher</li>
+  </ul>
+</div>
+
+<p><strong>Localizaciones:</strong> cabeza femoral (la más frecuente), cabeza humeral, cóndilos femorales, escafoides (Preiser), semilunar (Kienböck), astrágalo.</p>
+<p><strong>Diagnóstico:</strong> <span class="tag">RMN</span> es la prueba más sensible y precoz.</p>
+
+<h3>18.2 Osteocondrosis del crecimiento</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Epónimo</th><th>Localización</th></tr></thead>
+<tbody>
+<tr><td>Osgood-Schlatter</td><td>Tuberosidad anterior de la tibia (adolescentes deportistas)</td></tr>
+<tr><td>Sever</td><td>Calcáneo (niños)</td></tr>
+<tr><td>Kienböck</td><td>Semilunar del carpo</td></tr>
+<tr><td>Köhler</td><td>Escafoides tarsiano (niños)</td></tr>
+<tr><td>Freiberg</td><td>Cabeza del 2º MT (mujeres jóvenes)</td></tr>
+<tr><td>Perthes / Legg-Calvé-Perthes</td><td>Cabeza femoral en niños 4-8 años</td></tr>
+<tr><td><strong>Scheuermann</strong></td><td>Epifisitis vertebral juvenil (adolescente con cifosis + nódulos de Schmörl)</td></tr>
+<tr><td>Osteocondritis disecante</td><td><strong>Cóndilo femoral medial</strong> (rodilla del joven deportista)</td></tr>
+</tbody></table></div>
+
+<h3>18.3 Osteoartropatía hipertrófica (Pierre Marie-Bamberger)</h3>
+<ul>
+  <li>Dolor sordo y quemante en miembros · <strong>acropaquias (dedos en palillo de tambor)</strong> · uñas en vidrio de reloj · <strong>periostitis</strong> en huesos largos.</li>
+  <li><strong>Causa más frecuente: neoplasia pulmonar</strong> (carcinoma broncogénico) → siempre Rx tórax.</li>
+  <li>Otras: cardiopatía cianosante, hepatopatía crónica, EII.</li>
+</ul>
+
+<h3>18.4 Preguntas — Vasculares/miscelánea</h3>
+
+<details class="qa"><summary>1. Adolescente con dolor dorsal + cifosis + nódulos de Schmörl</summary>
+<div class="qa-body">
+<p>Joven de 15 años con dolor en raquis dorsal y leve cifosis dorsal. Rx: irregularidad de los platillos vertebrales y presencia de nódulos de Schmörl. Analítica normal salvo leve ↑ FA. Sugiere el diagnóstico de:</p>
+<ol type="a">
+<li>Osteoporosis juvenil</li>
+<li><strong>Epifisitis juvenil o enfermedad de Scheuermann</strong></li>
+<li>Enfermedad de Sever</li>
+<li>Osteomalacia</li>
+<li>Artritis idiopática juvenil forma axial</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Scheuermann: osteocondrosis vertebral juvenil con <em>nódulos de Schmörl + acuñamientos vertebrales + cifosis</em>. Adolescentes. Tratamiento: ejercicios, ortesis si cifosis &gt; 50°.</div>
+</div></details>
+
+<details class="qa"><summary>2. Varón con dolor en MMII + acropaquias + uñas en vidrio de reloj</summary>
+<div class="qa-body">
+<p>Varón de 65 años con dolor sordo y quemante en MMII que se incrementa al elevarlos. EF: engrosamiento de la porción distal de los dedos de manos y pies, aumento de la convexidad de las uñas y tumefacción articular. Sugiere:</p>
+<ol type="a">
+<li>Gota tofácea crónica</li>
+<li><strong>Osteoartropatía hipertrófica (Pierre Marie-Bamberger)</strong></li>
+<li>Artropatía psoriásica clásica</li>
+<li>Condrocalcinosis articular</li>
+<li>Poliartritis de comienzo senil</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Acropaquias (dedos en palillo de tambor) + uñas en vidrio de reloj + periostitis = osteoartropatía hipertrófica. <em>Causa más frecuente: cáncer broncogénico</em>. Hacer Rx tórax SIEMPRE.</div>
+</div></details>
+
+<details class="qa"><summary>3. Osteocondritis/osteocondrosis — INCORRECTA</summary>
+<div class="qa-body">
+<p>Una de las siguientes afirmaciones es INCORRECTA:</p>
+<ol type="a">
+<li><strong>La osteocondritis disecante afecta preferentemente a la tuberosidad anterior de la tibia</strong></li>
+<li>La enfermedad de Osgood-Schlatter se caracteriza por engrosamiento del tubérculo anterior de la tibia</li>
+<li>La enfermedad de Sever afecta al calcáneo</li>
+<li>La enfermedad de Kienböck es una necrosis avascular del semilunar</li>
+<li>Todas son cuadros determinados por una necrosis avascular</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Osteocondritis disecante afecta a la <em>rodilla (cóndilo femoral medial)</em>, NO a la tuberosidad anterior de la tibia. Esa es Osgood-Schlatter.</div>
+</div></details>
+
+<details class="qa"><summary>4. Periostitis en Rx/gammagrafía</summary>
+<div class="qa-body">
+<p>La presencia de signos de periostitis en un estudio radiológico o gammagrafía sugiere el diagnóstico de:</p>
+<ol type="a">
+<li>Osteoartritis idiopática</li>
+<li><strong>Osteoartropatía hipertrófica</strong></li>
+<li>Osteocondritis</li>
+<li>Osteítis condensans</li>
+<li>Hiperóstosis idiopática difusa</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Periostitis en huesos largos = osteoartropatía hipertrófica. Buscar siempre cáncer pulmonar.</div>
+</div></details>
+
+<details class="qa"><summary>5. Técnica más sensible para osteonecrosis</summary>
+<div class="qa-body">
+<p>Indique cuál de las siguientes técnicas de imagen es la más sensible en el diagnóstico de osteonecrosis avascular:</p>
+<ol type="a">
+<li>Radiología simple contrastada</li>
+<li>Gammagrafía ósea con Tc-99m</li>
+<li>Tomografía axial computarizada</li>
+<li><strong>Resonancia magnética nuclear</strong></li>
+<li>Gammagrafía ósea con gadolinio</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> RMN es la prueba más sensible y específica para osteonecrosis (signo del "doble halo", edema medular). Detecta lesiones antes que Rx (cambios visibles en fases avanzadas).</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 19: Locorregionales =============== -->
+<section class="card" id="t19">
+<h2 class="section-title"><span class="num">19</span>Síndromes locorregionales · partes blandas</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Cervicalgia y lumbalgia más frecuente: mecánica.</strong></li>
+    <li><strong>Hombro doloroso más frecuente: tendinopatía del supraespinoso.</strong></li>
+    <li><strong>Hombro + Horner (ptosis, miosis, enoftalmos) → Pancoast</strong> → Rx tórax (no RMN).</li>
+    <li><strong>Cola de caballo:</strong> lumbociática + anestesia en silla de montar + retención urinaria + reflejos exaltados → <em>emergencia neuroquirúrgica</em>.</li>
+    <li>Estenosis canal lumbar: anciano con claudicación neurógena ("carrito de la compra").</li>
+  </ul>
+</div>
+
+<h3>19.1 Banderas rojas en lumbalgia (red flags)</h3>
+<ul>
+  <li>Edad &gt; 50 años con nuevo dolor</li>
+  <li>Pérdida de peso, fiebre, dolor nocturno que no mejora con reposo</li>
+  <li>Antecedentes oncológicos</li>
+  <li>Inmunosupresión, ADVP</li>
+  <li>Trauma o fragilidad ósea</li>
+  <li>Déficit neurológico, alteraciones esfinterianas</li>
+</ul>
+
+<h3>19.2 Otros síndromes regionales</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Epicondilitis lateral</span><span class="v">"Codo de tenista"</span></div>
+  <div class="kv"><span class="k">Epicondilitis medial</span><span class="v">"Codo de golfista"</span></div>
+  <div class="kv"><span class="k">Túnel carpiano</span><span class="v">Compresión n. mediano · parestesias nocturnas · Tinel/Phalen</span></div>
+  <div class="kv"><span class="k">Fascitis plantar</span><span class="v">Dolor en talón con los primeros pasos</span></div>
+  <div class="kv"><span class="k">Bursitis trocantérea</span><span class="v">Dolor lateral de cadera a la palpación local</span></div>
+</div>
+
+<h3>19.3 Preguntas — Locorregionales</h3>
+
+<details class="qa"><summary>1. (Jun 2017) Anciano con dolor lumbar + claudicación neurógena</summary>
+<div class="qa-body">
+<p>Hombre de 70 años con dolor lumbar, dificultad para la marcha, pérdida de fuerza y parestesias en MMII, teniendo que pararse a los pocos metros de iniciar la marcha. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Fractura vertebral lumbar osteoporótica</li>
+<li>Hernia distal central L5-S1</li>
+<li>Espondilodiscitis</li>
+<li><strong>Estenosis de canal lumbar</strong></li>
+<li>Escoliosis lumbar degenerativa</li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Estenosis canal lumbar = <em>claudicación neurógena</em> (pesadez/debilidad en MMII tras pocos metros, mejora al sentarse o inclinarse hacia delante — "signo del carrito de la compra"). Causa: artrosis degenerativa.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2018) Fumador con dolor de hombro persistente</summary>
+<div class="qa-body">
+<p>Hombre de 57 años, fumador importante, con dolor intenso a nivel de hombro izquierdo de varias semanas que no mejora con analgesia. EF de hombro normal. Ecografía de hombro sin hallazgos. ¿Qué prueba pediría en primer lugar?</p>
+<ol type="a">
+<li>Hemograma con VSG</li>
+<li>Niveles de ácido úrico y calcio</li>
+<li><strong>Radiografía de tórax</strong></li>
+<li>RMN de hombro izquierdo</li>
+<li>Ecocardiografía</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Fumador + dolor de hombro inexplicado con EF y eco normales → <em>SOSPECHA DE PANCOAST</em> (tumor del vértice pulmonar). La Rx tórax es la primera prueba; si dudosa, TC. Síntomas asociados: síndrome de Horner (ptosis, miosis, enoftalmos, anhidrosis).</div>
+</div></details>
+
+<details class="qa"><summary>3. Causa más frecuente de cervicalgia</summary>
+<div class="qa-body">
+<p>La causa más frecuente de cervicalgia es:</p>
+<ol type="a">
+<li>Fractura osteoporótica</li>
+<li>Discitis infecciosa</li>
+<li>Metástasis</li>
+<li>Hernia discal</li>
+<li><strong>Mecánica: relacionada con posturas, esfuerzos y artrosis</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> &gt; 90 % de las cervicalgias son mecánicas (contractura, artrosis cervical, mala postura). Las causas graves (banderas rojas: dolor nocturno, fiebre, pérdida de peso, déficit neurológico) son minoritarias pero hay que descartarlas siempre.</div>
+</div></details>
+
+<details class="qa"><summary>4. Causa más frecuente de hombro doloroso</summary>
+<div class="qa-body">
+<p>Señalar la causa más frecuente de hombro doloroso:</p>
+<ol type="a">
+<li><strong>Tendinopatía del músculo supraespinoso</strong></li>
+<li>Artrosis glenohumeral</li>
+<li>Gota</li>
+<li>Subluxación cabeza humeral</li>
+<li>Artritis infecciosa</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Tendinopatía del manguito rotador (especialmente supraespinoso) por compromiso subacromial. Maniobras: Jobe, Hawkins, Neer. Tratamiento: AINE, fisioterapia, infiltración, cirugía si rotura completa sintomática.</div>
+</div></details>
+
+<details class="qa"><summary>5. Hombro + Horner — Pancoast</summary>
+<div class="qa-body">
+<p>Paciente de 57 años con dolor en hombro izquierdo de 3 semanas, ritmo inflamatorio. EF: leve dolor a la movilidad, caída de párpado y enoftalmos izquierdo. ¿Qué prueba pedir en primer lugar?</p>
+<ol type="a">
+<li>Radiografía de columna cervical</li>
+<li>RMN de hombro izquierdo</li>
+<li>Electromiograma</li>
+<li>Electrocardiograma</li>
+<li><strong>Radiografía de tórax</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> Síndrome de Horner (ptosis + miosis + enoftalmos + anhidrosis) por compresión del simpático cervical → <em>tumor de Pancoast del vértice pulmonar</em> que invade el plexo braquial. Rx tórax y luego TC.</div>
+</div></details>
+
+<details class="qa"><summary>6. Anciano con dolor lumbar nocturno — sospecha de neoplasia</summary>
+<div class="qa-body">
+<p>Paciente de 70 años con dolor lumbar nocturno muy intenso con sospecha de neoplasia. La EF debe completarse para diagnóstico temprano con:</p>
+<ol type="a">
+<li>Analítica completa</li>
+<li>Una punción lumbar</li>
+<li>Gammagrafía ósea</li>
+<li>Electromiografía</li>
+<li><strong>Exploración neurológica</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: e.</strong> La exploración neurológica completa es parte de la EF. Detectar compresión medular es prioritario antes de pruebas. Luego: Rx, analítica con marcadores, RMN/TC, gammagrafía.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Jun 2020) Lumbociática → cola de caballo</summary>
+<div class="qa-body">
+<p>Paciente de 31 años, mecánico, con dolor lumbar irradiado por MMII izq hasta planta del pie. Lasègue (+), fuerzas y reflejos normales. Se prescribe analgesia. Una semana después: continúa con dolor + debilidad en pierna izq + anestesia en zona genital y parte interna de muslos + retención urinaria + exaltación de reflejos. Pensaría en primer lugar en:</p>
+<ol type="a">
+<li>Espondilitis infecciosa</li>
+<li><strong>Síndrome de cola de caballo</strong></li>
+<li>Fractura vertebral</li>
+<li>Espondiloartritis</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Anestesia en silla de montar + retención urinaria + déficit progresivo = cola de caballo. <strong>EMERGENCIA neuroquirúrgica</strong>. RMN urgente + descompresión &lt; 48 h.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 20: Fibromialgia =============== -->
+<section class="card" id="t20">
+<h2 class="section-title"><span class="num">20</span>Fibromialgia (FM) y SFC</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Síndrome de sensibilización central</strong>: dolor musculoesquelético generalizado + fatiga + sueño no reparador + alteraciones cognitivas ("fibro-fog").</li>
+    <li>Prevalencia ≈ 2-4 % · mujer 9:1.</li>
+    <li>Patogenia: alteración eje HHS · <strong>↑ sustancia P en LCR</strong> · ↓ serotonina · ↓ noradrenalina.</li>
+    <li><strong>Laboratorio normal</strong> (CK, TSH).</li>
+    <li>Criterios actuales (ACR 2010/2016): <strong>NO requieren puntos sensibles</strong> (WPI + SSS).</li>
+  </ul>
+</div>
+
+<h3>20.1 Tratamiento</h3>
+<ul>
+  <li><strong>Educación, ejercicio aeróbico moderado, terapia cognitivo-conductual, higiene del sueño.</strong></li>
+  <li><strong>Amitriptilina</strong> a dosis bajas nocturnas (la más estudiada).</li>
+  <li><strong>Duloxetina</strong> (IRSN) · <strong>pregabalina</strong> · ciclobenzaprina.</li>
+  <li><span class="tag danger">Evitar:</span> opioides, AINE crónicos, benzodiacepinas.</li>
+</ul>
+
+<h3>20.2 Preguntas — Fibromialgia</h3>
+
+<details class="qa"><summary>1. Diagnóstico de fibromialgia</summary>
+<div class="qa-body">
+<p>Para efectuar un diagnóstico correcto de fibromialgia es preciso la presencia de:</p>
+<ol type="a">
+<li>Seis puntos fibromiálgicos y al menos seis meses de evolución</li>
+<li><strong>Once puntos y al menos tres meses de evolución</strong></li>
+<li>Cansancio, trastornos del sueño y seis puntos dolorosos</li>
+<li>Siempre debe haber dieciocho puntos fibromiálgicos</li>
+<li>Las dos primeras respuestas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Criterios ACR 1990: dolor generalizado ≥ 3 meses + ≥ 11 de 18 puntos sensibles. <em>Criterios actuales (ACR 2010/2016) NO requieren puntos sensibles</em> — basados en WPI + SSS.</div>
+</div></details>
+
+<details class="qa"><summary>2. NO mecanismo fisiopatológico en FM</summary>
+<div class="qa-body">
+<p>Entre los mecanismos fisiopatológicos implicados en el desarrollo de la fibromialgia, NO se encuentra:</p>
+<ol type="a">
+<li>Reactividad anormal del eje hipófisis-hipotálamo-suprarrenal</li>
+<li>Incremento de los núcleos sarcolémicos</li>
+<li><strong>Disminución de la sustancia P en líquido cefalorraquídeo</strong></li>
+<li>Aumento de prolactina</li>
+<li>Descenso plasmático de serotonina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> En la FM la sustancia P está AUMENTADA en LCR (sensibilización central). La serotonina y noradrenalina están disminuidas. Alteración del eje HHS y de la prolactina también descrita.</div>
+</div></details>
+
+<details class="qa"><summary>3. Punto doloroso NO correcto en FM</summary>
+<div class="qa-body">
+<p>Uno de los siguientes puntos dolorosos NO es correcto en pacientes con FM:</p>
+<ol type="a">
+<li>Origen del músculo supraespinoso</li>
+<li><strong>Inserción del músculo temporal</strong></li>
+<li>Prominencia del trocánter mayor</li>
+<li>Paquete adiposo de las rodillas</li>
+<li>Inserción del músculo suboccipital</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> El temporal no está entre los 18 puntos clásicos. Los 18 puntos: occipucio (suboccipital), trapecio, supraespinoso, 2ª articulación condrocostal, epicóndilo lateral, glúteo, trocánter mayor, paquete adiposo medial de rodillas (cada uno bilateral).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Jun 2018) Sobre la FM</summary>
+<div class="qa-body">
+<p>En la Fibromialgia es cierto que:</p>
+<ol type="a">
+<li>Tiene una prevalencia cercana al 0,3 % de la población general mayor de 18 años</li>
+<li><strong>El dolor musculoesquelético generalizado crónico es un síntoma frecuente</strong></li>
+<li>Es indispensable en la actualidad, para su diagnóstico, la presencia de dolor a la palpación digital en al menos 11 de los 18 puntos sensibles definidos en los Criterios ACR de 1990</li>
+<li>Todas las anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Prevalencia 2-4 % (no 0,3 %). Los puntos sensibles NO son indispensables en los criterios actuales (2010/2016).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Jun 2019) Sobre la FM — CIERTO</summary>
+<div class="qa-body">
+<p>En la fibromialgia es cierto que:</p>
+<ol type="a">
+<li>Suele existir un aumento de la CK</li>
+<li>Suele existir un descenso de la TSH</li>
+<li><strong>La amitriptilina ha mostrado cierto efecto beneficioso en el tratamiento de esta entidad</strong></li>
+<li>Todas las respuestas anteriores son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Amitriptilina (tricíclico, dosis bajas nocturnas) es el fármaco con mayor evidencia en FM. CK y TSH son NORMALES en FM (si están alteradas, buscar otra causa: miopatía, hipotiroidismo).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Jun 2020) Sobre la FM — CIERTO</summary>
+<div class="qa-body">
+<p>En la fibromialgia es cierto que:</p>
+<ol type="a">
+<li><strong>La duloxetina ha mostrado cierto efecto beneficioso en el tratamiento de esta entidad</strong></li>
+<li>Suele existir un aumento de la CK</li>
+<li>Suele existir un descenso de la TSH</li>
+<li>Ninguna respuesta es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Duloxetina (IRSN) y pregabalina (anticonvulsivante) también están aprobados con evidencia. CK y TSH normales.</div>
+</div></details>
+
+</section>
+
+<!-- =============== TEMA 21: Embarazo =============== -->
+<section class="card" id="t21">
+<h2 class="section-title"><span class="num">21</span>Embarazo y enfermedades reumáticas</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>HCQ mantener siempre</strong> (mejora pronóstico LES y previene lupus neonatal/BAV).</li>
+    <li>Planificar embarazo en remisión ≥ 6 meses.</li>
+    <li><strong>Certolizumab</strong> es el único anti-TNF <em>sin fragmento Fc</em> → preferido en embarazo.</li>
+  </ul>
+</div>
+
+<h3>21.1 Fármacos en embarazo y lactancia</h3>
+<div class="compare">
+  <div>
+    <h4>✔ Compatibles</h4>
+    <ul>
+      <li><strong>Hidroxicloroquina</strong> (mantener)</li>
+      <li>Sulfasalazina (+ folato)</li>
+      <li><strong>Azatioprina</strong> (de elección como inmunosupresor)</li>
+      <li>Ciclosporina, tacrolimús</li>
+      <li>Corticoides (preferir &lt; 7,5 mg/día)</li>
+      <li>AAS bajas dosis + HBPM profiláctica (SAF)</li>
+      <li>AINE ok hasta sem. 30</li>
+    </ul>
+  </div>
+  <div>
+    <h4>✘ Contraindicados (teratógenos)</h4>
+    <ul>
+      <li><strong>Metotrexato</strong> — suspender ≥ 3 m antes en ambos sexos</li>
+      <li><strong>Leflunomida</strong> — necesita lavado con colestiramina 11 días</li>
+      <li><strong>Micofenolato de mofetilo</strong> — suspender ≥ 6 sem antes</li>
+      <li><strong>Ciclofosfamida</strong> — gonadotóxica y teratógena</li>
+      <li>Warfarina — embriopatía warfarínica</li>
+    </ul>
+  </div>
+</div>
+
+<h3>21.2 Biológicos en embarazo</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">💉</span>Anti-TNF y placenta</div>
+  <p style="margin:4px 0">La mayoría tienen <strong>fragmento Fc</strong> y atraviesan la placenta sobre todo en 2º-3er trimestre.</p>
+  <p style="margin:4px 0"><strong>Certolizumab</strong> es un <em>Fab pegilado SIN Fc</em> → NO atraviesa placenta de forma significativa → <strong>niveles fetales más bajos</strong> → preferido.</p>
+</div>
+
+<h3>21.3 Preguntas — Embarazo</h3>
+
+<details class="qa"><summary>1. (Jun 2019) Fármaco compatible con embarazo</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes fármacos se puede utilizar durante el embarazo?</p>
+<ol type="a">
+<li>Metotrexato</li>
+<li>Leflunomida</li>
+<li><strong>Azatioprina</strong></li>
+<li>Micofenolato de mofetilo</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Azatioprina es el inmunosupresor de elección durante el embarazo. MTX y leflunomida son teratógenos (suspender 3 meses o lavar con colestiramina). MMF es teratógeno (suspender 6 sem antes). Otros compatibles: HCQ, sulfasalazina, ciclosporina, tacrolimús, corticoides, AAS bajas dosis, HBPM.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Jun 2019) Biológico SIN fragmento Fc</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes agentes biológicos NO tiene fragmento Fc?</p>
+<ol type="a">
+<li>Tocilizumab</li>
+<li><strong>Certolizumab</strong></li>
+<li>Infliximab</li>
+<li>Golimumab</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Certolizumab pegol es un fragmento Fab pegilado — no tiene fragmento Fc → no atraviesa la placenta de forma significativa → preferido en el embarazo.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Jun 2020) Biológico con niveles más bajos en sangre fetal</summary>
+<div class="qa-body">
+<p>¿Con cuál de los siguientes biológicos se han encontrado niveles más bajos en sangre fetal?</p>
+<ol type="a">
+<li><strong>Certolizumab</strong></li>
+<li>Adalimumab</li>
+<li>Abatacept</li>
+<li>Golimumab</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Igual razonamiento: al carecer de Fc, no atraviesa la placenta por transporte FcRn. Los otros sí tienen Fc y atraviesan placenta especialmente en 2º-3er trimestre.</div>
+</div></details>
+
+</section>
+
+<!-- ============================================================ -->
+<!-- BLOQUE B -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-b">
+  <h2>🩹 BLOQUE B · Traumatología</h2>
+  <div class="b-sub">12 temas · fracturas, complicaciones, pelvis, cadera, rodilla, tobillo e inmovilizaciones</div>
+</div>
+
+<!-- =============== TEMA 22: Fracturas generalidades =============== -->
+<section class="card" id="t22">
+<h2 class="section-title"><span class="num">22</span>Fracturas — generalidades</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Fractura:</strong> solución de continuidad ósea.</li>
+    <li>Tipos: traumáticas · por fatiga · patológicas · por insuficiencia.</li>
+    <li><strong>Salter-Harris II</strong> = la más frecuente en niños; <strong>V</strong> el peor pronóstico (aplastamiento).</li>
+    <li><strong>Gustilo III-C</strong> = fractura abierta con lesión vascular asociada → fijación externa + reparación vascular.</li>
+    <li><strong>Tabaco</strong> = factor modificable más importante que retrasa la consolidación.</li>
+  </ul>
+</div>
+
+<h3>22.1 Tipos según trazo y mecanismo</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Transversa</span><span class="v">Mecanismo directo</span></div>
+  <div class="kv"><span class="k">Oblicua</span><span class="v">Indirecto en flexión</span></div>
+  <div class="kv"><span class="k">Espiroidea</span><span class="v">Torsión</span></div>
+  <div class="kv"><span class="k">Conminuta</span><span class="v">≥ 3 fragmentos</span></div>
+  <div class="kv"><span class="k">Tallo verde</span><span class="v">Incompleta (niños)</span></div>
+  <div class="kv"><span class="k">Torus / rodete</span><span class="v">Compresión metafisaria (niños)</span></div>
+</div>
+
+<h3>22.2 Epifisiolisis — Salter-Harris</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Descripción</th><th>Notas</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Solo cartílago de crecimiento</td><td>—</td></tr>
+<tr><td><strong>II</strong></td><td>Cartílago + metáfisis</td><td><strong>El más frecuente</strong></td></tr>
+<tr><td>III</td><td>Cartílago + epífisis (intraarticular)</td><td>—</td></tr>
+<tr><td>IV</td><td>Metáfisis + cartílago + epífisis</td><td>—</td></tr>
+<tr><td><strong>V</strong></td><td>Aplastamiento</td><td><strong>Peor pronóstico</strong> (alteración del crecimiento)</td></tr>
+</tbody></table></div>
+
+<h3>22.3 Fracturas abiertas — Gustilo-Anderson</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Grado</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Herida &lt; 1 cm limpia</td></tr>
+<tr><td>II</td><td>Herida 1-10 cm sin lesiones graves de partes blandas</td></tr>
+<tr><td>III-A</td><td>&gt; 10 cm o graves; <strong>cobertura adecuada</strong></td></tr>
+<tr><td>III-B</td><td>Descobertura ósea con pérdida de periostio</td></tr>
+<tr><td><strong>III-C</strong></td><td>Lesión vascular asociada que requiere reparación</td></tr>
+</tbody></table></div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🚨</span>Manejo de la fractura abierta</div>
+  <ul style="margin:6px 0">
+    <li>Antibioterapia precoz (cefalosporina ± aminoglucósido; añadir penicilina en grado III)</li>
+    <li>Profilaxis antitetánica</li>
+    <li>Lavado + desbridamiento quirúrgico precoz (&lt; 6 h ideal)</li>
+    <li>Estabilización (fijación externa habitual en grado III-B/C)</li>
+  </ul>
+</div>
+
+<h3>22.4 Consolidación ósea</h3>
+<ol>
+  <li>Hematoma fracturario (inmediato)</li>
+  <li>Fase inflamatoria (24-72 h)</li>
+  <li>Callo blando fibroso-cartilaginoso (2-3 sem)</li>
+  <li>Callo duro óseo (osificación endocondral, 4-12 sem)</li>
+  <li>Remodelación (Ley de Wolff)</li>
+</ol>
+
+<div class="compare">
+  <div>
+    <h4>Consolidación directa (primaria)</h4>
+    <ul>
+      <li><strong>Sin callo</strong></li>
+      <li>Requiere <em>reducción anatómica perfecta + estabilidad absoluta</em></li>
+      <li>Osteosíntesis con placa a compresión</li>
+    </ul>
+  </div>
+  <div>
+    <h4>Consolidación indirecta (secundaria)</h4>
+    <ul>
+      <li><strong>Con callo</strong></li>
+      <li>Estabilidad relativa</li>
+      <li>Clavo endomedular, fijador externo, yeso</li>
+    </ul>
+  </div>
+</div>
+</section>
+
+<!-- =============== TEMA 23: Tratamiento y complicaciones =============== -->
+<section class="card" id="t23">
+<h2 class="section-title"><span class="num">23</span>Tratamiento de fracturas y complicaciones</h2>
+
+<h3>23.1 Las "4 R"</h3>
+<ol>
+  <li><strong>Reconocimiento</strong> (diagnóstico)</li>
+  <li><strong>Reducción</strong> (cerrada o abierta)</li>
+  <li><strong>Retención</strong> (inmovilización/estabilización)</li>
+  <li><strong>Rehabilitación</strong></li>
+</ol>
+
+<h3>23.2 Métodos quirúrgicos (osteosíntesis)</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Tornillos</span><span class="v">Compresión interfragmentaria</span></div>
+  <div class="kv"><span class="k">Placas</span><span class="v">DCP · LC-DCP · LCP (placas bloqueadas — fijación angular estable). Permiten consolidación primaria si compresión absoluta</span></div>
+  <div class="kv"><span class="k">Clavos endomedulares</span><span class="v">Fémur, tibia, húmero diafisarios. Consolidación secundaria con callo. Acerrojado proximal y distal</span></div>
+  <div class="kv"><span class="k">Fijación externa</span><span class="v">Abiertas graves · conminutas · infectadas · pediátricas · "damage control"</span></div>
+  <div class="kv"><span class="k">Banda de tensión</span><span class="v">Rótula · olécranon (fragmentos a tracción)</span></div>
+  <div class="kv"><span class="k">Artroplastia primaria</span><span class="v">Fracturas no reconstruibles del anciano (subcapital cuello femoral)</span></div>
+</div>
+
+<h3>23.3 Complicaciones precoces</h3>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🫁</span>Embolia grasa</div>
+  <p style="margin:4px 0">Sobre todo en fracturas de fémur y pelvis. <strong>A las 24-72 h</strong>.</p>
+  <p style="margin:4px 0"><strong>Tríada de Gurd:</strong></p>
+  <ul style="margin:4px 0">
+    <li>Insuficiencia respiratoria (hipoxemia, distress)</li>
+    <li>Alteraciones neurológicas (confusión, agitación)</li>
+    <li><strong>Petequias</strong> en tronco, axilas y conjuntiva (lo más específico)</li>
+  </ul>
+  <p style="margin:4px 0"><strong>Tratamiento:</strong> soporte respiratorio · fluidos · <em>estabilización precoz de la fractura</em>.</p>
+</div>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">💥</span>Síndrome compartimental</div>
+  <p style="margin:4px 0"><strong>Emergencia ortopédica</strong> — aumento de presión en compartimento osteofascial → isquemia.</p>
+  <p style="margin:4px 0"><strong>5 P (clínica):</strong></p>
+  <ul style="margin:4px 0">
+    <li><strong>Pain</strong> — <em>dolor desproporcionado al estiramiento pasivo</em> (signo más precoz)</li>
+    <li>Pallor (palidez)</li>
+    <li>Pulselessness (tardío, no fiable)</li>
+    <li>Parestesias / Paralysis</li>
+    <li>Poikilothermia</li>
+  </ul>
+  <p style="margin:4px 0"><strong>Diagnóstico:</strong> presión &gt; 30 mmHg (o diferencia con TAD &lt; 30).</p>
+  <p style="margin:4px 0"><strong>Tratamiento: FASCIOTOMÍA URGENTE</strong> (&lt; 6 h).</p>
+</div>
+
+<h3>23.4 Complicaciones tardías</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Retardo de consolidación</span><span class="v">No consolida en tiempo esperado</span></div>
+  <div class="kv"><span class="k">Pseudoartrosis</span><span class="v">&gt; 6 meses sin signos de consolidación</span></div>
+  <div class="kv"><span class="k">Consolidación viciosa</span><span class="v">Con angulación, rotación o acortamiento</span></div>
+  <div class="kv"><span class="k">Necrosis avascular</span><span class="v">Cabeza femoral · escafoides proximal · astrágalo</span></div>
+  <div class="kv"><span class="k">Artrosis postraumática</span><span class="v">—</span></div>
+  <div class="kv"><span class="k">SDRC tipo I (Sudeck)</span><span class="v">Dolor desproporcionado + edema + cambios tróficos + alodinia · tras Colles típicamente. Tratamiento: rehab + bifosfonatos + calcitonina · vitamina C profiláctica</span></div>
+  <div class="kv"><span class="k">Volkmann</span><span class="v">Contractura isquémica del antebrazo tras síndrome compartimental no tratado (clásica en supracondíleas de niños)</span></div>
+  <div class="kv"><span class="k">Rigidez articular · osificación heterotópica</span><span class="v">—</span></div>
+</div>
+
+<h3>23.5 Profilaxis</h3>
+<ul>
+  <li>Tromboembólica (HBPM/ACOD) <strong>4-6 semanas (35 días en cadera)</strong> en MMII/caderas.</li>
+  <li>Antitetánica en abiertas.</li>
+  <li>Antibiótica perioperatoria (cefazolina) y según Gustilo en abiertas.</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 24: Fisiopatología articular =============== -->
+<section class="card" id="t24">
+<h2 class="section-title"><span class="num">24</span>Fisiopatología articular</h2>
+
+<h3>24.1 Estructura de la articulación sinovial</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Cartílago hialino</span><span class="v"><strong>Avascular, aneural</strong>; condrocitos en matriz de colágeno tipo II y proteoglicanos. Se nutre por difusión desde el líquido sinovial</span></div>
+  <div class="kv"><span class="k">Hueso subcondral</span><span class="v">Soporta y amortigua</span></div>
+  <div class="kv"><span class="k">Cápsula</span><span class="v">Fibrosa</span></div>
+  <div class="kv"><span class="k">Membrana sinovial</span><span class="v">Sinoviocitos A (macrofágicos) y B (producen ácido hialurónico)</span></div>
+  <div class="kv"><span class="k">Líquido sinovial</span><span class="v">Ultrafiltrado plasmático + AH → lubricación + nutrición</span></div>
+  <div class="kv"><span class="k">Meniscos</span><span class="v">Fibrocartílago (rodilla, articulación temporomandibular...)</span></div>
+</div>
+
+<h3>24.2 Vulnerabilidad del cartílago</h3>
+<ul>
+  <li><strong>No tiene capacidad de regeneración significativa.</strong> Cuando se lesiona, se forma fibrocartílago (colágeno tipo I) que no resiste igual.</li>
+  <li>Sensible a sobrecarga, microtraumatismos, isquemia subcondral, inflamación.</li>
+</ul>
+
+<h3>24.3 Respuesta al daño</h3>
+<ul>
+  <li><strong>Trauma agudo:</strong> derrame, hemartros, dolor, impotencia.</li>
+  <li><strong>Sinovitis</strong> (cristales, autoinmune, infección, trauma) → IL-1, TNF, MMPs → daño cartilaginoso secundario.</li>
+  <li><strong>Cicatrización ligamentaria:</strong> inflamación → proliferación → remodelación; reduce resistencia mecánica permanente.</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 25: Traumatismos articulares =============== -->
+<section class="card" id="t25">
+<h2 class="section-title"><span class="num">25</span>Traumatismos articulares</h2>
+
+<h3>25.1 Esguince (sprain)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Grado</th><th>Descripción</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Distensión sin rotura macroscópica; estabilidad conservada</td><td>RICE + vendaje funcional</td></tr>
+<tr><td>II</td><td>Rotura parcial; cierta laxitud</td><td>Inmovilización + carga progresiva</td></tr>
+<tr><td>III</td><td>Rotura completa; <strong>inestabilidad</strong></td><td>Inmovilización ± reconstrucción quirúrgica (LCA en deportistas)</td></tr>
+</tbody></table></div>
+
+<p><strong>Localizaciones más frecuentes:</strong> tobillo (<em>ligamento peroneo-astragalino anterior</em>), rodilla (LLI, LLE, LCA, LCP), muñeca, MCF del pulgar (esguince del esquiador).</p>
+
+<h3>25.2 Luxaciones articulares</h3>
+<div class="box box-clave">
+  <div class="box-title"><span class="icon">🩺</span>Manejo general</div>
+  <p style="margin:0"><strong>Reducción urgente</strong> bajo sedación/anestesia + inmovilización + estudio de lesiones asociadas (vasculonerviosas).</p>
+</div>
+
+<div class="kv-grid">
+  <div class="kv"><span class="k">Hombro</span><span class="v"><strong>La más frecuente del cuerpo</strong> · &gt; 90 % anterior subcoracoidea · Hill-Sachs, Bankart · inestabilidad recidivante si &lt; 25 años</span></div>
+  <div class="kv"><span class="k">Codo</span><span class="v">Segunda en adultos · posterior la más común · cuidado con braquial y mediano</span></div>
+  <div class="kv"><span class="k">Cadera</span><span class="v">Posterior la más común (dashboard injury) · riesgo NAV</span></div>
+  <div class="kv"><span class="k">Rótula</span><span class="v">Lateral; cuidado con fractura osteocondral</span></div>
+</div>
+
+<h3>25.3 Lesiones meniscales y ligamentarias de rodilla</h3>
+
+<h4>Meniscos</h4>
+<ul>
+  <li><strong>Menisco medial: más fijo → más lesionado.</strong></li>
+  <li>Clínica: dolor en interlínea, derrame, <em>bloqueo articular</em>, crujidos.</li>
+  <li>Exploración: <strong>McMurray, Apley, Steinmann</strong>.</li>
+  <li>Diagnóstico: <strong>RMN</strong>.</li>
+  <li>Tratamiento: artroscopia con meniscectomía parcial o reparación (sutura en jóvenes, zona vascularizada).</li>
+</ul>
+
+<h4>LCA</h4>
+<ul>
+  <li>Mecanismo: cambio de dirección, valgo + rotación externa.</li>
+  <li>Clínica: <strong>crujido audible</strong> + derrame inmediato (hemartros) + sensación de fallo.</li>
+  <li>Exploración: <strong>Lachman (la más sensible)</strong>, pivot shift, cajón anterior.</li>
+  <li>Tratamiento: reconstrucción artroscópica con plastia (HTH o isquiotibiales) en jóvenes activos.</li>
+</ul>
+
+<h4>LCP</h4>
+<ul>
+  <li>Trauma directo sobre la tibia anterior ("dashboard injury").</li>
+  <li>Cajón posterior (+).</li>
+</ul>
+
+<h4>Colaterales y tríadas</h4>
+<ul>
+  <li>LLI: valgo forzado · LLE: varo forzado.</li>
+  <li><strong>Tríada de O'Donoghue (infausta):</strong> LCA + LLI + menisco medial.</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 26: Cirugía articular =============== -->
+<section class="card" id="t26">
+<h2 class="section-title"><span class="num">26</span>Principios de cirugía articular</h2>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Modalidad</th><th>Indicaciones</th></tr></thead>
+<tbody>
+<tr><td><strong>Artroscopia</strong></td><td>Diagnóstica y terapéutica · meniscectomía/sutura · plastia LCA · reparación del manguito · cuerpos libres · sinovectomía</td></tr>
+<tr><td>Osteotomía</td><td>Corrección de ejes (tibia alta valguizante en gonartrosis medial joven); PAO en displasia cadera</td></tr>
+<tr><td>Artrodesis</td><td>Fusión: cuando no es posible la artroplastia (jóvenes con cargas extremas, infección crónica, IFD, muñeca)</td></tr>
+<tr><td><strong>Artroplastia (prótesis)</strong></td><td>Total (PTC, PTR) o hemi · cementada o no cementada · artrosis avanzada · fractura subcapital del anciano · AR avanzada · NAV</td></tr>
+</tbody></table></div>
+
+<h3>26.1 Complicaciones de la artroplastia</h3>
+<ul>
+  <li><strong>Aflojamiento aséptico</strong> (la más frecuente a largo plazo)</li>
+  <li><strong>Infección protésica</strong> (la más temida)</li>
+  <li>Luxación protésica</li>
+  <li>Fractura periprotésica</li>
+  <li>Desgaste de polietileno, osteólisis</li>
+</ul>
+
+<h3>26.2 Manejo perioperatorio</h3>
+<ul>
+  <li>Profilaxis antibiótica (cefazolina perioperatoria)</li>
+  <li>Profilaxis tromboembólica (HBPM o ACOD) · 4-6 sem cadera, 2 sem rodilla</li>
+  <li>Rehabilitación precoz</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 27: Pelvis =============== -->
+<section class="card" id="t27">
+<h2 class="section-title"><span class="num">27</span>Fracturas y luxaciones de pelvis</h2>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🚨</span>¡Riesgo vital!</div>
+  <p style="margin:0">Hemorragia masiva (plexo venoso pre-sacro, arterias iliacas, hueso esponjoso) → <strong>causa frecuente de shock hipovolémico en politraumas</strong>.</p>
+</div>
+
+<h3>27.1 Clasificación de Young-Burgess (mecanismo)</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">APC (libro abierto)</span><span class="v">Apertura sinfisis púbica + disrupción SI posterior. Atropello frontal</span></div>
+  <div class="kv"><span class="k">LC (Lateral Compression)</span><span class="v">Impactos laterales → ramas púbicas + lesiones sacras impactadas</span></div>
+  <div class="kv"><span class="k">VS (Vertical Shear / Malgaigne)</span><span class="v">Desplazamiento vertical hemipélvico (caída desde altura)</span></div>
+  <div class="kv"><span class="k">CM</span><span class="v">Combinado</span></div>
+</div>
+
+<h3>27.2 Clasificación de Tile (estabilidad)</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">A</span><span class="v">Estable</span></div>
+  <div class="kv"><span class="k">B</span><span class="v">Parcialmente inestable (rotacional)</span></div>
+  <div class="kv"><span class="k">C</span><span class="v">Completamente inestable (rotacional + vertical)</span></div>
+</div>
+
+<h3>27.3 Lesiones asociadas</h3>
+<ul>
+  <li><strong>Hemorragia retroperitoneal masiva</strong></li>
+  <li><strong>Urológicas:</strong> rotura uretral (uretra membranosa en hombre, ascensión prostática), vesical</li>
+  <li>Vaginales / rectales (fractura abierta)</li>
+  <li>Neurológicas (plexo lumbosacro, S1)</li>
+  <li>TVP</li>
+</ul>
+
+<h3>27.4 Manejo inicial</h3>
+<ol>
+  <li><strong>ABCDE del politrauma</strong></li>
+  <li><strong>Compresión externa precoz</strong> con faja pélvica o sábana a nivel de trocánteres mayores (¡no en crestas iliacas!)</li>
+  <li>Fluidoterapia + transfusión + ácido tranexámico</li>
+  <li>Fijador externo de urgencia para Tile B/C</li>
+  <li><strong>Packing pélvico + arteriografía con embolización</strong> si sangrado persistente (la a. glútea superior es la lesión más frecuente)</li>
+  <li>Reconstrucción definitiva con osteosíntesis interna en segundo tiempo</li>
+</ol>
+
+<h3>27.5 Fracturas por insuficiencia en el anciano</h3>
+<p>Caídas banales en osteoporóticos · dolor lumbosacro/inguinal sin trauma · <strong>Rx puede ser normal</strong> · <strong>RMN o TAC</strong> confirman · tratamiento conservador (analgesia + movilización con carga tolerada).</p>
+</section>
+
+<!-- =============== TEMA 28: Luxación cadera =============== -->
+<section class="card" id="t28">
+<h2 class="section-title"><span class="num">28</span>Luxación traumática de cadera</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li><strong>Articulación profunda y congruente</strong> → requiere alta energía.</li>
+    <li><strong>90 % posteriores</strong> (dashboard injury): cadera flexionada y aducida.</li>
+    <li><strong>Reducción urgente &lt; 6 h</strong> (para disminuir NAV).</li>
+  </ul>
+</div>
+
+<h3>28.1 Tipos y clínica</h3>
+<div class="compare">
+  <div>
+    <h4>Posterior (90 %)</h4>
+    <ul>
+      <li>Cadera <strong>flexionada, aducida, rotación INTERNA</strong></li>
+      <li>Miembro acortado</li>
+      <li>Mecanismo: dashboard injury</li>
+      <li>Riesgo: <strong>lesión ciático</strong> (peroneo común) en 10-20 %</li>
+    </ul>
+  </div>
+  <div>
+    <h4>Anterior (10 %)</h4>
+    <ul>
+      <li>Miembro <strong>alargado, abducción, rotación EXTERNA</strong></li>
+      <li>Riesgo: arteria/nervio femoral</li>
+    </ul>
+  </div>
+</div>
+
+<h3>28.2 Diagnóstico</h3>
+<ul>
+  <li>Rx AP de pelvis</li>
+  <li><strong>TAC tras la reducción</strong> para descartar fragmentos intraarticulares y fracturas del cótilo</li>
+</ul>
+
+<h3>28.3 Complicaciones temibles</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">NAV cabeza femoral</span><span class="v">10-40 % · proporcional al tiempo hasta reducción</span></div>
+  <div class="kv"><span class="k">Lesión ciática</span><span class="v">Pie caído (rama peronea común)</span></div>
+  <div class="kv"><span class="k">Artrosis postraumática · osificación heterotópica</span><span class="v">—</span></div>
+</div>
+
+<h3>28.4 Tratamiento</h3>
+<ul>
+  <li><strong>Reducción cerrada bajo AG urgente &lt; 6 h</strong>: maniobras de <em>Allis</em> (tracción en eje + flexión + rotación interna) o <em>Bigelow</em>.</li>
+  <li>Si irreducible o fragmento intraarticular: reducción abierta urgente.</li>
+  <li>Postreducción: TAC · descarga 6-8 sem · RMN a 3-6 meses para descartar NAV.</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 29: Fractura cadera =============== -->
+<section class="card" id="t29">
+<h2 class="section-title"><span class="num">29</span>Fractura de cadera (anciano)</h2>
+
+<div class="box box-resumen">
+  <div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+  <ul>
+    <li>Anciano osteoporótico con caída banal.</li>
+    <li><strong>Mortalidad a 1 año: 20-30 %.</strong></li>
+    <li><strong>Cirugía precoz &lt; 48 h</strong> mejora supervivencia.</li>
+    <li>Miembro acortado y en <strong>rotación externa</strong> (clásico).</li>
+  </ul>
+</div>
+
+<h3>29.1 Clasificación anatómica</h3>
+<div class="compare">
+  <div>
+    <h4>Intracapsulares (cuello)</h4>
+    <ul>
+      <li><strong>Riesgo de NAV</strong> (la cabeza pierde aporte)</li>
+      <li>Subcapitales · transcervicales · basicervicales</li>
+      <li>Sin sangrado masivo</li>
+    </ul>
+  </div>
+  <div>
+    <h4>Extracapsulares</h4>
+    <ul>
+      <li><strong>No NAV pero más sangrantes</strong></li>
+      <li>Pertrocantéreas (las más frecuentes en ancianos)</li>
+      <li>Subtrocantéreas (biomecánicamente exigentes)</li>
+    </ul>
+  </div>
+</div>
+
+<h3>29.2 Garden (subcapitales)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Garden</th><th>Descripción</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Incompleta, en valgo, impactada</td><td>Tornillos canulados</td></tr>
+<tr><td>II</td><td>Completa no desplazada</td><td>Tornillos canulados</td></tr>
+<tr><td><strong>III</strong></td><td>Completa con desplazamiento parcial</td><td><strong>Artroplastia</strong> en &gt; 65-70 años (alto riesgo NAV)</td></tr>
+<tr><td><strong>IV</strong></td><td>Completa con desplazamiento completo</td><td><strong>Artroplastia (hemi o total)</strong> · NAV casi segura</td></tr>
+</tbody></table></div>
+
+<h3>29.3 Tratamiento quirúrgico</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Tratamiento de elección</th></tr></thead>
+<tbody>
+<tr><td>Subcapital Garden I-II</td><td>Tornillos canulados o DHS</td></tr>
+<tr><td>Subcapital Garden III-IV</td><td><strong>Hemiartroplastia cementada</strong> (anciano) o <strong>PTC</strong> (mayor demanda funcional, expectativa &gt; 10 a., artrosis previa)</td></tr>
+<tr><td>Pertrocantérea</td><td><strong>Clavo cefalomedular (PFNA, gamma)</strong> o DHS</td></tr>
+<tr><td>Subtrocantérea</td><td>Clavo cefalomedular largo</td></tr>
+</tbody></table></div>
+
+<h3>29.4 Manejo perioperatorio</h3>
+<ul>
+  <li><strong>Cirugía precoz &lt; 48 h.</strong></li>
+  <li>Profilaxis tromboembólica 35 días.</li>
+  <li>Rehabilitación inmediata.</li>
+  <li>Tratamiento de la osteoporosis (Ca + vitamina D + bifosfonatos/denosumab/teriparatida).</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 30: Cadera dolorosa =============== -->
+<section class="card" id="t30">
+<h2 class="section-title"><span class="num">30</span>Cadera dolorosa del adulto</h2>
+
+<h3>30.1 Diagnóstico diferencial</h3>
+<div class="compare">
+  <div>
+    <h4>Intraarticular (mecánico)</h4>
+    <ul>
+      <li><strong>Coxartrosis</strong> (la más frecuente &gt; 50 años)</li>
+      <li><strong>NAV de cabeza femoral</strong> (corticoides, alcohol, LES, SAF)</li>
+      <li><strong>FAI</strong> (Cam — varones jóvenes deportistas; Pincer — mujer)</li>
+      <li>Lesión del labrum acetabular</li>
+      <li>Sinovitis (transitoria, séptica, AR)</li>
+      <li>Condromatosis sinovial</li>
+    </ul>
+  </div>
+  <div>
+    <h4>Extraarticular</h4>
+    <ul>
+      <li>Bursitis trocantérea</li>
+      <li>Tendinopatía glúteos medio/menor</li>
+      <li>Síndrome del piramidal</li>
+      <li>Pubalgia / osteopatía del pubis</li>
+      <li>Meralgia parestésica</li>
+      <li>Cólico nefrítico, hernia inguinal, ginecológica</li>
+    </ul>
+  </div>
+</div>
+
+<h3>30.2 Coxartrosis</h3>
+<ul>
+  <li>Dolor inguinal mecánico, irradiado a rodilla a veces.</li>
+  <li><strong>Limitación dolorosa de la rotación interna</strong> (la primera en perderse) y abducción.</li>
+  <li><strong>Test de Patrick (FABER) +.</strong></li>
+  <li>Rx: pinzamiento superoexterno · esclerosis · osteofitos · geodas.</li>
+  <li>Tratamiento: conservador → <strong>PTC</strong> cuando dolor refractario.</li>
+</ul>
+
+<h3>30.3 NAV cabeza femoral — fases de Ficat/ARCO</h3>
+<ol>
+  <li><strong>0-1:</strong> Rx normal, RMN (+)</li>
+  <li><strong>2:</strong> esclerosis, quistes</li>
+  <li><strong>3:</strong> signo de la luna creciente, colapso</li>
+  <li><strong>4:</strong> artrosis</li>
+</ol>
+<p><strong>Tratamiento precoz:</strong> descompresión central + injerto vascularizado. Avanzado: PTC.</p>
+</section>
+
+<!-- =============== TEMA 31: Muslo, rodilla, pierna =============== -->
+<section class="card" id="t31">
+<h2 class="section-title"><span class="num">31</span>Fracturas y luxaciones de muslo, rodilla y pierna</h2>
+
+<h3>31.1 Fracturas diafisarias de fémur</h3>
+<ul>
+  <li>Alta energía en jóvenes; osteoporosis en ancianos.</li>
+  <li><strong>Pérdida sanguínea 1-2 L</strong> (riesgo de shock).</li>
+  <li>Riesgo de <strong>embolia grasa</strong>.</li>
+  <li><strong>Tratamiento de elección: clavo endomedular acerrojado.</strong></li>
+</ul>
+
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">💊</span>Fracturas atípicas de fémur por bifosfonatos</div>
+  <p style="margin:0">Trazo transverso · subtrocantéreas · "pico" en cortical externa · bilaterales. En pacientes con tratamiento prolongado (&gt; 5 años).</p>
+</div>
+
+<h3>31.2 Fracturas distales de fémur (supracondíleas, condíleas)</h3>
+<ul>
+  <li>Tratamiento: <strong>placa LCP distal</strong> o clavo retrógrado.</li>
+  <li>Riesgo de afectación de la arteria poplítea.</li>
+</ul>
+
+<h3>31.3 Luxación de rodilla</h3>
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🚨</span>Emergencia ortopédico-vascular</div>
+  <p style="margin:0">Lesión de la arteria poplítea hasta en 40 % · <strong>reducción inmediata + valoración vascular</strong> (ITB, arteriografía si dudoso).</p>
+</div>
+
+<h3>31.4 Fractura de rótula</h3>
+<ul>
+  <li>Mecanismo directo o indirecto (contracción brusca).</li>
+  <li>Imposibilidad de extensión activa contra gravedad.</li>
+  <li>Tratamiento: no desplazada → conservador con yeso 4-6 sem; desplazada → <strong>osteosíntesis con cerclaje en banda de tensión + agujas K</strong>.</li>
+</ul>
+
+<h3>31.5 Fractura del platillo tibial</h3>
+<ul>
+  <li>Mecanismo: caída de altura, atropello.</li>
+  <li>Clasificación de <strong>Schatzker (I-VI)</strong>.</li>
+  <li>Lesiones asociadas: meniscos, LCA, LCP, peroneo.</li>
+  <li>Tratamiento: conservador en no desplazadas; ORIF con placa si depresión &gt; 2-3 mm.</li>
+</ul>
+
+<h3>31.6 Fracturas de tibia y peroné</h3>
+<ul>
+  <li><strong>Diafisaria de tibia:</strong> la más frecuente de los huesos largos.</li>
+  <li>Riesgo elevado de <strong>fractura abierta</strong> (tibia subcutánea).</li>
+  <li>Síndrome compartimental frecuente.</li>
+  <li>Tratamiento: <strong>clavo endomedular acerrojado</strong> en cerradas y abiertas Gustilo I-IIIA; fijador externo en IIIB-C.</li>
+  <li>Peroné aislado → habitualmente conservador.</li>
+</ul>
+</section>
+
+<!-- =============== TEMA 32: Tobillo y pie =============== -->
+<section class="card" id="t32">
+<h2 class="section-title"><span class="num">32</span>Lesiones traumáticas de tobillo y pie</h2>
+
+<h3>32.1 Fracturas de tobillo (Weber)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Weber</th><th>Localización del trazo peroneo</th><th>Estabilidad y tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>A</strong></td><td>Infrasindesmal</td><td>Estable → conservador</td></tr>
+<tr><td><strong>B</strong></td><td>Transindesmal</td><td>Variable → conservador si estable · ORIF si inestable</td></tr>
+<tr><td><strong>C</strong></td><td>Suprasindesmal</td><td><strong>Siempre inestable</strong> → ORIF con placa peroneal + reconstrucción sindesmal</td></tr>
+</tbody></table></div>
+
+<p><strong>Maisonneuve:</strong> fractura proximal del peroné + ruptura sindesmosis + lesión maleolo medial/LLI → tratar la sindesmosis.</p>
+
+<h3>32.2 Esguince de tobillo</h3>
+<ul>
+  <li><strong>Lesión más frecuente del aparato locomotor.</strong></li>
+  <li>Mecanismo: <strong>inversión forzada</strong> → primero el <em>ligamento peroneo-astragalino anterior (PAA)</em>.</li>
+  <li><strong>Criterios de Ottawa</strong> para Rx (dolor borde posterior maleolos, base 5º MT/escafoides, o imposibilidad de apoyo).</li>
+  <li>Tratamiento <strong>funcional</strong> (vendaje, ortesis, carga progresiva).</li>
+</ul>
+
+<h3>32.3 Fractura del astrágalo</h3>
+<ul>
+  <li>Alta energía · pobre vascularización → <strong>alto riesgo NAV</strong> del cuerpo (Hawkins II-IV).</li>
+  <li>ORIF con tornillos.</li>
+</ul>
+
+<h3>32.4 Fractura de calcáneo</h3>
+<div class="box box-warning">
+  <div class="box-title"><span class="icon">🦶</span>Caída desde altura</div>
+  <p style="margin:4px 0"><strong>Siempre buscar fracturas vertebrales asociadas</strong> (hasta 10 %, sobre todo lumbares) → Rx columna.</p>
+  <p style="margin:4px 0">Ángulo de Böhler disminuido (normal 25-40°).</p>
+  <p style="margin:4px 0">Tratamiento: conservador en no desplazadas; ORIF con placa en desplazadas con afectación articular.</p>
+</div>
+
+<h3>32.5 Lesiones del antepié</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Fractura de Jones (5º MT)</span><span class="v">Metáfisis-diáfisis · alto riesgo de no unión · cirugía en deportistas</span></div>
+  <div class="kv"><span class="k">Avulsión de la base del 5º MT</span><span class="v">Tracción del peroneo lateral corto · conservador</span></div>
+  <div class="kv"><span class="k">Fractura de marcha</span><span class="v">Por estrés del 2º/3er MT (recluta militar) · Rx puede ser normal · gammagrafía/RMN diagnostican · conservador</span></div>
+  <div class="kv"><span class="k">Luxación tarsometatarsiana (Lisfranc)</span><span class="v">Carga axial + flexión plantar · inestable → ORIF</span></div>
+</div>
+
+<h3>32.6 Movimientos del pie</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Tibiotarsiana (tobillo)</span><span class="v">Flexión dorsal y plantar</span></div>
+  <div class="kv"><span class="k">Subastragalina</span><span class="v">Inversión y eversión</span></div>
+  <div class="kv"><span class="k">Mediotarsiana</span><span class="v">Combinación</span></div>
+</div>
+</section>
+
+<!-- =============== TEMA 33: Inmovilizaciones =============== -->
+<section class="card" id="t33">
+<h2 class="section-title"><span class="num">33</span>Inmovilizaciones</h2>
+
+<h3>33.1 Tipos</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Yeso cerrado/cilíndrico</span><span class="v">Tras el edema inicial</span></div>
+  <div class="kv"><span class="k">Yeso abierto</span><span class="v">Primeros días, con vendaje compresivo</span></div>
+  <div class="kv"><span class="k">Férulas (splints)</span><span class="v">Yeso parcial, no circunferencial · permite edema · fase aguda</span></div>
+  <div class="kv"><span class="k">Ortesis funcional</span><span class="v">Sarmiento (húmero, tibia)</span></div>
+  <div class="kv"><span class="k">Vendaje funcional</span><span class="v">Esguinces, tendinitis</span></div>
+  <div class="kv"><span class="k">Fijación externa</span><span class="v">Fracturas abiertas, conminutas, infectadas</span></div>
+</div>
+
+<h3>33.2 Reglas básicas</h3>
+<ol>
+  <li><strong>Inmovilizar la articulación proximal y distal</strong> a la fractura.</li>
+  <li>En posición funcional.</li>
+  <li>Acolchado adecuado y vigilar zonas de presión.</li>
+  <li><strong>Vigilancia neurovascular postaplicación</strong>: pulso, sensibilidad, motilidad, color, temperatura.</li>
+  <li>Elevación del miembro las primeras 48 h.</li>
+  <li><strong>Educación al paciente:</strong>
+    <ul>
+      <li>Acudir si dolor en aumento, parestesias, palidez, frialdad, cianosis (¡síndrome compartimental!).</li>
+      <li>No introducir objetos para rascarse.</li>
+      <li>No mojar (yeso convencional).</li>
+    </ul>
+  </li>
+  <li>Movilizar las articulaciones libres (dedos, hombro) para prevenir rigidez.</li>
+</ol>
+
+<h3>33.3 Complicaciones</h3>
+<div class="kv-grid">
+  <div class="kv"><span class="k">Síndrome compartimental</span><span class="v">Yesos demasiado apretados</span></div>
+  <div class="kv"><span class="k">Lesiones por presión</span><span class="v">Úlceras</span></div>
+  <div class="kv"><span class="k">Rigidez articular y atrofia muscular</span><span class="v">—</span></div>
+  <div class="kv"><span class="k">TVP</span><span class="v">Especialmente en MMII e inmovilización prolongada</span></div>
+  <div class="kv"><span class="k">SDRC (Sudeck)</span><span class="v">—</span></div>
+  <div class="kv"><span class="k">Dermatitis · pseudoartrosis</span><span class="v">—</span></div>
+</div>
+
+<h3>33.4 Duración orientativa</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Localización</th><th>Duración</th></tr></thead>
+<tbody>
+<tr><td>Antebrazo distal (Colles)</td><td>4-6 semanas</td></tr>
+<tr><td>Húmero (Sarmiento)</td><td>6-8 semanas</td></tr>
+<tr><td>Fémur diafisario</td><td>No con yeso normalmente (clavo IM)</td></tr>
+<tr><td>Tibia (conservador)</td><td>8-12 semanas</td></tr>
+<tr><td>Tobillo (Weber A estable)</td><td>4-6 semanas</td></tr>
+<tr><td>Metacarpianos</td><td>4 semanas</td></tr>
+</tbody></table></div>
+</section>
+
+<!-- =============== FINAL =============== -->
+<section class="card" id="final" style="background:linear-gradient(135deg,#eff6ff,#dbeafe);border:2px solid var(--primary);">
+<h2 class="section-title"><span class="num">⭐</span>Consejos finales — cómo usar este skrypt</h2>
+
+<ol style="font-size:15px;line-height:1.8">
+  <li><strong>Empieza por el "Resumen exprés" de cada tema</strong> — son los puntos que casi siempre caen.</li>
+  <li><strong>Memoriza las tablas comparativas</strong> (AR vs OA · ES limitada vs difusa · cristales gota vs CPPD · Scadding · Gustilo · Garden · Weber · Salter-Harris).</li>
+  <li><strong>Asocia cada autoanticuerpo con una imagen mental:</strong>
+    <ul>
+      <li>anti-DNAn = riñón en LES</li>
+      <li>anti-Sm = LES</li>
+      <li>anti-Ro = subagudo + bloqueo AV neonatal</li>
+      <li>anti-centrómero = CREST</li>
+      <li>anti-Scl-70 = ES difusa</li>
+      <li>anti-Jo-1 = manos de mecánico + EPI</li>
+      <li>c-ANCA = Wegener/GPA</li>
+      <li>p-ANCA = PAM y GEPA</li>
+    </ul>
+  </li>
+  <li><strong>Practica con las preguntas resueltas</strong> al final de cada tema — son tus mejores predictores.</li>
+</ol>
+
+<div class="box box-mnemo">
+  <div class="box-title"><span class="icon">🧠</span>Reglas mnemotécnicas que valen oro</div>
+  <ul style="margin:6px 0">
+    <li><strong>HCQ a TODO LES.</strong></li>
+    <li><strong>Fiebre en EAS bajo inmunosupresor → infección primero.</strong></li>
+    <li><strong>Dolor abdominal en LES activo → vasculitis intestinal.</strong></li>
+    <li><strong>Mujer con disnea + ES limitada de años → HAP.</strong></li>
+    <li><strong>Crisis renal esclerodérmica → IECA, NO corticoides.</strong></li>
+    <li><strong>Sjögren con parotidomegalia unilateral persistente → linfoma MALT.</strong></li>
+    <li><strong>Síndrome antisintetasa = miositis + EPI + Raynaud + artritis + manos de mecánico + anti-Jo-1.</strong></li>
+    <li><strong>EMTC = anti-RNP a títulos altos + manos hinchadas + Raynaud ± HAP.</strong></li>
+    <li><strong>GPA = c-ANCA/PR3, sinusitis, nódulos cavitados, "nariz en silla de montar".</strong></li>
+    <li><strong>Behçet = aftas + uveítis + patergia + HLA-B51.</strong></li>
+    <li><strong>Sarcoidosis Löfgren = eritema nudoso + adenopatías hiliares + artritis tobillos → benigno.</strong></li>
+    <li><strong>Schöber = movilidad lumbar; FABER = sacroilíacas; Lachman = LCA.</strong></li>
+    <li><strong>Síndrome compartimental → dolor desproporcionado + fasciotomía urgente.</strong></li>
+    <li><strong>Embolia grasa → petequias + hipoxemia + confusión a las 24-72 h tras fractura de huesos largos.</strong></li>
+    <li><strong>Garden III-IV → artroplastia; Garden I-II → tornillos canulados.</strong></li>
+    <li><strong>Cadera traumática posterior → miembro en aducción, flexión y rotación INTERNA.</strong></li>
+    <li><strong>Luxación de rodilla → descartar lesión de poplítea.</strong></li>
+    <li><strong>Fractura de calcáneo → buscar fractura vertebral asociada.</strong></li>
+  </ul>
+</div>
+
+<div class="box box-tip">
+  <div class="box-title"><span class="icon">💪</span>Mensaje final</div>
+  <p style="margin:0;font-size:15px"><strong>¡Mucha suerte, Jan!</strong> Con dedicación y constancia, este examen es absolutamente superable. Si organizas el estudio bloque a bloque, dedicando 2-3 días a cada bloque grande, y haces 2-3 pasadas (lectura inicial → repaso con preguntas → resumen final), llegarás al examen con la materia controlada. ¡Vamos!</p>
+</div>
+</section>
+
+</main>
+</div>
+
+<footer>
+  Documento preparado a partir de los apuntes del prof. Norberto Ortego Centeno (UGR · Dpto. Medicina), presentaciones del bloque de Traumatología (UGR), recopilaciones de preguntas Wuolah con respuestas, MIR 2020-2025, seminarios v.Sabat y bibliografía estándar (Harrison, Rozman, Farreras, Campbell's Operative Orthopaedics, EULAR/ACR guidelines).
+</footer>
+
+<script src="script.js"></script>
+
+</body>
+</html>

--- a/jasiu/granada/osteoarticular-sistemicas/script.js
+++ b/jasiu/granada/osteoarticular-sistemicas/script.js
@@ -1,0 +1,68 @@
+// Filtro del índice
+(function () {
+  var search = document.getElementById('tocSearch');
+  if (!search) return;
+  search.addEventListener('input', function () {
+    var q = this.value.toLowerCase().trim();
+    var list = document.querySelectorAll('#tocList li');
+    list.forEach(function (li) {
+      if (li.classList.contains('group-title')) { li.style.display = ''; return; }
+      var txt = (li.textContent || '').toLowerCase();
+      li.style.display = (!q || txt.indexOf(q) >= 0) ? '' : 'none';
+    });
+  });
+})();
+
+// TOC plegable en móvil
+(function () {
+  var sidebar = document.querySelector('.sidebar');
+  if (!sidebar) return;
+  var h3 = sidebar.querySelector('h3');
+  if (!h3) return;
+
+  var mq = window.matchMedia('(max-width: 1100px)');
+
+  function applyState() {
+    if (mq.matches) {
+      sidebar.classList.add('is-collapsible');
+      h3.setAttribute('role', 'button');
+      h3.setAttribute('tabindex', '0');
+      h3.setAttribute('aria-expanded', sidebar.classList.contains('is-open') ? 'true' : 'false');
+    } else {
+      sidebar.classList.remove('is-collapsible');
+      sidebar.classList.remove('is-open');
+      h3.removeAttribute('role');
+      h3.removeAttribute('tabindex');
+      h3.removeAttribute('aria-expanded');
+    }
+  }
+
+  function toggle() {
+    if (!mq.matches) return;
+    var nowOpen = !sidebar.classList.contains('is-open');
+    sidebar.classList.toggle('is-open', nowOpen);
+    h3.setAttribute('aria-expanded', nowOpen ? 'true' : 'false');
+  }
+
+  h3.addEventListener('click', toggle);
+  h3.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    }
+  });
+
+  // Auto-close after clicking a TOC link on mobile
+  sidebar.addEventListener('click', function (e) {
+    if (!mq.matches) return;
+    var a = e.target.closest && e.target.closest('a');
+    if (a && sidebar.contains(a)) {
+      sidebar.classList.remove('is-open');
+      h3.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  if (mq.addEventListener) mq.addEventListener('change', applyState);
+  else if (mq.addListener) mq.addListener(applyState);
+  applyState();
+})();

--- a/jasiu/granada/osteoarticular-sistemicas/style.css
+++ b/jasiu/granada/osteoarticular-sistemicas/style.css
@@ -1,0 +1,560 @@
+/* Palette: Atomic Tangerine · Peach Glow · Beige · Steel Azure · Baltic Blue */
+:root {
+  /* Original brand variables remapped to the new palette */
+  --navy:#002d52;          /* deeper than steel-azure for gradient depth */
+  --primary:#004e89;       /* steel-azure */
+  --primary-dark:#003a6b;  /* between navy and steel-azure */
+  --primary-mid:#1a659e;   /* baltic-blue */
+  --secondary:#1a659e;     /* baltic-blue */
+  --sky:#ff6b35;           /* atomic-tangerine (bold orange accent!) */
+  --light:#fce6d3;         /* pale peach-glow tint */
+  --lighter:#fef4ea;       /* paler still */
+  --bg:#fdfbf2;            /* very pale warm white with beige tint */
+  --card:#ffffff;
+  --text:#0f172a;
+  --muted:#5c6573;
+  --border:#d4d4ad;        /* beige-leaning border */
+  --soft-border:#e6e6c8;   /* beige soft border */
+  --amber:#f59e0b;
+  --amber-light:#fef3c7;
+  --green:#10b981;
+  --green-light:#d1fae5;
+  --red:#dc2626;
+  --red-light:#fee2e2;
+  --purple:#7c3aed;
+}
+
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{
+  margin:0;
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  background:var(--bg);
+  color:var(--text);
+  line-height:1.65;
+  font-size:15.5px;
+}
+
+/* ===== HEADER ===== */
+.hero{
+  background:linear-gradient(135deg,var(--navy) 0%,var(--primary) 50%,var(--secondary) 100%);
+  color:#fff;
+  padding:48px 40px 56px;
+  box-shadow:0 8px 28px rgba(0,45,82,.30);
+}
+.hero h1{
+  margin:0 0 8px;
+  font-size:38px;
+  font-weight:700;
+  letter-spacing:-.5px;
+}
+.hero .subtitle{
+  font-size:17px;
+  opacity:.93;
+  margin-bottom:18px;
+}
+.hero-meta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  margin-top:18px;
+}
+.chip{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  background:rgba(255,255,255,.15);
+  border:1px solid rgba(255,255,255,.3);
+  padding:6px 14px;
+  border-radius:20px;
+  font-size:13px;
+  backdrop-filter:blur(4px);
+}
+
+/* ===== LAYOUT ===== */
+.wrap{
+  display:grid;
+  grid-template-columns:280px 1fr;
+  gap:24px;
+  max-width:1400px;
+  margin:0 auto;
+  padding:24px 32px 80px;
+}
+@media (max-width:1100px){
+  .wrap{grid-template-columns:1fr;padding:16px}
+  .sidebar{position:static;max-height:none}
+
+  /* Collapsible TOC on mobile/tablet */
+  .sidebar.is-collapsible h3{
+    cursor:pointer;user-select:none;display:flex;align-items:center;
+    justify-content:space-between;gap:8px;margin-bottom:0;
+    border-bottom:none;padding-bottom:0;
+  }
+  .sidebar.is-collapsible h3::after{
+    content:"▼";font-size:11px;color:var(--primary);
+    transition:transform .25s ease;flex-shrink:0;
+  }
+  .sidebar.is-collapsible.is-open h3{
+    margin-bottom:12px;padding-bottom:8px;border-bottom:2px solid var(--light);
+  }
+  .sidebar.is-collapsible.is-open h3::after{transform:rotate(180deg)}
+  .sidebar.is-collapsible h3:hover{color:var(--primary)}
+  .sidebar.is-collapsible h3:focus-visible{outline:2px solid var(--primary);outline-offset:2px;border-radius:4px}
+
+  .sidebar.is-collapsible > .toc-search,
+  .sidebar.is-collapsible > ol{display:none}
+  .sidebar.is-collapsible.is-open > .toc-search{display:block}
+  .sidebar.is-collapsible.is-open > ol{display:block}
+}
+
+/* ===== SIDEBAR ===== */
+.sidebar{
+  position:sticky;
+  top:16px;
+  align-self:start;
+  max-height:calc(100vh - 32px);
+  overflow-y:auto;
+  background:var(--card);
+  border:1px solid var(--soft-border);
+  border-radius:14px;
+  padding:18px 16px;
+  box-shadow:0 2px 12px rgba(0,45,82,.08);
+}
+.sidebar h3{
+  margin:0 0 12px;
+  color:var(--primary-dark);
+  font-size:13px;
+  text-transform:uppercase;
+  letter-spacing:1.2px;
+  border-bottom:2px solid var(--light);
+  padding-bottom:8px;
+}
+.sidebar ol{
+  list-style:none;
+  padding:0;
+  margin:0;
+  counter-reset:item;
+}
+.sidebar li{
+  font-size:13.5px;
+  margin:2px 0;
+}
+.sidebar a{
+  color:var(--muted);
+  text-decoration:none;
+  display:block;
+  padding:5px 8px;
+  border-radius:6px;
+  border-left:3px solid transparent;
+  transition:all .15s;
+}
+.sidebar a:hover{
+  background:var(--lighter);
+  color:var(--primary);
+  border-left-color:var(--primary);
+}
+.sidebar .group-title{
+  font-weight:700;
+  color:var(--navy);
+  font-size:11.5px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  margin:14px 0 4px 8px;
+  padding-top:8px;
+  border-top:1px dashed var(--border);
+}
+.sidebar .group-title:first-of-type{border-top:none;padding-top:0}
+
+/* ===== MAIN ===== */
+main{min-width:0}
+
+/* ===== BLOQUE BANNER ===== */
+.bloque-banner{
+  background:linear-gradient(120deg,var(--primary-dark),var(--primary));
+  color:#fff;
+  padding:24px 28px;
+  border-radius:14px;
+  margin:32px 0 24px;
+  box-shadow:0 4px 18px rgba(0,78,137,.28);
+}
+.bloque-banner h2{margin:0;font-size:26px;font-weight:700}
+.bloque-banner .b-sub{opacity:.9;font-size:14px;margin-top:4px}
+
+/* ===== SECTIONS / CARDS ===== */
+.card{
+  background:var(--card);
+  border:1px solid var(--soft-border);
+  border-radius:14px;
+  padding:28px 32px;
+  margin:0 0 24px;
+  box-shadow:0 2px 10px rgba(0,45,82,.06);
+  scroll-margin-top:16px;
+}
+.card h2.section-title{
+  margin:0 0 6px;
+  color:var(--primary-dark);
+  font-size:24px;
+  font-weight:700;
+  letter-spacing:-.3px;
+  display:flex;
+  align-items:center;
+  gap:12px;
+}
+.card h2.section-title .num{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:36px;
+  height:36px;
+  background:linear-gradient(135deg,var(--primary),var(--sky));
+  color:#fff;
+  border-radius:10px;
+  font-size:16px;
+  font-weight:700;
+  flex-shrink:0;
+}
+.card h3{
+  color:var(--primary-dark);
+  font-size:18px;
+  margin:24px 0 10px;
+  padding-left:12px;
+  border-left:4px solid var(--secondary);
+}
+.card h4{
+  color:var(--primary);
+  font-size:16px;
+  margin:18px 0 8px;
+}
+
+/* ===== CALLOUT BOXES ===== */
+.box{
+  border-radius:12px;
+  padding:16px 20px;
+  margin:14px 0;
+  position:relative;
+  border-left:5px solid;
+}
+.box-title{
+  font-weight:700;
+  font-size:13px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  margin-bottom:8px;
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+.box-title .icon{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:24px;
+  height:24px;
+  border-radius:50%;
+  font-size:14px;
+  font-weight:700;
+}
+
+.box-resumen{
+  background:var(--lighter);
+  border-left-color:var(--primary);
+}
+.box-resumen .box-title{color:var(--primary-dark)}
+.box-resumen .icon{background:var(--primary);color:#fff}
+
+.box-clave{
+  background:#fff1e8;
+  border-left-color:var(--sky);
+}
+.box-clave .box-title{color:#cc4a1f}
+.box-clave .icon{background:var(--sky);color:#fff}
+
+.box-mnemo{
+  background:#fffbeb;
+  border-left-color:var(--amber);
+}
+.box-mnemo .box-title{color:#b45309}
+.box-mnemo .icon{background:var(--amber);color:#fff}
+
+.box-warning{
+  background:var(--red-light);
+  border-left-color:var(--red);
+}
+.box-warning .box-title{color:#991b1b}
+.box-warning .icon{background:var(--red);color:#fff}
+
+.box-tip{
+  background:var(--green-light);
+  border-left-color:var(--green);
+}
+.box-tip .box-title{color:#065f46}
+.box-tip .icon{background:var(--green);color:#fff}
+
+.box ul{margin:6px 0;padding-left:22px}
+.box li{margin:4px 0}
+
+/* ===== TABLES ===== */
+.table-wrap{overflow-x:auto;margin:14px 0;border-radius:10px;border:1px solid var(--soft-border)}
+table{
+  width:100%;
+  border-collapse:collapse;
+  font-size:14px;
+  background:#fff;
+}
+table th{
+  background:linear-gradient(135deg,var(--primary-dark),var(--primary));
+  color:#fff;
+  padding:11px 12px;
+  text-align:left;
+  font-weight:600;
+  font-size:13px;
+  letter-spacing:.3px;
+}
+table td{
+  padding:10px 12px;
+  border-top:1px solid var(--soft-border);
+  vertical-align:top;
+}
+table tr:nth-child(even) td{background:var(--lighter)}
+table tr:hover td{background:#fbe2cd}
+
+/* ===== QUESTIONS BLOCK ===== */
+details.qa{
+  background:var(--card);
+  border:1px solid var(--soft-border);
+  border-radius:10px;
+  margin:10px 0;
+  overflow:hidden;
+  transition:all .2s;
+}
+details.qa[open]{
+  border-color:var(--secondary);
+  box-shadow:0 2px 12px rgba(26,101,158,.18);
+}
+details.qa summary{
+  cursor:pointer;
+  padding:12px 16px;
+  font-weight:600;
+  color:var(--primary-dark);
+  background:var(--lighter);
+  list-style:none;
+  display:flex;
+  align-items:center;
+  gap:10px;
+  font-size:14px;
+}
+details.qa summary::-webkit-details-marker{display:none}
+details.qa summary::before{
+  content:"▶";
+  font-size:10px;
+  color:var(--secondary);
+  transition:transform .2s;
+}
+details.qa[open] summary::before{transform:rotate(90deg)}
+details.qa summary:hover{background:#fce6d3}
+.qa-body{padding:14px 18px;font-size:14.5px}
+.qa-body .answer{
+  margin-top:8px;
+  padding:10px 14px;
+  background:var(--green-light);
+  border-left:4px solid var(--green);
+  border-radius:6px;
+}
+.qa-body .answer strong{color:#065f46}
+
+/* "Quick" question chip - inline format */
+.q{
+  background:var(--lighter);
+  border:1px solid var(--light);
+  border-radius:8px;
+  padding:10px 14px;
+  margin:8px 0;
+  font-size:14.2px;
+}
+.q .q-tag{
+  display:inline-block;
+  background:var(--primary);
+  color:#fff;
+  font-size:11px;
+  font-weight:700;
+  padding:2px 8px;
+  border-radius:4px;
+  margin-right:6px;
+  letter-spacing:.5px;
+}
+.q strong.correct{
+  color:#065f46;
+  background:var(--green-light);
+  padding:1px 6px;
+  border-radius:4px;
+}
+
+/* ===== KEY/VALUE GRID ===== */
+.kv-grid{
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+  gap:10px;
+  margin:14px 0;
+}
+.kv{
+  background:var(--lighter);
+  border:1px solid var(--light);
+  border-radius:8px;
+  padding:10px 14px;
+}
+.kv .k{
+  display:block;
+  font-size:11.5px;
+  text-transform:uppercase;
+  letter-spacing:1px;
+  color:var(--primary);
+  font-weight:700;
+  margin-bottom:3px;
+}
+.kv .v{font-size:14px;color:var(--text)}
+
+/* ===== INLINE ELEMENTS ===== */
+strong{color:var(--navy);font-weight:700}
+em{color:var(--primary-mid);font-style:normal;font-weight:600}
+code{
+  background:var(--light);
+  color:var(--navy);
+  padding:1px 6px;
+  border-radius:4px;
+  font-size:.93em;
+  font-family:"SF Mono","Monaco","Consolas",monospace;
+}
+.tag{
+  display:inline-block;
+  padding:1px 8px;
+  background:var(--primary);
+  color:#fff;
+  border-radius:4px;
+  font-size:12px;
+  font-weight:600;
+  margin:0 2px;
+}
+.tag.danger{background:var(--red)}
+.tag.warn{background:var(--amber)}
+.tag.ok{background:var(--green)}
+
+ul,ol{padding-left:24px}
+li{margin:3px 0}
+
+hr{
+  border:none;
+  height:1px;
+  background:linear-gradient(90deg,transparent,var(--border),transparent);
+  margin:30px 0;
+}
+
+/* ===== FOOTER ===== */
+footer{
+  text-align:center;
+  padding:30px 16px;
+  color:var(--muted);
+  font-size:13px;
+  border-top:1px solid var(--soft-border);
+  margin-top:40px;
+}
+
+/* ===== PRINT ===== */
+@media print{
+  .sidebar{display:none}
+  .wrap{grid-template-columns:1fr;padding:0}
+  .card{box-shadow:none;page-break-inside:avoid;border:1px solid #ccc}
+  .hero{background:#003a6b !important;-webkit-print-color-adjust:exact;print-color-adjust:exact}
+  details.qa[open] .qa-body{display:block}
+  details.qa summary::before{display:none}
+  details.qa{page-break-inside:avoid}
+}
+
+/* ===== UTILITIES ===== */
+.center{text-align:center}
+.muted{color:var(--muted)}
+.small{font-size:13px}
+.flex{display:flex;gap:10px;flex-wrap:wrap}
+
+/* ===== TWO-COLUMN COMPARISON ===== */
+.compare{
+  display:grid;
+  grid-template-columns:1fr 1fr;
+  gap:14px;
+  margin:14px 0;
+}
+.compare > div{
+  background:var(--lighter);
+  border:1px solid var(--light);
+  border-radius:10px;
+  padding:14px 16px;
+}
+.compare h4{margin-top:0;margin-bottom:8px}
+.compare ul{margin:0;padding-left:20px}
+@media (max-width:700px){
+  body{font-size:14.5px;line-height:1.6}
+  .hero{padding:28px 18px 32px}
+  .hero h1{font-size:24px;letter-spacing:-.3px}
+  .hero .subtitle{font-size:13px;margin-bottom:12px}
+  .hero-meta{gap:6px;margin-top:12px}
+  .chip{font-size:11px;padding:4px 9px;gap:4px}
+  .wrap{padding:12px 10px 50px;gap:14px}
+  .sidebar{padding:12px 10px;border-radius:10px;max-height:none;position:static}
+  .sidebar h3{font-size:12px;margin-bottom:8px}
+  .sidebar li{font-size:13px}
+  .sidebar a{padding:6px 8px}
+  .bloque-banner{padding:16px 16px;margin:22px 0 16px;border-radius:10px}
+  .bloque-banner h2{font-size:19px}
+  .bloque-banner .b-sub{font-size:13px}
+  .card{padding:18px 14px;border-radius:10px;margin:0 0 16px}
+  .card h2.section-title{font-size:18px;gap:8px}
+  .card h2.section-title .num{width:28px;height:28px;font-size:13px;border-radius:7px}
+  .card h3{font-size:15.5px;margin:18px 0 8px;padding-left:10px;border-left-width:3px}
+  .card h4{font-size:14.5px;margin:14px 0 6px}
+  .box{padding:12px 14px;margin:10px 0;border-radius:9px;border-left-width:4px}
+  .box-title{font-size:12px;letter-spacing:.6px}
+  .box-title .icon{width:20px;height:20px;font-size:12px}
+  .box ul{padding-left:18px}
+  table{font-size:13px}
+  table th{padding:8px 9px;font-size:12px}
+  table td{padding:8px 9px}
+  details.qa{margin:8px 0;border-radius:8px}
+  details.qa summary{padding:10px 12px;font-size:13.2px;gap:8px}
+  .qa-body{padding:12px 14px;font-size:13.5px}
+  .q{padding:9px 12px;font-size:13.5px}
+  .kv-grid{grid-template-columns:1fr;gap:8px}
+  .kv{padding:9px 12px}
+  .compare{grid-template-columns:1fr;gap:10px}
+  .compare > div{padding:12px 14px}
+  footer{padding:22px 12px;font-size:12.5px;margin-top:24px}
+}
+
+/* ===== TOC HEADER ===== */
+.toc-search{
+  position:relative;
+  margin-bottom:10px;
+}
+.toc-search input{
+  width:100%;
+  padding:8px 10px 8px 30px;
+  border:1px solid var(--border);
+  border-radius:8px;
+  font-size:13px;
+}
+.toc-search::before{
+  content:"🔍";
+  position:absolute;
+  left:8px;
+  top:50%;
+  transform:translateY(-50%);
+  font-size:12px;
+  opacity:.6;
+}
+
+/* Anchor offset for fixed header */
+:target{
+  animation:flash 1.2s ease;
+}
+@keyframes flash{
+  0%{background:#fef3c7}
+  100%{background:transparent}
+}

--- a/jasiu/granada/urinaria-infecciosas/index.html
+++ b/jasiu/granada/urinaria-infecciosas/index.html
@@ -1,0 +1,8255 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Skrypt — Patología Urinaria y Enfermedades Infecciosas</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="hero">
+  <h1>🩺 Patología Urinaria y Enfermedades Infecciosas</h1>
+  <div class="subtitle">Apuntes integrales · Universidad de Granada · 4º Grado en Medicina</div>
+  <div class="hero-meta">
+    <span class="chip">🎓 Para: Jan Fedak</span>
+    <span class="chip">📅 Convocatoria 2026</span>
+    <span class="chip">🧪 32 Urología</span>
+    <span class="chip">🫘 25 Nefrología</span>
+    <span class="chip">🦠 43 Enf. Infecciosas</span>
+    <span class="chip">❓ +200 preguntas resueltas (Ordinaria + Extraordinaria 2025)</span>
+  </div>
+</header>
+
+<div class="wrap">
+
+<nav class="sidebar" id="toc">
+<h3>Índice general</h3>
+<div class="toc-search"><input id="tocSearch" type="text" placeholder="Buscar tema..." aria-label="Buscar tema"></div>
+<ol id="tocList">
+<li class="group-title">Bloque A · Urología</li>
+<li><a href="#u1">U1. Anomalías riñón y tracto superior</a></li>
+<li><a href="#u2">U2. Anomalías vesicales y uretrales</a></li>
+<li><a href="#u3">U3. Uropatía obstructiva · hidronefrosis</a></li>
+<li><a href="#u4">U4. Traumatismos renales, ureterales, vesicales</a></li>
+<li><a href="#u5">U5. Trasplante renal</a></li>
+<li><a href="#u6">U6. Tumores del parénquima renal</a></li>
+<li><a href="#u7">U7. Tumores del urotelio · cáncer vesical</a></li>
+<li><a href="#u8">U8. Infecciones urinarias inespecíficas</a></li>
+<li><a href="#u9">U9. TBC urogenital · uretritis · ETS</a></li>
+<li><a href="#u10">U10. Urolitiasis</a></li>
+<li><a href="#u11">U11. Incontinencia urinaria · vejiga hiperactiva</a></li>
+<li><a href="#u12">U12. Vejiga neurógena</a></li>
+<li><a href="#u13">U13. HBP · prostatitis</a></li>
+<li><a href="#u14">U14. Cáncer de próstata</a></li>
+<li><a href="#u15">U15. Aparato genital masculino · criptorquidia</a></li>
+<li><a href="#u16">U16. Uretra y pene · cáncer de pene</a></li>
+<li><a href="#u17">U17. Cáncer de testículo</a></li>
+<li><a href="#u18">U18. Disfunción eréctil · infertilidad</a></li>
+<li><a href="#u19">U19. Retroperitoneo · suprarrenales</a></li>
+
+<li class="group-title">Bloque B · Nefrología</li>
+<li><a href="#n1">N1. Función renal · semiología</a></li>
+<li><a href="#n2">N2. Trastornos hidroelectrolíticos · diuréticos</a></li>
+<li><a href="#n3">N3. Ácido-base · calcio-fósforo</a></li>
+<li><a href="#n4">N4. Síndromes nefróticos/nefríticos</a></li>
+<li><a href="#n5">N5. GN primarias</a></li>
+<li><a href="#n6">N6. GN secundarias</a></li>
+<li><a href="#n7">N7. Nefropatía tubulointersticial · tubulopatías</a></li>
+<li><a href="#n8">N8. Hereditarias · quísticas</a></li>
+<li><a href="#n9">N9. Nefropatía vascular · MAT</a></li>
+<li><a href="#n10">N10. Insuficiencia renal aguda</a></li>
+<li><a href="#n11">N11. Enfermedad renal crónica</a></li>
+<li><a href="#n12">N12. Diálisis y trasplante</a></li>
+
+<li class="group-title">Bloque C · Enf. Infecciosas</li>
+<li><a href="#i1">I1. Sepsis y shock séptico</a></li>
+<li><a href="#i2">I2. Uso de antibióticos</a></li>
+<li><a href="#i3">I3. Intraabdominales · anaerobios</a></li>
+<li><a href="#i4">I4. Piel y partes blandas · fascitis</a></li>
+<li><a href="#i5">I5. Fiebre intermedia · Coxiella, Rickettsia</a></li>
+<li><a href="#i6">I6. Endocarditis</a></li>
+<li><a href="#i7">I7. Neumonías · Legionella</a></li>
+<li><a href="#i8">I8. Gripe · COVID-19</a></li>
+<li><a href="#i9">I9. Viajeros · inmigrantes</a></li>
+<li><a href="#i10">I10. Virus emergentes</a></li>
+<li><a href="#i11">I11. Tétanos · botulismo · Bartonella</a></li>
+<li><a href="#i12">I12. Mononucleosis · herpesvirus</a></li>
+<li><a href="#i13">I13. Hongos</a></li>
+<li><a href="#i14">I14. Leptospira · Borrelia</a></li>
+<li><a href="#i15">I15. Micobacterias</a></li>
+<li><a href="#i16">I16. Cestodos · nematodos</a></li>
+<li><a href="#i17">I17. VIH</a></li>
+
+<li class="group-title">Seminarios</li>
+<li><a href="#sem">S. Seminarios (ITS, SNC, inmunodeprimidos, casos uro)</a></li>
+<li><a href="#final">⭐ Consejos finales</a></li>
+</ol>
+</nav>
+
+<main>
+
+<!-- ============================================================ -->
+<!-- BLOQUE A · UROLOGÍA -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-a">
+  <h2>🧪 BLOQUE A · UROLOGÍA</h2>
+  <div class="b-sub">19 temas · 32 preguntas en el examen · Prof. Arrabal, Cózar y col.</div>
+</div>
+
+<!-- =============== U1 =============== -->
+<section class="card" id="u1">
+<h2 class="section-title"><span class="num">U1</span>Anomalías del riñón y del tracto urinario superior</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las malformaciones urológicas son las más frecuentes del organismo (~ 4 % de RN).</li>
+<li><strong>Etiopatogenia:</strong> alteración en la migración, fusión, división o rotación del blastema metanéfrico y de las yemas ureterales (5ª-8ª semana de embriogénesis).</li>
+<li><strong>Anomalías de número:</strong> agenesia renal (uni- o bilateral — bilateral incompatible con la vida → <em>síndrome de Potter</em>), riñón supernumerario.</li>
+<li><strong>Anomalías de tamaño:</strong> hipoplasia, hiperplasia compensatoria.</li>
+<li><strong>Anomalías de posición:</strong> ectopia renal (pélvica la más frecuente, intratorácica, cruzada).</li>
+<li><strong>Anomalías de fusión:</strong> <em>riñón en herradura</em> (fusión de polos inferiores, 1:400-600, predominio masculino, mayor riesgo de litiasis, ITU, tumor de Wilms, lesión en traumatismos).</li>
+<li><strong>Anomalías de rotación:</strong> malrotación (pelvis hacia anterior o posterior).</li>
+<li><strong>Anomalías quísticas:</strong> quiste simple (lo más frecuente; Bosniak I-IV según ecotomografía/TC), riñón multiquístico displásico (no funcionante, atrofia), poliquistosis renal AD y AR (ver N8).</li>
+<li><strong>Anomalías de la pelvis y uréter:</strong> <em>estenosis de la UPU</em> (causa más frecuente de hidronefrosis congénita), duplicidad pieloureteral, megauréter (obstructivo/refluyente/mixto), ureterocele, uréter retrocavo, divertículos ureterales.</li>
+</ul>
+</div>
+
+<h3>1.1 Embriología útil para entender las anomalías</h3>
+<ul>
+<li>El riñón definitivo (metanefros) se forma a partir del <em>blastema metanéfrico</em> (ureter futuro = yema ureteral, túbulos colectores, cálices, pelvis) + <em>yema ureteral</em> que emerge del conducto mesonéfrico.</li>
+<li>La <em>migración ascendente</em> del riñón ocurre entre la 6ª y 9ª semana. Fallo de migración → riñón pélvico/ectópico.</li>
+<li>Si dos yemas ureterales emergen del conducto mesonéfrico → <em>duplicidad ureteral</em>.</li>
+<li>Si los polos inferiores se fusionan antes de la migración → quedan atrapados por la arteria mesentérica inferior → <em>riñón en herradura</em>.</li>
+</ul>
+
+<h3>1.2 Riñón en herradura</h3>
+<ul>
+<li>Anomalía de fusión más frecuente: 1:400-600 nacimientos, varones 2:1.</li>
+<li>Fusión de polos inferiores por istmo de tejido renal o fibroso, anterior a aorta/cava.</li>
+<li>La migración se detiene cuando el istmo choca con la mesentérica inferior → riñón <em>BAJO</em> y <em>ROTADO</em> (pelvis en posición anterior).</li>
+<li><strong>Clínica:</strong> la mayoría <em>asintomática</em> (hallazgo casual). Mayor incidencia de complicaciones por la disposición anómala:
+  <ul>
+    <li>Estenosis funcional de la UPU → hidronefrosis</li>
+    <li>Litiasis recurrente (40 %)</li>
+    <li>ITU de repetición</li>
+    <li><strong>Mayor riesgo de tumor de Wilms en niños</strong> y de tumores renales en adultos</li>
+    <li>Vulnerabilidad a traumatismos abdominales (posición anterior)</li>
+  </ul>
+</li>
+<li>Asociaciones: síndrome de Turner (XO) en 60 % de las niñas con Turner.</li>
+</ul>
+
+<h3>1.3 Ley de Weigert-Meyer (duplicidad ureteral completa)</h3>
+<div class="box box-clave">
+<div class="box-title"><span class="icon">📐</span>Memorizar</div>
+<p style="margin:4px 0">El <strong>uréter del polo SUPERIOR</strong> desemboca en posición <strong>CAUDAL e INTERNA</strong> en la vejiga (más distal), suele asociarse a <em>ureterocele</em> u obstrucción → dilatación del polo superior.</p>
+<p style="margin:4px 0">El <strong>uréter del polo INFERIOR</strong> desemboca en posición <strong>CEFÁLICA y EXTERNA</strong>, suele asociarse a <em>reflujo vesicoureteral</em> → daño del polo inferior.</p>
+<p style="margin:4px 0">Ecografía postnatal: detecta ambas pelvis renales separadas con dilatación selectiva de un polo.</p>
+</div>
+
+<h3>1.4 Estenosis de la unión pieloureteral (UPU)</h3>
+<ul>
+<li><strong>Causa más frecuente de hidronefrosis congénita.</strong></li>
+<li>Tipos:
+  <ul>
+    <li><em>Intrínseca</em>: segmento aperistáltico, displasia del músculo liso ureteral, válvulas mucosas.</li>
+    <li><em>Extrínseca</em>: vaso polar aberrante (rama de la arteria renal que cruza por delante de la UPU comprimiéndola), bridas fibrosas.</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> diagnóstico prenatal por eco (dilatación pieloureteral), ITU febril, dolor abdominal/lumbar, masa palpable, hipertensión, deterioro de la función renal.</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Ecografía pre y postnatal: dilatación pielocalicial (sistema de la <em>SFU</em> grado I-IV).</li>
+    <li><em>Renograma diurético MAG-3 + furosemida</em>: patrón obstructivo (eliminación T½ &gt; 20 min) y diferencial de función renal.</li>
+    <li>UroTC con reconstrucción.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Observación si dilatación leve (SFU I-II) sin deterioro funcional.</li>
+    <li><strong>Pieloplastia de Anderson-Hynes</strong> (resección del segmento estenótico y reanastomosis pieloureteral) — laparoscópica o robótica. Tasa de éxito &gt; 95 %.</li>
+    <li>Endopielotomía (incisión endoscópica) en casos seleccionados.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>1.5 Megauréter</h3>
+<ul>
+<li>Diámetro ureteral &gt; 7 mm en niños o &gt; 10 mm en adultos.</li>
+<li><strong>Tipos:</strong>
+  <ul>
+    <li><em>Obstructivo primario (estenosis adinámica yuxtavesical)</em>: segmento aperistáltico distal.</li>
+    <li><em>Refluyente</em>: incompetencia del meato vesicoureteral.</li>
+    <li><em>No obstructivo no refluyente</em>: dilatación sin obstrucción ni reflujo (mayoría se resuelve sola).</li>
+    <li><em>Obstructivo y refluyente</em>: combinado, peor pronóstico.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong> observación + profilaxis ATB en megaureteres no obstructivos no refluyentes. Cirugía (<em>reimplantación ureterovesical con remodelaje</em>) en obstructivos sintomáticos o con deterioro funcional.</li>
+</ul>
+
+<h3>1.6 Ureterocele</h3>
+<p>Dilatación quística terminal del uréter intravesical:</p>
+<ul>
+<li><em>Ortotópico/intravesical</em>: dentro de la vejiga, suele ser unilateral, en adulto.</li>
+<li><em>Ectópico</em>: en niños, asociado a duplicidad ureteral del polo superior. Puede prolapsarse por uretra en niñas.</li>
+<li>Clínica: ITU recurrente, hidronefrosis del polo superior, prolapso uretral.</li>
+<li>Tratamiento: incisión endoscópica del ureterocele (descompresión); en formas complejas → cirugía abierta.</li>
+</ul>
+
+<h3>1.7 Reflujo vesicoureteral (RVU)</h3>
+<ul>
+<li>Paso retrógrado de orina desde la vejiga al uréter ± riñón.</li>
+<li><strong>Causa:</strong> incompetencia del mecanismo antirreflujo de la unión ureterovesical (túnel submucoso insuficiente).</li>
+<li><strong>Clasificación CUMS (grados I-V):</strong>
+  <ul>
+    <li>I: orina retrógrada solo en uréter</li>
+    <li>II: hasta pelvis renal sin dilatación</li>
+    <li>III: dilatación leve-moderada de uréter y pelvis</li>
+    <li>IV: dilatación moderada con tortuosidad ureteral</li>
+    <li>V: dilatación masiva + tortuosidad + pérdida de impresiones papilares (alto riesgo de cicatriz renal)</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> ITU febril recurrente, pielonefritis, cicatrices renales (nefropatía por reflujo), HTA, IR.</li>
+<li><strong>Diagnóstico:</strong> <em>CUMS</em> (cistouretrografía miccional seriada) = gold standard.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Bajo grado (I-III): profilaxis ATB + seguimiento (mayoría resuelve espontáneamente con el crecimiento).</li>
+    <li>Alto grado (IV-V) o ITU de ruptura bajo profilaxis: inyección endoscópica de Deflux subureteral o reimplantación quirúrgica (Cohen, Lich-Gregoir).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>1.8 Hidronefrosis bilateral fetal/neonatal — diagnóstico diferencial</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Entidad</th><th>Sexo</th><th>Vejiga</th><th>Líquido amniótico</th><th>Diagnóstico</th></tr></thead>
+<tbody>
+<tr><td><strong>VUP</strong></td><td>Varón exclusivo</td><td>Distendida + pared engrosada</td><td>Oligohidramnios</td><td>CUMS</td></tr>
+<tr><td>RVU bilateral grave</td><td>Ambos</td><td>Normal</td><td>Normal</td><td>CUMS</td></tr>
+<tr><td>Megauréter obstructivo bilateral</td><td>Ambos</td><td>Normal</td><td>Normal</td><td>Eco + MAG-3</td></tr>
+<tr><td>Ureterocele bilateral</td><td>Más en niñas</td><td>Normal</td><td>Normal</td><td>Eco + CUMS</td></tr>
+<tr><td>Estenosis UPU bilateral</td><td>Ambos</td><td>Normal</td><td>Normal</td><td>Eco + MAG-3</td></tr>
+</tbody></table></div>
+
+<div class="box box-mnemo">
+<div class="box-title"><span class="icon">🧠</span>Regla útil</div>
+<p style="margin:0">Lactante <strong>VARÓN</strong> con hidronefrosis bilateral + <strong>vejiga distendida con pared engrosada</strong> + ITU + oligohidramnios prenatal = <strong>VUP hasta demostrar lo contrario</strong>.</p>
+</div>
+
+<h3>1.9 Preguntas — U1</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Lactante varón con ITU + hidronefrosis bilateral + vejiga poco distendida</summary>
+<div class="qa-body">
+<p>Paciente varón de 4 meses que ingresa con fiebre de 39 ºC. Urocultivo positivo para <em>E. coli</em>. Ecografía abdominal: hidronefrosis bilateral, vejiga poco distendida. ¿Diagnóstico diferencial más probable?</p>
+<ol type="a">
+<li>Ureterocele bilateral</li>
+<li>Megauréter obstructivo y refluyente</li>
+<li>Reflujo vesicoureteral</li>
+<li><strong>Válvulas de uretra posterior</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> <em>Lactante VARÓN + hidronefrosis bilateral + ITU</em> = VUP hasta demostrar lo contrario. Pedir CUMS urgente. Suelen detectarse en ecografía prenatal. Tratamiento: fulguración endoscópica.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Ley de Weigert-Meyer</summary>
+<div class="qa-body">
+<p>En los casos de duplicidad pieloureteral completa, según la Ley de Weigert-Meyer, la localización de los orificios ureterales en vejiga es:</p>
+<ol type="a">
+<li>El orificio más cefálico y externo procede del polo superior, mientras que el más caudal e interno drena la orina del polo inferior</li>
+<li><strong>El orificio más cefálico y externo procede del polo inferior, mientras que el más caudal e interno drena la orina del polo superior renal</strong></li>
+<li>El orificio más cefálico e interno procede del polo inferior, mientras que el más caudal y externo drena la orina del polo superior renal</li>
+<li>El orificio más cefálico e interno procede del polo superior, mientras que el más caudal y externo drena la orina del polo inferior renal</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> <em>Polo SUPERIOR → caudal e interno</em> (suele obstruirse, ureterocele). <em>Polo INFERIOR → cefálico y externo</em> (suele refluir).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Gestante 32 sem con dilatación pélvica fetal bilateral + vejiga distendida</summary>
+<div class="qa-body">
+<p>Mujer en 32 semana de gestación, en control obstétrico se detecta desarrollo fetal normal pero con dilatación moderada de ambas pelvis renales y vejiga distendida, aceptable cantidad de líquido amniótico. Tras parto se colocó sonda vesical al recién nacido. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Megauréter refluyente bilateral</li>
+<li><strong>Válvulas de uretra posterior</strong></li>
+<li>Reflujo vesicoureteral</li>
+<li>Hidronefrosis congénita bilateral y atonía vesical</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> <em>Vejiga distendida</em> en feto + hidronefrosis bilateral = VUP en varón. La sonda vesical resuelve temporalmente la obstrucción.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Lactante varón con ITU + hidronefrosis bilateral (variante)</summary>
+<div class="qa-body">
+<p>Paciente varón de 5 meses con ITU por <em>E. coli</em>. Eco: hidronefrosis bilateral, vejiga poco distendida. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>Reflujo vesicoureteral</strong></li>
+<li>Megauréter obstructivo y refluyente</li>
+<li>Ureterocele bilateral</li>
+<li>Las respuestas a y c son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a (banco).</strong> En la variante donde la vejiga es <em>poco</em> distendida (no engrosada), el RVU bilateral grave es muy plausible. La VUP típicamente da vejiga gruesa y trabeculada. Si la opción VUP estuviera disponible, sería preferida.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Recién nacido con dilatación renal bilateral postnatal + parénquima disminuido</summary>
+<div class="qa-body">
+<p>Séptimo mes de gestación: dilatación bilateral de pelvis renal con líquido amniótico normal. Tras parto: ureterohidronefrosis bilateral con parénquima renal disminuido, vejiga normal. ¿Diagnóstico?</p>
+<ol type="a">
+<li><strong>Reflujo vesicoureteral grado IV</strong></li>
+<li>Reflujo vesicoureteral grado II</li>
+<li>Megauréter obstructivo</li>
+<li>Válvulas de uretra posterior</li>
+</ol>
+<div class="answer"><strong>Respuesta: a (banco).</strong> <em>Vejiga normal</em> excluye VUP. La dilatación ureteral + pieloureteral con parénquima disminuido sugiere RVU grado IV (con dilatación marcada). VUP daría vejiga engrosada.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U2 =============== -->
+<section class="card" id="u2">
+<h2 class="section-title"><span class="num">U2</span>Anomalías vesicales y uretrales</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Anomalías vesicales:</strong> extrofia vesical, persistencia del uraco, divertículos congénitos, vejiga doble, anomalías de la cúpula y trígono.</li>
+<li><strong>Persistencia del uraco:</strong> conexión vejiga ↔ ombligo. Tipos: fístula completa, quiste, divertículo vesical-uracal, seno umbilical. Riesgo de <em>adenocarcinoma de uraco</em> en adultos.</li>
+<li><strong>Persistencia del seno urogenital / cloaca:</strong> ambigüedad genital femenina (XX) con un solo orificio perineal (seno) o solo uno (cloaca). Asociadas a hiperplasia suprarrenal congénita.</li>
+<li><strong>Válvulas de uretra posterior (VUP):</strong> obstrucción del recién nacido varón (1:5000), descrita en U1 — exclusiva del varón.</li>
+<li><strong>Hipospadias</strong> (1:300 varones): meato uretral en cara <em>ventral</em> del pene. Glandular &gt; coronal &gt; peneana media &gt; escrotal &gt; perineal. Asociaciones: chordee, criptorquidia, hernia inguinal.</li>
+<li><strong>Epispadias</strong>: meato en cara <em>dorsal</em>. Más raro. Asociado a extrofia vesical.</li>
+<li><strong>Estenosis uretral:</strong> congénita o adquirida (iatrogénica, traumática, infecciosa).</li>
+<li><strong>Divertículo vesical:</strong> congénito (Hutch — paraureteral, asociado a RVU) o adquirido por obstrucción crónica (HBP).</li>
+</ul>
+</div>
+
+<h3>2.1 Extrofia vesical</h3>
+<ul>
+<li>Defecto raro (1:30.000-50.000), predominio masculino 2-3:1.</li>
+<li>Fallo de cierre de la pared abdominal anterior y de la vejiga → vejiga expuesta en hipogastrio, con mucosa visible.</li>
+<li>Asocia: diástasis púbica, epispadias completo (incontinencia), hernias inguinales, malformaciones anorrectales.</li>
+<li><strong>Síndrome OEIS (complejo Omphalocele-Extrofia-Imperforación anal-anomalías eSpinales)</strong>: forma más severa.</li>
+<li>Tratamiento: cierre primario neonatal o por etapas con reconstrucción vesical y genital. Continencia y función reproductora con resultados variables.</li>
+</ul>
+
+<h3>2.2 Persistencia del uraco</h3>
+<p>El uraco es la conexión embriológica entre la cúpula vesical y el ombligo (alantoides). Normalmente involuciona al ligamento umbilical medio. Si persiste:</p>
+<div class="kv-grid">
+<div class="kv"><span class="k">Fístula uracal completa</span><span class="v">Comunicación vejiga ↔ ombligo. Secreción de orina por ombligo en RN.</span></div>
+<div class="kv"><span class="k">Quiste de uraco</span><span class="v">Tracto cerrado en ambos extremos. Asintomático o complicado (infección, dolor). En adulto puede malignizar a <em>adenocarcinoma de uraco</em>.</span></div>
+<div class="kv"><span class="k">Divertículo vesical-uracal</span><span class="v">Abierto a vejiga.</span></div>
+<div class="kv"><span class="k">Seno umbilical</span><span class="v">Abierto al ombligo.</span></div>
+</div>
+<p>Tratamiento: <em>resección completa quirúrgica</em> de todo el tracto y de un manguito de vejiga (riesgo de adenocarcinoma uracal en remanentes).</p>
+
+<h3>2.3 Hipospadias</h3>
+<ul>
+<li>Anomalía congénita más frecuente del pene: 1:200-300 varones, en aumento.</li>
+<li><strong>Meato uretral en cara ventral</strong> del pene + a menudo:
+  <ul>
+    <li><em>Chordee</em>: incurvación ventral del pene.</li>
+    <li>Prepucio en "capuchón dorsal" (deficiente ventralmente).</li>
+    <li>Tabique escrotal.</li>
+  </ul>
+</li>
+<li><strong>Asociaciones:</strong> criptorquidia (10 %), hernia inguinal, anomalías del tracto urinario superior, infertilidad.</li>
+<li><strong>Tratamiento quirúrgico</strong> entre los 6 y 18 meses (técnicas TIP/Snodgrass, MAGPI, Mathieu, Duplay). NO circuncisar al nacimiento (prepucio se usa para la plastia).</li>
+<li>Si genitales ambiguos: descartar trastornos del desarrollo sexual (DSD).</li>
+</ul>
+
+<h3>2.4 Epispadias</h3>
+<ul>
+<li>Mucho menos frecuente que hipospadias (1:30.000).</li>
+<li>Meato uretral en cara <em>dorsal</em> del pene.</li>
+<li>Asociado a extrofia vesical en formas completas.</li>
+<li>Cirugía reconstructiva en el primer año.</li>
+</ul>
+
+<h3>2.5 Anomalías de Prader (genital ambiguo en cariotipo XX)</h3>
+<p>Grado de virilización en niñas con hiperplasia suprarrenal congénita (déficit de 21-hidroxilasa el más frecuente):</p>
+<div class="kv-grid">
+<div class="kv"><span class="k">Tipo I</span><span class="v">Hipertrofia mínima del clítoris, sin fusión labial</span></div>
+<div class="kv"><span class="k">Tipo II</span><span class="v">Clítoris hipertrofiado + fusión labial parcial (introito en V)</span></div>
+<div class="kv"><span class="k">Tipo III</span><span class="v">Fusión labial mayor + clítoris muy hipertrofiado + <strong>un solo orificio perineal (seno urogenital)</strong></span></div>
+<div class="kv"><span class="k">Tipo IV</span><span class="v">Genitales aparentemente masculinos pero <strong>sin testículos palpables</strong>, cariotipo XX</span></div>
+<div class="kv"><span class="k">Tipo V</span><span class="v">Genitales completamente masculinos en cariotipo XX</span></div>
+</div>
+
+<h3>2.6 Persistencia de la cloaca</h3>
+<p>Más severa: <strong>un único orificio perineal</strong> que comunica vejiga + vagina + recto. Niñas. Asocia múltiples malformaciones (anorrectales, espinales, cardíacas). Requiere reconstrucción quirúrgica compleja por etapas.</p>
+
+<h3>2.7 Estenosis uretral</h3>
+<ul>
+<li><strong>Etiología:</strong>
+  <ul>
+    <li>Idiopática (la más frecuente).</li>
+    <li>Iatrogénica: postsondaje, post-cirugía endoscópica (RTU), trasplante.</li>
+    <li>Traumática: fracturas pélvicas, caídas a horcajadas.</li>
+    <li>Inflamatoria: liquen escleroso atrófico (BXO), uretritis (gonocócica).</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> chorro débil, esfuerzo miccional, vaciado incompleto, residuo, ITU recurrente.</li>
+<li><strong>Diagnóstico:</strong> <em>uretrocistografía retrógrada y miccional</em>, uretroscopia, uroflujometría.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Dilatación uretral: alivio temporal, alta recidiva.</li>
+    <li><em>Uretrotomía interna endoscópica</em>: para estenosis &lt; 2 cm, recidiva alta.</li>
+    <li><strong>Uretroplastia abierta</strong>: tratamiento de elección en estenosis recidivantes o largas (anastomótica, sustitutiva con mucosa bucal de Bracka, Asopa).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>2.8 Preguntas — U2</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Recién nacido con 2 orificios perineales + cariotipo 46XX</summary>
+<div class="qa-body">
+<p>Recién nacido en cuya exploración física se detecta que solo existen dos orificios perineales, ausencia de otro desarrollo genital externo y no se palpan testículos. Cariotipo 46XX. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Anomalía genital tipo II de Prader</li>
+<li>Persistencia de cloaca</li>
+<li><strong>Persistencia del seno urogenital</strong></li>
+<li>Anomalía genital tipo IV de Prader</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Dos orificios perineales (ano + seno urogenital común) en cariotipo XX = persistencia del seno urogenital. La cloaca persistente tendría <em>un solo orificio</em>. Tipo IV de Prader tendría genitales aparentemente masculinos.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U3 =============== -->
+<section class="card" id="u3">
+<h2 class="section-title"><span class="num">U3</span>Uropatía obstructiva e hidronefrosis</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>La <strong>uropatía obstructiva</strong> = obstrucción al flujo urinario en cualquier punto del aparato urinario → ↑ presión retrógrada → dilatación (hidronefrosis) → daño parenquimatoso progresivo (atrofia tubulointersticial).</li>
+<li><strong>Reversibilidad:</strong> los cambios son reversibles si se desobstruye precozmente. Obstrucción &gt; 6-8 semanas produce daño permanente.</li>
+<li><strong>Topografía:</strong>
+  <ul>
+    <li><em>ALTA</em>: uréter, UPU, pelvis renal. Suele ser unilateral.</li>
+    <li><em>BAJA</em>: cuello vesical, próstata, uretra. Suele afectar ambos riñones por retención vesical.</li>
+  </ul>
+</li>
+<li><strong>Etiología</strong> (memorizar por edad/sexo): véase tabla.</li>
+<li><strong>Manifestación aguda:</strong> dolor cólico, fiebre si infección concomitante, anuria si bilateral o monorreno.</li>
+<li><strong>Crónica:</strong> asintomática hasta fases tardías, deterioro lento de la función renal.</li>
+<li><strong>Tratamiento urgente:</strong> derivación urinaria si <em>fiebre/sepsis/anuria/IR aguda</em> → cateterismo ureteral doble J o nefrostomía percutánea. <span class="tag danger">Pielonefritis obstructiva = emergencia urológica</span>.</li>
+</ul>
+</div>
+
+<h3>3.1 Etiología por edad y sexo</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Grupo</th><th>Causas más frecuentes</th></tr></thead>
+<tbody>
+<tr><td>Neonato/lactante</td><td>VUP (varón), estenosis UPU, megauréter, ureterocele, RVU grave</td></tr>
+<tr><td>Niños</td><td>RVU, UPU, vejiga neurógena</td></tr>
+<tr><td>Adulto joven</td><td><strong>Litiasis</strong> (la causa más frecuente en varones jóvenes), embarazo (mujer), fibrosis retroperitoneal idiopática, traumatismos</td></tr>
+<tr><td>Mujer adulta</td><td>Embarazo, neoplasia ginecológica, endometriosis ureteral, iatrogenia (cirugía pélvica), litiasis</td></tr>
+<tr><td>Varón &gt; 50 años</td><td><strong>HBP</strong> (la más frecuente), cáncer de próstata, tumores vesicales, litiasis</td></tr>
+<tr><td>Cualquier edad</td><td>Tumores retroperitoneales, ligadura ureteral iatrogénica, infecciones específicas (TBC, schistosomiasis)</td></tr>
+</tbody></table></div>
+
+<h3>3.2 Fisiopatología</h3>
+<ol>
+<li><em>Fase de hipertensión intratubular</em>: vasodilatación inicial compensadora → ↑ FG por unidad de nefrona.</li>
+<li><em>Fase de hipoperfusión</em>: vasoconstricción intrarrenal mediada por angiotensina II, TXA₂ → ↓ FG.</li>
+<li><em>Fase de atrofia</em>: apoptosis tubular, fibrosis intersticial, atrofia cortical, pérdida de masa renal funcionante.</li>
+</ol>
+
+<h3>3.3 Clínica</h3>
+<ul>
+<li><strong>Aguda:</strong>
+  <ul>
+    <li>Dolor cólico (litiasis): lumbar irradiado a fosa iliaca-genitales, intermitente, agitación, hematuria.</li>
+    <li>Anuria: si bilateral o monorreno (urgencia).</li>
+    <li>Fiebre + dolor: sospecha de pielonefritis obstructiva → sepsis.</li>
+  </ul>
+</li>
+<li><strong>Crónica:</strong>
+  <ul>
+    <li>Asintomática hasta fases avanzadas.</li>
+    <li>HTA por activación del SRAA.</li>
+    <li>Síntomas obstructivos del tracto inferior (HBP): chorro débil, esfuerzo, vaciado incompleto, polaquiuria, nicturia.</li>
+    <li>Globo vesical palpable en retención crónica.</li>
+    <li>Pérdida de la función renal con IR progresiva.</li>
+  </ul>
+</li>
+<li><strong>Síndrome de poliuria postobstructiva</strong>: al desobstruir, diuresis abundante con riesgo de deshidratación. Reponer fluidos.</li>
+</ul>
+
+<h3>3.4 Diagnóstico</h3>
+<ul>
+<li><strong>Ecografía</strong>: prueba inicial. Detecta hidronefrosis, residuo postmiccional, globo vesical, masas.</li>
+<li><strong>TAC sin contraste</strong>: identifica litiasis, niveles de obstrucción, causas intra/extraureterales.</li>
+<li><strong>UroTC con contraste</strong>: anatomía detallada.</li>
+<li><strong>Renograma con MAG-3 + furosemida</strong>: distingue obstrucción "verdadera" de dilatación sin obstrucción funcional + función renal diferencial.</li>
+<li><strong>Cistouretrografía miccional</strong>: niños con sospecha de VUP/RVU.</li>
+<li>Cistoscopia/uretrocistografía en obstrucción baja.</li>
+</ul>
+
+<h3>3.5 Tratamiento</h3>
+
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🚨</span>Pielonefritis obstructiva — emergencia</div>
+<p style="margin:4px 0"><strong>Fiebre + dolor lumbar + obstrucción</strong> = sepsis urinaria potencial.</p>
+<p style="margin:4px 0">Indicación absoluta de <em>derivación urinaria urgente</em> (cateterismo doble J o nefrostomía percutánea) + ATB iv empírica (ceftriaxona o piperacilina-tazobactam).</p>
+<p style="margin:4px 0"><strong>No esperar a tratar el cálculo</strong>. El tratamiento definitivo (LEOC, ureteroscopia) se difiere 4-6 semanas tras curación de la infección.</p>
+</div>
+
+<h4>Métodos de derivación urinaria</h4>
+<div class="kv-grid">
+<div class="kv"><span class="k">Cateterismo doble J (DJ)</span><span class="v">Endoscópico, en obstrucción del tracto superior. Se cambia cada 3-6 meses.</span></div>
+<div class="kv"><span class="k">Nefrostomía percutánea (NPC)</span><span class="v">Drenaje directo desde el riñón a la piel. Si DJ no es posible (estenosis distal, edema). Bajo control ecográfico.</span></div>
+<div class="kv"><span class="k">Sondaje vesical</span><span class="v">Obstrucción uretrovesical (HBP aguda, retención).</span></div>
+<div class="kv"><span class="k">Talla suprapúbica</span><span class="v">Si no se puede sondar por uretra (impactación de litiasis, estenosis).</span></div>
+<div class="kv"><span class="k">Derivaciones definitivas</span><span class="v">Cutáneas (Bricker, conducto ileal), continentes (Indiana), ortotópicas (neovejiga ileal de Studer/Hautmann) tras cistectomía.</span></div>
+</div>
+
+<h4>Tratamiento etiológico</h4>
+<p>Tras desobstruir, se trata la causa: litotricia, RTU-P, prostatectomía, tratamiento del tumor, embarazo (esperar parto si tolera), corticoides en fibrosis retroperitoneal idiopática.</p>
+
+<h3>3.6 Preguntas — U3</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Paciente con HBP + retención + IR + ITU</summary>
+<div class="qa-body">
+<p>Varón de 75 años con incontinencia casi continua, micciones escasas y dificultad miccional. Tacto rectal: próstata adenomatosa volumen III no sospechosa de tumor. Analítica: IR con creatinina 3 mg/dL, sedimento patológico (infección), PSA normal 3.4. Ecografía: próstata 70 cc con crecimiento endoluminal a vejiga (lóbulo medio), residuo postmiccional 300 mL. Es FALSO que:</p>
+<ol type="a">
+<li>El paciente presenta una micción por rebosamiento por el componente obstructivo</li>
+<li><strong>Si presentara una litiasis vesical secundaria con residuo postmiccional, no precisará tratamiento simultáneo de ambas patologías</strong></li>
+<li>Puede estar indicado el sondaje vesical de manera temporal asociado a un tratamiento desobstructivo posterior</li>
+<li>El tratamiento desobstructivo ofrece la posibilidad a posteriori de una mejoría de la capacidad de vaciamiento vesical y de la función renal</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La litiasis vesical secundaria <em>SÍ</em> precisa tratamiento simultáneo de la obstrucción y de la litiasis (cistolitotricia + RTU-P o adenomectomía). Si solo se resuelve la obstrucción quedaría la litiasis recurrente como nido de infección.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U4 =============== -->
+<section class="card" id="u4">
+<h2 class="section-title"><span class="num">U4</span>Traumatismos renales, ureterales y vesicales</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>El <strong>riñón es el órgano genitourinario más frecuentemente lesionado</strong> (50 % de los traumatismos GU).</li>
+<li><strong>Mecanismo:</strong>
+  <ul>
+    <li><em>Cerrado/contuso</em> (90 %): accidentes de tráfico, caídas, agresiones, deportes.</li>
+    <li><em>Abierto/penetrante</em>: arma blanca, arma de fuego.</li>
+    <li><em>Iatrogénico</em>: biopsias, LEOC, cirugía pélvica (ureteral), endoscopia.</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> <em>hematuria (sin correlación con la gravedad)</em>, dolor lumbar/abdominal, hipotensión, fractura costal baja o lumbar, equimosis en flanco (signo de Grey-Turner).</li>
+<li><strong>Diagnóstico:</strong> <em>TC con contraste en fase nefrográfica y excretora</em> = gold standard. La ecografía es insuficiente para evaluar grados II-V (no diferencia laceraciones del sistema colector).</li>
+<li><strong>Clasificación AAST</strong> en 5 grados (ver tabla).</li>
+<li><strong>Tratamiento:</strong> conservador en grado I-III hemodinámicamente estables (también IV/V seleccionados); cirugía si inestabilidad hemodinámica, hematoma expansivo, lesión vascular grave, urohematoma sintomático.</li>
+<li><strong>Complicación tardía:</strong> <em>HTA por riñón de Page</em> (compresión por hematoma capsular o subcapsular crónico → isquemia → SRAA → HTA renovascular).</li>
+</ul>
+</div>
+
+<h3>4.1 Clasificación AAST del traumatismo renal</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Grado</th><th>Lesión</th><th>Tratamiento habitual</th></tr></thead>
+<tbody>
+<tr><td><strong>I</strong></td><td>Contusión / hematoma subcapsular no expansivo, sin laceración</td><td>Conservador, observación, reposo</td></tr>
+<tr><td><strong>II</strong></td><td>Hematoma perirrenal no expansivo. Laceración cortical <em>&lt; 1 cm</em>, SIN extravasación urinaria</td><td>Conservador</td></tr>
+<tr><td><strong>III</strong></td><td>Laceración cortical <em>&gt; 1 cm</em>, SIN afectación del sistema colector ni extravasación urinaria. Hematoma perirrenal</td><td>Conservador en estable; vigilancia con TAC seriado</td></tr>
+<tr><td><strong>IV</strong></td><td>Laceración que atraviesa córtex, médula y <em>sistema colector con extravasación urinaria (urohematoma)</em> · Lesión vascular segmentaria con hematoma contenido</td><td>Conservador si estable + doble J/NPC; cirugía si urohematoma sintomático o expansivo</td></tr>
+<tr><td><strong>V</strong></td><td>Riñón <em>destrozado</em> (shattered) · Avulsión del pedículo vascular con desvascularización completa del riñón</td><td>Cirugía urgente (nefrectomía mayoría); embolización si lesión segmentaria estable</td></tr>
+</tbody></table></div>
+
+<h3>4.2 Manejo según estabilidad hemodinámica</h3>
+<ul>
+<li><strong>Paciente estable:</strong> TC con contraste, manejo conservador (reposo en cama, hidratación, ATB profiláctico si urohematoma, control con TC a las 48-72 h).</li>
+<li><strong>Paciente inestable:</strong> reanimación → si responde a fluidos → TC; si no responde → laparotomía exploradora urgente (eco FAST en quirófano si dudoso).</li>
+<li>Indicaciones de cirugía urgente: <em>hematoma retroperitoneal expansivo, lesión vascular grave (grado V), avulsión del pedículo, lesión penetrante, fracaso del tratamiento conservador</em>.</li>
+</ul>
+
+<h3>4.3 Traumatismos ureterales</h3>
+<ul>
+<li>Raros (&lt; 1 % del trauma urogenital). Más frecuente <em>iatrogenia</em> (ginecología, cirugía colorrectal, ureteroscopia).</li>
+<li><strong>Clínica:</strong> fiebre, dolor lumbar, débito anómalo por drenaje, fístula urinaria. El diagnóstico precoz es difícil (muchas veces se detectan tardíamente).</li>
+<li><strong>Diagnóstico:</strong> UroTC con fase excretora, pielografía retrógrada, ureteroscopia.</li>
+<li><strong>Clasificación:</strong>
+  <ul>
+    <li>I: hematoma sin pérdida de continuidad</li>
+    <li>II: laceración &lt; 50 %</li>
+    <li>III: laceración &gt; 50 %</li>
+    <li>IV: sección completa o devascularización ≤ 2 cm</li>
+    <li>V: devascularización &gt; 2 cm</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong> doble J + sutura primaria si lesión pequeña reciente; reimplantación con psoas hitch o Boari si lesión distal; ureteroureterostomía si lesión proximal; sustitución con segmento intestinal si pérdida masiva.</li>
+</ul>
+
+<h3>4.4 Traumatismos vesicales</h3>
+<ul>
+<li>Asociados a fracturas pélvicas (60-90 %) o a traumas penetrantes.</li>
+<li><strong>Clínica:</strong> hematuria macroscópica (95 %), dolor suprapúbico, dificultad para orinar.</li>
+<li><strong>Diagnóstico:</strong> <em>cistografía retrógrada</em> con contraste, fase miccional + post-vaciado. TC con cistografía.</li>
+<li><strong>Clasificación:</strong>
+  <ul>
+    <li><em>Contusión vesical</em> (sin perforación).</li>
+    <li><em>Rotura intraperitoneal</em>: rotura de la cúpula. Asociada a vejiga llena + impacto abdominal. Contraste libre en peritoneo. <span class="tag danger">Requiere reparación quirúrgica urgente</span>.</li>
+    <li><em>Rotura extraperitoneal</em>: asociada a fractura pélvica. Tratamiento <em>conservador</em> (sondaje vesical 10-14 días) si no hay otra indicación quirúrgica pélvica.</li>
+    <li>Lesión combinada / lesión del cuello / extravasación uretral.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>4.5 Traumatismos uretrales</h3>
+<ul>
+<li><strong>Uretra posterior (membranosa, prostática):</strong> asociada a fracturas pélvicas, sobre todo "disyunción tipo libro abierto". Cizallamiento.</li>
+<li><strong>Uretra anterior (bulbar, peneana):</strong> traumatismo directo, "caída a horcajadas" en la bulbar.</li>
+<li><strong>Clínica:</strong> uretrorragia (sangre por el meato), hematoma perineal/escrotal/peneano, imposibilidad para orinar, próstata "flotante" en TR.</li>
+<li><strong>Diagnóstico:</strong> <em>uretrografía retrógrada</em> ANTES de sondaje (si sospecha, contraindicación de sondaje a ciegas — puede empeorar la lesión).</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Talla suprapúbica de urgencia.</li>
+    <li>Reparación primaria endoscópica o realineación.</li>
+    <li>Uretroplastia diferida (3-6 meses) si estenosis residual.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>4.6 Traumatismos genitales externos</h3>
+<ul>
+<li><strong>Fractura de pene</strong>: rotura de la albugínea de los cuerpos cavernosos durante coito o trauma. Chasquido, dolor, hematoma, "berenjena". <em>Cirugía urgente</em>: sutura de la albugínea.</li>
+<li><strong>Traumatismo escrotal</strong>: hematocele (ecografía con flujo), <em>rotura testicular</em> (línea irregular del parénquima en eco, hematoma intratesticular). Exploración quirúrgica con sutura o orquiectomía si destrucción amplia.</li>
+</ul>
+
+<h3>4.7 Preguntas — U4</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Varón con traumatismo renal — afirmación FALSA</summary>
+<div class="qa-body">
+<p>Paciente varón de 25 años con antecedente de traumatismo renal. Señale la respuesta FALSA:</p>
+<ol type="a">
+<li>La ecografía no permite evaluar correctamente los traumatismos renales grado II y III</li>
+<li><strong>La intensidad de la hematuria guarda relación con la gravedad del traumatismo renal</strong></li>
+<li>La presencia de urohematoma indica traumatismo renal grado IV según la AAST</li>
+<li>Paciente con traumatismo renal y tratamiento conservador puede presentar HTA por riñón de Page</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La <em>hematuria NO se correlaciona con la gravedad</em>. Lesiones graves (avulsión del pedículo, grado V) pueden cursar sin hematuria; lesiones leves pueden producir hematuria masiva.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Hematoma perirrenal + laceración 2 cm — AAST</summary>
+<div class="qa-body">
+<p>Paciente de 46 años con accidente laboral. TAC: hematoma perirrenal y laceración de parénquima renal de 2 cm. Según AAST corresponde a:</p>
+<ol type="a">
+<li>Traumatismo renal grado V</li>
+<li><strong>Traumatismo renal grado III</strong></li>
+<li>Traumatismo renal grado II</li>
+<li>La reevaluación abdominal se debería haber realizado con la misma prueba de imagen</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Laceración &gt; 1 cm sin afectación del sistema colector = grado III. (Grado II sería &lt; 1 cm sin extravasación; grado IV requiere extravasación urinaria.)</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Traumatismo renal — afirmación CORRECTA</summary>
+<div class="qa-body">
+<p>En relación con el traumatismo renal, señale la respuesta CORRECTA:</p>
+<ol type="a">
+<li>La ecografía permite evaluar correctamente los traumatismos renales grado III</li>
+<li>La intensidad de la hematuria guarda relación con la gravedad</li>
+<li>La presencia de urohematoma indica grado III según la AAST</li>
+<li><strong>Paciente con traumatismo renal tratado conservadoramente que presenta HTA puede estar relacionado con riñón de Page</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> El <em>riñón de Page</em> = compresión renal por hematoma capsular/subcapsular crónico que isquemiza el riñón → activación SRAA → HTA renovascular. La ecografía es insuficiente para grado III. El urohematoma es del grado IV.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U5 =============== -->
+<section class="card" id="u5">
+<h2 class="section-title"><span class="num">U5</span>Trasplante renal y donación de órganos</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Tratamiento de elección de la ERC terminal</strong>: mejora supervivencia (vs HD: mortalidad anual en HD &gt; 25 %, expectativa de vida en HD &lt; 50 % a 5 años en grupo 65-74 a) y calidad de vida. La <em>enfermedad cardiovascular es la principal causa de muerte</em> en pacientes en diálisis.</li>
+<li><strong>Indicaciones de trasplante:</strong> FGe &lt; 20 mL/min sin contraindicación + expectativa de vida y edad <em>evaluables caso a caso</em>.</li>
+<li><strong>Contraindicaciones absolutas:</strong> <em>cáncer activo, infección no tratada, expectativa de vida &lt; 2 años</em>.</li>
+<li><strong>Donante:</strong> vivo (familiar/cruzado/altruista) o cadáver (muerte encefálica o asistolia).</li>
+<li><strong>Implantación HETEROTÓPICA en fosa iliaca</strong> (anastomosis término-lateral a arteria y vena iliaca externa + reimplantación ureterovesical de Lich-Gregoir o Leadbetter-Politano). NO se extirpan los riñones nativos salvo indicación específica.</li>
+<li><strong>Inmunosupresión:</strong> sinergia de varios fármacos en distintos niveles. Inducción (basiliximab o timoglobulina) + mantenimiento (anticalcineurínico + antiproliferativo + corticoides). <em>Se individualiza, no es la misma combinación para todos</em>.</li>
+</ul>
+</div>
+
+<h3>5.1 ERC terminal y opciones de TRS</h3>
+<p>La ERC se define como aclaramiento de creatinina &lt; 60 mL/min sostenido durante &gt; 3 meses; la <em>ERC terminal</em> es la que cursa con FGe &lt; 15 mL/min. La DM y la HTA son las causas más frecuentes (han desplazado a las glomerulopatías, malformaciones de la vía urinaria y poliquistosis).</p>
+<p>Pese a los beneficios de la diálisis, su mortalidad es alta (hasta 27 %/año) y la expectativa de vida en grupos &gt; 65 a. es &lt; 50 % a 5 años. La <em>enfermedad cardiovascular</em> es la principal causa de muerte en pacientes en HD. Por todo ello, el trasplante renal — siempre que no haya contraindicación — es la <em>mejor opción terapéutica</em>.</p>
+
+<h3>5.2 Evaluación del receptor</h3>
+<p>No todo paciente en TRS es candidato. La evaluación pretende minimizar riesgos para el paciente y para el injerto:</p>
+<div class="compare">
+<div>
+<h4>✔ Indicaciones</h4>
+<ul>
+<li>FGe &lt; 20 mL/min sin contraindicación médica</li>
+<li>Expectativa de vida: evaluable caso a caso</li>
+<li>Edad: evaluable caso a caso (no hay límite absoluto)</li>
+</ul>
+</div>
+<div>
+<h4>✘ Contraindicaciones absolutas</h4>
+<ul>
+<li><strong>Cáncer activo</strong></li>
+<li>Infección aguda o crónica no tratada</li>
+<li>Expectativa de vida &lt; 2 años (según informe del especialista)</li>
+<li>Abuso de drogas/alcohol no controlado</li>
+<li>Mala adherencia terapéutica</li>
+<li>Patología cardiovascular severa no recuperable</li>
+</ul>
+</div>
+</div>
+<p>El consentimiento informado <em>debe renovarse anualmente</em> en el centro de diálisis. Estudios pre-trasplante: bioquímica completa, virológicos (VIH, VHB, VHC, CMV, EBV, VVZ, sífilis), tipificación HLA + anti-HLA, ECG/eco TT, valoración cardiológica, dental, ginecológica, urológica.</p>
+
+<h3>5.3 Evaluación y selección del donante</h3>
+
+<h4>Donante cadáver (muerte encefálica o asistolia)</h4>
+<p><strong>Diagnóstico de muerte encefálica (ME):</strong> pérdida total de las funciones del cerebro, incluyendo tronco. Causas más frecuentes: <em>HSA espontánea, TCE grave, ACV hemorrágico</em>. Se requieren criterios clínicos (coma profundo, ausencia de reflejos del tronco, apnea persistente) confirmados por al menos 2 exploradores + pruebas instrumentales (EEG plano, doppler transcraneal, angiografía).</p>
+<p><strong>Donación en asistolia (DCD):</strong> tipo Maastricht I-V. La calidad del injerto es algo inferior por mayor tiempo de isquemia caliente, pero permite ampliar el pool de donantes.</p>
+
+<h4>Donante añoso / con criterios expandidos (ECD)</h4>
+<p>Para aceptar o rechazar un riñón añoso se utiliza un <em>score histológico</em> (Karpinski / Remuzzi) sobre la biopsia pre-implante:</p>
+<div class="kv-grid">
+<div class="kv"><span class="k">Esclerosis glomerular</span><span class="v">% de glomérulos esclerosados</span></div>
+<div class="kv"><span class="k">Atrofia tubular</span><span class="v">% de túbulos atróficos</span></div>
+<div class="kv"><span class="k">Fibrosis intersticial</span><span class="v">% de área afectada</span></div>
+<div class="kv"><span class="k">Hialinosis arteriolar</span><span class="v">Grado de afectación vascular</span></div>
+</div>
+<p>Suma 0-3 puntos: ≤ 3 = trasplante simple; 4-6 = trasplante dual (los 2 riñones en mismo receptor); &gt; 6 = descartar.</p>
+
+<h4>Donante vivo</h4>
+<ul>
+<li><strong>Ventajas vs cadáver:</strong> mejor supervivencia del injerto y del paciente, tiempo de isquemia mínimo, cirugía electiva planificada, estudio exhaustivo del donante, ausencia de fenómenos de muerte cerebral, inicio de inmunosupresión antes de la cirugía, <em>mejor compatibilidad HLA</em> (en familiares).</li>
+<li><strong>Mortalidad de la nefrectomía del donante:</strong> ≈ 0,02 % (la técnica laparoscópica/robótica es el gold standard).</li>
+<li><strong>Repercusión renal en el donante:</strong> el riñón remanente compensa rápidamente alcanzando ≈ 70 % del FGe original. En &gt; 60 a. y obesos, puede instalarse ERC con FGe &lt; 60 → selección cuidadosa.</li>
+</ul>
+
+<h3>5.4 Preservación del injerto</h3>
+<p>Una vez procurados los órganos, se inicia la <em>perfusión fría</em> mediante canulación de aorta + cava tras clampeo pre y posrenal. La solución de perfusión combate la lesión por isquemia-reperfusión, manteniendo la viabilidad del órgano y permitiendo distribuirlo entre centros.</p>
+<p><strong>Mecanismos del daño celular:</strong> depleción de ATP → falla de la bomba Na/K → edema intracelular → metabolismo anaerobio → acumulación de radicales libres → muerte celular.</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Solución</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td><strong>Wisconsin (UW)</strong></td><td>Alto potasio, alta viscosidad. La más usada clásicamente.</td></tr>
+<tr><td><strong>Celsior</strong></td><td>Buffer histidina, alto sodio, bajo potasio, baja viscosidad. Menor coste, menor Cr post-implante.</td></tr>
+<tr><td>Custodiol (HTK), IGL-1, Marshall</td><td>Otras soluciones de preservación.</td></tr>
+</tbody></table></div>
+<p><strong>Tiempos de isquemia:</strong> caliente (procura) &lt; 30 min; fría (preservación a 4 ºC) &lt; 24 h (idealmente &lt; 12-18 h). Tiempos prolongados aumentan riesgo de NTA y retraso en la función del injerto.</p>
+
+<h3>5.5 Inmunología del trasplante</h3>
+
+<h4>Sistema HLA (complejo mayor de histocompatibilidad)</h4>
+<ul>
+<li>Codificado en el brazo corto del cromosoma 6. ≈ 400 genes, polimorfismo extremo (≥ 490 alelos descritos).</li>
+<li><strong>Clase I:</strong> loci HLA-A, HLA-B, HLA-C. Expresados en casi todas las células somáticas.</li>
+<li><strong>Clase II:</strong> loci HLA-DR, HLA-DQ, HLA-DP. Expresados principalmente en células presentadoras de antígenos.</li>
+<li><strong>Compatibilidad:</strong> se evalúan antígenos A, B, DR y DQ (cada uno en número de 2). Máxima compatibilidad = <em>8/8</em>. Cuantos más antígenos compatibles, mejor supervivencia del injerto.</li>
+<li><strong>Sistema ABO:</strong> otra barrera inmunológica. Se requiere compatibilidad ABO (existe protocolo de trasplante ABO incompatible con desensibilización, pero es excepcional).</li>
+</ul>
+
+<h4>Antígenos menores: MICA</h4>
+<p>El gen <em>MICA</em> (MHC class I Chain related Gen A) está implicado en rechazos crónicos en pacientes que carecen de anticuerpos anti-HLA. Descrito como factor de mal pronóstico tardío.</p>
+
+<h4>Sensibilización inmunológica (PRA)</h4>
+<p>El paciente puede desarrollar anticuerpos anti-HLA por:</p>
+<ul>
+<li><strong>Transfusiones sanguíneas previas</strong></li>
+<li><strong>Embarazos</strong> (exposición a HLA paterno)</li>
+<li><strong>Trasplantes previos</strong></li>
+<li>NO: infecciones de repetición (no sensibilizan)</li>
+</ul>
+<p>El <em>PRA (Panel Reactive Antibodies)</em> mide el % de población contra cuyos HLA reacciona el paciente. PRA alto = "hiperinmunizado", mayor dificultad para encontrar donante compatible.</p>
+
+<h4>Crossmatch (prueba cruzada)</h4>
+<p>Al momento del trasplante se enfrentan suero del receptor con linfocitos del donante. <strong>Crossmatch (+) = contraindicación absoluta del trasplante</strong> (riesgo de rechazo hiperagudo).</p>
+
+<h3>5.6 Fármacos inmunosupresores</h3>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Grupo</th><th>Fármacos</th><th>Mecanismo</th><th>Efectos adversos</th></tr></thead>
+<tbody>
+<tr><td><strong>Corticoides</strong></td><td>Prednisona oral · metilprednisolona iv (bolos)</td><td>Inhiben IL-1, IL-6, TNF</td><td>HTA, DM, osteoporosis, infecciones, cataratas, Cushing</td></tr>
+<tr><td><strong>Antiproliferativos</strong></td><td>Azatioprina, <em>micofenolato mofetilo (MMF)</em>, micofenolato sódico</td><td>Inhibición síntesis de purinas → ↓ proliferación linfocitaria</td><td>Diarrea, mielotoxicidad, leucopenia</td></tr>
+<tr><td><strong>Anticalcineurínicos</strong></td><td><em>Tacrolimus</em> (1ª línea actual), ciclosporina</td><td>Inhiben calcineurina → ↓ síntesis de citoquinas (IL-2, IFN-γ) → ↓ proliferación T</td><td><em>Nefrotoxicidad</em>, neurotoxicidad, HTA, diabetes (TAC), hipertricosis (CSA)</td></tr>
+<tr><td><strong>Inhibidores mTOR</strong></td><td>Sirolimus, everolimus</td><td>Bloquean mTOR → ↓ proliferación T y B</td><td>Cicatrización deficiente, hiperlipemia, neumonitis, proteinuria</td></tr>
+<tr><td><strong>Anticuerpos policlonales</strong></td><td><em>Timoglobulina</em></td><td>Antilinfocitaria</td><td>Citoquinas (cytokine release syndrome) si infusión rápida; infecciones, linfomas</td></tr>
+<tr><td><strong>Anticuerpos monoclonales</strong></td><td>Basiliximab (anti-IL-2R/CD25) · rituximab (anti-CD20)</td><td>Bloqueo selectivo</td><td>Reacciones infusionales</td></tr>
+<tr><td><strong>Belatacept</strong></td><td>Anti-CD80/86 (similar a abatacept)</td><td>Bloquea coestimulación</td><td>Riesgo de linfoma SNC primario en seronegativos para VEB → contraindicado en ese caso</td></tr>
+</tbody></table></div>
+
+<h4>Esquema estándar actual (en pacientes sin alto riesgo)</h4>
+<ul>
+<li><strong>Inducción</strong>: basiliximab (riesgo bajo/intermedio) o <em>timoglobulina</em> (alto riesgo: PRA alto, retrasplante, raza negra, donante marginal).</li>
+<li><strong>Mantenimiento</strong>: tacrolimus + MMF + corticoides en pauta descendente. Se ajusta según niveles plasmáticos de tacrolimus (objetivo 5-10 ng/mL tras los primeros meses).</li>
+</ul>
+
+<h3>5.7 Técnica quirúrgica (Kuss 1951, prácticamente sin cambios)</h3>
+<ol>
+<li><em>Incisión de Gibson</em> en fosa iliaca (preferentemente derecha).</li>
+<li>Vía <em>extraperitoneal</em>.</li>
+<li>Disección de vasos iliacos externos (libre de tejido linfático para prevenir linfocele).</li>
+<li>Anastomosis vascular término-lateral: vena renal a vena iliaca externa + arteria renal a arteria iliaca externa.</li>
+<li>Comprobar perfusión del injerto.</li>
+<li><strong>Reimplantación ureterovesical</strong> con técnica antirreflujo:
+  <ul>
+    <li><em>Leadbetter-Politano</em>: transvesical (cistostomía + túnel submucoso).</li>
+    <li><em>Lich-Gregoir</em>: extravesical (más usada en la actualidad). Sin diferencias significativas de resultados entre ambas; en ambas se realiza túnel submucoso y sutura sin tensión.</li>
+  </ul>
+</li>
+</ol>
+
+<h3>5.8 Complicaciones — agudas</h3>
+
+<h4>1. Retraso en la función inicial del injerto (DGF)</h4>
+<ul>
+<li>Más en donante cadáver (10-50 %) que vivo (&lt; 1 %).</li>
+<li>Causa: NTA por isquemia-reperfusión.</li>
+<li>FR: parada cardíaca del donante, hipotensión prolongada, isquemia fría y caliente prolongadas.</li>
+<li>Clínica: anuria + falta de descenso de Cr post-trasplante.</li>
+<li>Diagnóstico diferencial con trombosis, estenosis ureteral, rechazo hiperagudo: <em>eco Doppler + cintigrafía MAG-3</em>.</li>
+<li>Tratamiento: <em>expectante</em> con apoyo dialítico. Recuperación en días-semanas. <em>~ 2 % no recuperan función (disfunción primaria del injerto)</em>.</li>
+</ul>
+
+<h4>2. Hemorragia</h4>
+<ul>
+<li>Visualización por drenaje o por taquicardia/hipotensión/dolor + caída de hematocrito.</li>
+<li>Origen: vasos no ligados en pedículo, vasos del retroperitoneo, incisión.</li>
+<li>Mayoría se resuelve conservadoramente; <em>compromiso hemodinámico, transfusiones, compresión del riñón por hematoma → exploración quirúrgica urgente</em>.</li>
+</ul>
+
+<h4>3. Trombosis vascular</h4>
+<p>Ocurre en &lt; 1 % pero <em>casi siempre termina en pérdida del injerto</em>.</p>
+<div class="kv-grid">
+<div class="kv"><span class="k">Trombosis arterial</span><span class="v"><strong>Anuria súbita</strong> tras descartar obstrucción urinaria → eco Doppler urgente. La causa más frecuente es torsión, disección o problemas técnicos. La exploración quirúrgica casi siempre acaba en nefrectomía.</span></div>
+<div class="kv"><span class="k">Trombosis venosa</span><span class="v"><strong>Hematuria + dolor + aumento de volumen del injerto</strong> en los primeros 10 días. Causas: linfocele compresivo, kinking, estenosis de la sutura. Doppler diagnóstico. Casi 100 % requieren nefrectomía.</span></div>
+</div>
+
+<h4>4. Aneurismas y fístulas arteriovenosas</h4>
+<p>Por disrupción de sutura, infecciones o biopsias. Mayoría asintomáticos (hallazgo en eco). Ante dolor/hematuria/anuria/inestabilidad → sospechar rotura → reparación (parche venoso o nefrectomía).</p>
+
+<h4>5. Complicaciones urinarias (≤ 5 %)</h4>
+<ul>
+<li><strong>Fístula urinaria</strong>: filtración a nivel de la anastomosis uretero-vesical por infección o isquemia ureteral. Fiebre + débito por drenaje. Tratamiento: doble J + sondaje vesical + reimplante si no resuelve.</li>
+</ul>
+
+<h3>5.9 Complicaciones — tardías</h3>
+
+<h4>1. Estenosis de arteria renal del injerto</h4>
+<ul>
+<li>Hasta 10 % de los pacientes.</li>
+<li>FR: ateroesclerosis, mala técnica, trauma de la arteria.</li>
+<li>Clínica: <em>HTA refractaria + disfunción del injerto + edema</em>.</li>
+<li>Diagnóstico: <em>doppler renal</em> (sensibilidad 87 %, especificidad 100 % en manos expertas).</li>
+<li>Tratamiento: <em>angioplastia ± stent endovascular</em> es la primera elección. Cirugía abierta si refractario. Riesgo de pérdida del injerto hasta 10 %.</li>
+</ul>
+
+<h4>2. Obstrucción ureteral / hidronefrosis del injerto</h4>
+<ul>
+<li>Más frecuentemente tardía.</li>
+<li>Causa: isquemia segmentaria del uréter, suturas con tensión.</li>
+<li>Clínica: aumento progresivo de Cr → eco muestra hidroureteronefrosis.</li>
+<li>Confirmación funcional con <em>cintigrama MAG-3</em>.</li>
+<li>Tratamiento: vía endoscópica (doble J, dilatación) o reimplante ureterovesical (puede usarse uréter nativo si obstrucción proximal).</li>
+</ul>
+
+<h4>3. Linfocele (hasta 20 %)</h4>
+<ul>
+<li>Colección de linfa por apertura no ligada de vasos linfáticos iliacos.</li>
+<li>Mayoría asintomáticos.</li>
+<li>Complicaciones: compresión de vía urinaria (↑ Cr), infección.</li>
+<li>Tratamiento: laparoscópico con marsupialización al peritoneo (preferente).</li>
+</ul>
+
+<h4>4. Hernia incisional</h4>
+<p>Favorecida por corticoides + inmunosupresores. Reparación tras estabilización del injerto.</p>
+
+<h4>5. Fístulas arteriovenosas tardías</h4>
+<p>Habitualmente secundarias a biopsia renal. Manejo angiográfico (embolización).</p>
+
+<h3>5.10 Rechazo del injerto</h3>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Momento</th><th>Mecanismo</th><th>Manejo</th></tr></thead>
+<tbody>
+<tr><td><strong>Hiperagudo</strong></td><td>Minutos-horas (en pabellón al desclampear)</td><td>Anticuerpos preformados anti-HLA o ABO</td><td><em>Sin tratamiento → trasplantectomía</em>. Se previene con crossmatch.</td></tr>
+<tr><td><strong>Agudo celular</strong></td><td>5 días — 3 meses (puede ser más tardío)</td><td>Linfocitos T del receptor reconocen HLA del donante</td><td>Pulsos de metilprednisolona iv (500 mg-1 g × 3 días). Si refractario: timoglobulina, OKT3.</td></tr>
+<tr><td><strong>Agudo humoral</strong></td><td>Días-meses</td><td>Anticuerpos anti-HLA (sensibilización previa) ± anti-MICA</td><td>Plasmaféresis + IgIV + rituximab ± bortezomib + esplenectomía si refractario.</td></tr>
+<tr><td><strong>Crónico</strong></td><td>Años</td><td>Inmune (anti-HLA de novo) + no inmune (nefrotoxicidad por anticalcineurínicos, HTA, recurrencia de enfermedad de base)</td><td>Optimizar inmunosupresión, IECA/ARA-II, control HTA. Eventualmente retrasplante.</td></tr>
+</tbody></table></div>
+
+<h4>Factores de riesgo de rechazo</h4>
+<ul>
+<li>Niveles bajos de inmunosupresión / mala adherencia.</li>
+<li>Pacientes hiperinmunizados (PRA alto).</li>
+<li>Retrasplantes.</li>
+<li>Receptores jóvenes y/o de raza negra.</li>
+<li>Incompatibilidad HLA.</li>
+<li>NTA inicial e infección por CMV (mayor expresión de antígenos HLA).</li>
+</ul>
+
+<h3>5.11 Infecciones post-trasplante</h3>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Periodo</th><th>Infecciones típicas</th><th>Profilaxis</th></tr></thead>
+<tbody>
+<tr><td><strong>0-1 mes</strong></td><td>Nosocomiales: heridas, vías, urinarias bacterianas, neumonía, <em>Candida</em>. Reactivación de VHS.</td><td>Cefalosporina de 1ª/3ª generación perioperatoria. Sonda vesical 5-7 d.</td></tr>
+<tr><td><strong>1-6 meses</strong></td><td><strong>Máxima inmunosupresión → oportunistas:</strong> <em>CMV</em>, BK virus, EBV, <em>Pneumocystis jirovecii</em>, micobacterias, listeria, toxoplasma, aspergillus, mucor, candidiasis invasiva.</td><td><em>Valganciclovir 3-6 meses (CMV)</em>, <em>TMP-SMX 6-12 meses (PJP + Listeria + Nocardia + Toxo)</em>, <em>nistatina oral</em>.</td></tr>
+<tr><td><strong>&gt; 6 meses</strong></td><td>Infecciones comunitarias (respiratorias, urinarias). Persistencia de oportunistas si rechazo crónico o aumento de inmunosupresión.</td><td>Vacunación (gripe, neumococo, COVID). Evitar vacunas vivas.</td></tr>
+</tbody></table></div>
+
+<h4>CMV en el trasplantado</h4>
+<ul>
+<li>Mayor riesgo en <em>donante (+) / receptor (−)</em> (D+R−).</li>
+<li>Manifestaciones: síndrome febril, leucopenia, hepatitis, neumonitis, colitis, retinitis.</li>
+<li>Diagnóstico: PCR cuantitativa de CMV (carga viral) en sangre o tejido.</li>
+<li>Tratamiento: ganciclovir iv o valganciclovir oral. Reducción de inmunosupresión.</li>
+</ul>
+
+<h4>Virus BK</h4>
+<p>Nefropatía por poliomavirus BK: viremia y viruria con disfunción del injerto. Diagnóstico por biopsia (células señuelo en orina, antígeno SV40 (+) en biopsia). Tratamiento: reducción de inmunosupresión.</p>
+
+<h3>5.12 Tumores post-trasplante</h3>
+<ul>
+<li><strong>Tumores cutáneos no melanoma</strong> (los más frecuentes): carcinoma espinocelular &gt; basocelular. Fotoprotección estricta.</li>
+<li><strong>Síndrome linfoproliferativo post-trasplante (PTLD)</strong>: asociado a infección por VEB. Variable desde hiperplasia policlonal a linfoma B agresivo. Tratamiento: reducción de inmunosupresión + rituximab + QT si linfoma.</li>
+<li><strong>Sarcoma de Kaposi</strong>: HHV-8. Reducir inmunosupresión, mTOR puede revertirlo.</li>
+<li>Otros: cáncer de próstata, mama, riñón nativo (mayor incidencia), urotelial.</li>
+</ul>
+
+<h3>5.13 Pronóstico</h3>
+<ul>
+<li>Supervivencia del paciente: 95 % al 1er año, ~ 85 % a 5 años.</li>
+<li>Supervivencia del injerto: 90 % al 1er año, ~ 70-80 % a 5 años (mejor en donante vivo).</li>
+<li>Vida media del injerto: 10-15 años (donante cadáver), 15-20 años (donante vivo).</li>
+<li>Principales causas de pérdida del injerto: rechazo crónico, muerte del paciente con injerto funcionante (CV), recurrencia de la enfermedad de base, nefrotoxicidad farmacológica.</li>
+</ul>
+
+<h3>5.14 Preguntas — U5</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Paciente con trasplante fallido — ubicación del segundo riñón</summary>
+<div class="qa-body">
+<p>Paciente de 55 años portador de trasplante renal en fosa iliaca derecha (rechazo crónico). Recibe segundo trasplante. ¿Dónde se ubica el nuevo riñón?</p>
+<ol type="a">
+<li>En la misma fosa iliaca derecha tras extirpar el riñón no funcionante</li>
+<li><strong>Se implanta el riñón en posición heterotópica en la fosa iliaca izquierda. No es necesario extirpar el riñón no funcionante</strong></li>
+<li>Se implanta en posición ortotópica derecha tras extirpar el riñón nativo</li>
+<li>Se implanta en la misma fosa iliaca derecha por encima del riñón no funcionante</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Segundo trasplante = fosa iliaca contralateral (izquierda). El injerto fallido NO se extirpa salvo intolerancia, infección crónica o malignización. La implantación es siempre <em>heterotópica</em> en fosa iliaca.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Mejor candidato familiar para donar</summary>
+<div class="qa-body">
+<p>Paciente de 28 años con ERC terminal. Familiares disponibles como donantes. ¿Mejor candidato?</p>
+<ol type="a">
+<li>Padre de 65 años hipertenso mal controlado y diabético tipo 1</li>
+<li>Madre con litiasis renal y nefrocalcinosis</li>
+<li><strong>Hermana con estenosis de la unión pieloureteral derecha</strong></li>
+<li>Padre o hermana pueden ser candidatos adecuados</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Padre con DM + HTA mal controlada (alto riesgo de ERC) y madre con litiasis recurrente/nefrocalcinosis están descartados. Hermana con estenosis UPU unilateral puede donar el <em>riñón contralateral sano</em> tras evaluación.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Inmunosupresión en trasplante — INCORRECTA</summary>
+<div class="qa-body">
+<p>Señale la INCORRECTA en cuanto a la inmunosupresión en trasplante renal:</p>
+<ol type="a">
+<li>Se basa en la sinergia de acción de varios inmunosupresores</li>
+<li><strong>Se utiliza la misma combinación de fármacos para todos los pacientes: anticalcineurínico, micofenolato y esteroides</strong></li>
+<li>La inmunosupresión implica mayor riesgo de infecciones y tumores</li>
+<li>En pacientes de alto riesgo inmunológico, puede utilizarse terapia de inducción con anticuerpos policlonales (timoglobulina)</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (INCORRECTA).</strong> Aunque la combinación tacrolimús + MMF + esteroides es la más usada, NO es universal: se individualiza según riesgo inmunológico, comorbilidades, edad y tolerancia.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Ord 2025) Patrón de infecciones post-trasplante</summary>
+<div class="qa-body">
+<p>¿Cuál afirmación describe mejor el patrón temporal de las infecciones en trasplante renal?</p>
+<ol type="a">
+<li>Las infecciones oportunistas son más comunes en el primer mes postrasplante</li>
+<li>Las tardías (&gt; 6º mes) son exclusivamente causadas por microorganismos comunitarios</li>
+<li><strong>Las infecciones que ocurren entre el primer y sexto mes postrasplante suelen estar asociadas con la máxima inmunosupresión y patógenos oportunistas</strong></li>
+<li>Las infecciones nosocomiales son más frecuentes a partir del sexto mes postrasplante</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Periodo 1-6 meses = ventana de máxima inmunosupresión y máximo riesgo de oportunistas (CMV, BK, PJP, Aspergillus, micobacterias, listeria).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Donante vivo — INCORRECTA</summary>
+<div class="qa-body">
+<p>El trasplante del donante vivo tiene ventajas sobre el donante cadáver, pero ¿cuál es la respuesta INCORRECTA?</p>
+<ol type="a">
+<li>Ausencia de los fenómenos intrínsecos a la muerte cerebral</li>
+<li>Se puede hacer un estudio extenso del donante vivo</li>
+<li>El donante vivo suele tener menos patología asociada</li>
+<li><strong>El donante vivo tiene peor compatibilidad HLA</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d (INCORRECTA).</strong> Justamente lo contrario: el donante vivo suele tener <em>MEJOR compatibilidad HLA</em> (familiar) que el donante cadáver.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) Selección histológica del donante añoso (SCORE)</summary>
+<div class="qa-body">
+<p>En la histología para la selección del donante añoso, ¿qué factores se utilizan para aceptarlos o rechazarlos (SCORE)?</p>
+<ol type="a">
+<li>La esclerosis glomerular</li>
+<li>La atrofia tubular</li>
+<li>El edema celular</li>
+<li><strong>Son ciertas a y b</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> SCORE histológico (Karpinski/Remuzzi) valora: esclerosis glomerular, atrofia tubular, fibrosis intersticial, hialinosis arteriolar. La suma orienta a aceptación o descarte del injerto añoso.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U6 =============== -->
+<section class="card" id="u6">
+<h2 class="section-title"><span class="num">U6</span>Tumores del parénquima renal</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Carcinoma de células renales (CCR)</strong> = neoplasia renal maligna más frecuente del adulto (90 %). Incidencia: 3-4 % de los cánceres.</li>
+<li><strong>Factores de riesgo:</strong> <em>tabaco</em> (×2), obesidad, HTA, ERC en diálisis (riñones poliquísticos adquiridos), exposición a cadmio, asbesto, tricloroetileno, hemodiálisis prolongada, síndromes hereditarios (VHL, Birt-Hogg-Dubé, esclerosis tuberosa, leiomiomatosis hereditaria HLRCC).</li>
+<li><strong>Histología:</strong>
+  <ul>
+    <li><em>Células claras</em> (75 %) — mutación VHL (3p25), del cromosoma 3p.</li>
+    <li><em>Papilar tipo 1 y 2</em> (10-15 %) — mutación MET (HLRCC tipo 2).</li>
+    <li><em>Cromófobo</em> (5 %) — Birt-Hogg-Dubé. Mejor pronóstico.</li>
+    <li><em>De Bellini</em> / conductos colectores (raro, agresivo).</li>
+    <li><em>Sarcomatoide</em> = desdiferenciación de cualquier tipo, muy mal pronóstico.</li>
+    <li><em>Oncocitoma</em> = benigno (pero indistinguible radiológicamente del cromófobo).</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li><em>Mayoría: hallazgo incidental</em> en pruebas de imagen (60-70 %).</li>
+    <li><em>Tríada clásica</em> (TARDÍA, &lt; 10 %): <strong>dolor lumbar + hematuria + masa palpable</strong>.</li>
+    <li>Síndrome general: astenia, pérdida de peso, fiebre.</li>
+    <li>Varicocele derecho de novo en adulto → sospechar invasión cava.</li>
+  </ul>
+</li>
+<li><strong>Síndromes paraneoplásicos:</strong>
+  <ul>
+    <li><em>HTA</em> (renina).</li>
+    <li><em>Eritrocitosis</em> (EPO).</li>
+    <li><em>Hipercalcemia</em> (PTHrP).</li>
+    <li><em>Síndrome de Stauffer</em>: disfunción hepática reversible sin metástasis (↑ FA, ↑ transaminasas, hipoalbuminemia). Resuelve tras nefrectomía.</li>
+    <li>Síndrome de Cushing, anemia, amiloidosis, polineuropatía.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Ecografía (cribado inicial).</li>
+    <li><strong>TAC TAP con contraste</strong> en 3 fases (basal + nefrográfica + excretora) = gold standard. Estadifica también pulmón y hígado.</li>
+    <li>RMN si dudoso o trombo cava.</li>
+    <li>Gammagrafía ósea si dolor óseo o ↑ FA.</li>
+    <li>Biopsia renal pre-tratamiento: NO de rutina (riesgo de siembra); sí si vigilancia activa o sospecha de metástasis.</li>
+  </ul>
+</li>
+<li><strong>Vías de diseminación:</strong> hematógena (pulmón, hueso, hígado, SNC, contralateral), linfática (ganglios hiliares, retroperitoneales), por contigüidad, invasión vascular (vena renal, cava — trombo tumoral, AD).</li>
+</ul>
+</div>
+
+<h3>6.1 Estadificación TNM (CCR)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>T</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td>T1a</td><td>≤ 4 cm, limitado al riñón</td></tr>
+<tr><td>T1b</td><td>4-7 cm, limitado al riñón</td></tr>
+<tr><td>T2a</td><td>7-10 cm</td></tr>
+<tr><td>T2b</td><td>&gt; 10 cm, limitado al riñón</td></tr>
+<tr><td>T3a</td><td>Invasión de vena renal o grasa perirrenal/seno (sin sobrepasar fascia de Gerota)</td></tr>
+<tr><td>T3b</td><td>Trombo tumoral en VCI infradiafragmática</td></tr>
+<tr><td>T3c</td><td>Trombo tumoral en VCI supradiafragmática o invasión de la pared cava</td></tr>
+<tr><td>T4</td><td>Sobrepasa fascia de Gerota o invade glándula suprarrenal ipsilateral</td></tr>
+</tbody></table></div>
+
+<h3>6.2 Tratamiento según estadio</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Situación</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>Tumor T1a (&lt; 4 cm)</td><td><strong>Nefrectomía parcial</strong> (preserva función renal) · alternativas: vigilancia activa en mayores con comorbilidad, ablación percutánea (RF/crioablación)</td></tr>
+<tr><td>Tumor T1b (4-7 cm)</td><td>Nefrectomía parcial preferida si factible · si no, nefrectomía radical</td></tr>
+<tr><td>Tumor T2 (&gt; 7 cm)</td><td><strong>Nefrectomía radical</strong> laparoscópica/robótica</td></tr>
+<tr><td>Tumor T3</td><td>Nefrectomía radical ± trombectomía cava (cirugía cardíaca con bypass en T3c)</td></tr>
+<tr><td>N+</td><td>Linfadenectomía regional</td></tr>
+<tr><td>M+ (metastásico)</td><td>Tratamiento sistémico ± nefrectomía citorreductora si carga sintomática</td></tr>
+</tbody></table></div>
+
+<h3>6.3 Tratamiento sistémico del CCR metastásico</h3>
+<ul>
+<li>El CCR es <em>quimio y radiorresistente</em>. La inmunoterapia y los TKI son la base.</li>
+<li><strong>Inhibidores tirosina cinasa (TKI) anti-VEGFR:</strong> sunitinib, pazopanib, cabozantinib, axitinib.</li>
+<li><strong>Inhibidores mTOR:</strong> everolimus, temsirolimus.</li>
+<li><strong>Inmunoterapia (inhibidores de checkpoint):</strong>
+  <ul>
+    <li>Anti-PD-1: nivolumab, pembrolizumab.</li>
+    <li>Anti-CTLA-4: ipilimumab.</li>
+    <li>Combinaciones: nivolumab + ipilimumab; pembrolizumab + axitinib; cabozantinib + nivolumab → primera línea actual en riesgo intermedio/alto.</li>
+  </ul>
+</li>
+<li>Clasificación de riesgo IMDC (International Metastatic RCC Database Consortium): tiempo desde diagnóstico &lt; 1 a, Karnofsky &lt; 80, anemia, hipercalcemia, neutrofilia, trombocitosis. 0 = bajo, 1-2 = intermedio, ≥ 3 = alto.</li>
+</ul>
+
+<h3>6.4 Tumores benignos del riñón</h3>
+<ul>
+<li><strong>Oncocitoma</strong> (3-7 % de tumores renales): origen tubular distal, citoplasma eosinófilo, cicatriz central radial. Indistinguible radiológicamente del CCR cromófobo → habitualmente se reseca como CCR.</li>
+<li><strong>Angiomiolipoma (AML)</strong>: tumor benigno mesenquimal compuesto de vasos + músculo liso + grasa madura. <em>Reconocido en TC por la grasa (-30 a -100 UH)</em>. Mujer 4:1. Asociado a <em>esclerosis tuberosa</em> (60 % presentan AML bilaterales múltiples).
+  <ul>
+    <li>&lt; 4 cm asintomático → vigilancia ecográfica anual.</li>
+    <li>&gt; 4 cm o sintomático → <em>embolización selectiva preferida</em> (preserva parénquima); cirugía si dudoso.</li>
+    <li>Complicación temible: <em>síndrome de Wunderlich</em> = hemorragia retroperitoneal espontánea por rotura del AML.</li>
+    <li>En esclerosis tuberosa con AML múltiples: <em>everolimus</em> (inhibidor mTOR) reduce el tamaño.</li>
+  </ul>
+</li>
+<li>Adenoma renal, fibroma, leiomioma, hemangioma — raros.</li>
+</ul>
+
+<h3>6.5 Tumor de Wilms (nefroblastoma)</h3>
+<ul>
+<li>Tumor renal maligno más frecuente <em>en niños</em> (1:10.000), pico 2-5 años.</li>
+<li>Asociado a <em>WT1, WT2</em> (síndrome WAGR: Wilms + Aniridia + anomalías Genitourinarias + Retraso mental; Beckwith-Wiedemann; Denys-Drash).</li>
+<li>Clínica: masa abdominal palpable, asintomática, HTA, hematuria, dolor.</li>
+<li>Tratamiento: nefrectomía + QT (vincristina + dactinomicina ± doxorrubicina) ± RT. Supervivencia &gt; 90 %.</li>
+</ul>
+
+<h3>6.6 Pronóstico del CCR</h3>
+<ul>
+<li>Supervivencia a 5 años por estadio: T1a ≈ 95 %, T1b 80 %, T2 70 %, T3 ≈ 50 %, T4/M+ &lt; 15 %.</li>
+<li>Factores pronósticos: estadio TNM, grado nuclear de Fuhrman, histología (cromófobo mejor que claras; sarcomatoide muy malo), tamaño, márgenes, comorbilidad, función renal.</li>
+</ul>
+
+<h3>6.7 Preguntas — U6</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Hallazgo casual de nódulo renal 75 mm — siguiente paso</summary>
+<div class="qa-body">
+<p>Paciente de 53 años con apendicitis aguda. Ecografía: nódulo de 75 mm en riñón derecho. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Solicitar RNM abdominal</li>
+<li>Solicitar ecografía abdominal con contraste</li>
+<li><strong>Solicitar TAC toraco-abdomino-pélvico</strong></li>
+<li>Solicitar PET-TAC con colina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Sospecha de tumor renal → TAC TAP con contraste para caracterizar la lesión y estadificar (descartar adenopatías, trombo cava, metástasis pulmonares y hepáticas).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Mujer joven con angiomiolipoma 55 mm exofítico</summary>
+<div class="qa-body">
+<p>Mujer de 35 años con lesión renal izquierda exofítica de 55 mm compatible con angiomiolipoma. ¿Opción más adecuada?</p>
+<ol type="a">
+<li>Observación y seguimiento anual</li>
+<li>No precisa seguimiento al ser benigna</li>
+<li><strong>Embolización selectiva del angiomiolipoma</strong></li>
+<li>Nefrectomía radical</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Angiomiolipoma <em>&gt; 4 cm</em> tiene riesgo de hemorragia espontánea (síndrome de Wunderlich) → embolización selectiva como tratamiento de elección. Conserva parénquima. Si &lt; 4 cm → seguimiento.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Masa renal 10 cm + adenopatías periaórticas en paciente birreno</summary>
+<div class="qa-body">
+<p>Paciente de 70 años, birreno, con hematuria. Masa renal izquierda de 10 cm circunscrita + adenopatías periaórticas. ¿Tratamiento?</p>
+<ol type="a">
+<li>Radioterapia</li>
+<li>Nefrectomía parcial</li>
+<li><strong>Nefrectomía radical</strong></li>
+<li>Inmunoterapia sistémica</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tumor &gt; 7 cm (T2) con adenopatías = nefrectomía radical citorreductora + linfadenectomía. La radioterapia NO es útil en CCR (poco radiosensible). La inmunoterapia se añadiría después en metastásico.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Angiomiolipoma de 3 cm — actitud</summary>
+<div class="qa-body">
+<p>Hombre de 55 años al que en ECO por cólico nefrítico se le diagnostica angiomiolipoma de 3 cm en riñón derecho. Actitud:</p>
+<ol type="a">
+<li>Extirpar con nefrectomía</li>
+<li><strong>Observación y seguimiento ecográfico para controlar su crecimiento</strong></li>
+<li>Radioterapia</li>
+<li>Todas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Angiomiolipoma &lt; 4 cm asintomático → vigilancia ecográfica anual.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U7 =============== -->
+<section class="card" id="u7">
+<h2 class="section-title"><span class="num">U7</span>Tumores del urotelio · cáncer vesical</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Carcinoma urotelial</strong> = 90 % de los tumores vesicales. <em>Pancarcinoma del urotelio</em>: puede originarse en cualquier punto entre cálices y uretra prostática.</li>
+<li><strong>Variantes histológicas:</strong>
+  <ul>
+    <li>Carcinoma urotelial (transicional) — 90 %.</li>
+    <li>Carcinoma <em>escamoso</em> — Schistosoma haematobium, irritación crónica (sonda vesical, litiasis), exstrofia.</li>
+    <li>Adenocarcinoma — uraco, cistitis glandular, exstrofia.</li>
+    <li>Carcinoma de células pequeñas, sarcomatoide, plasmocitoide — raros, agresivos.</li>
+  </ul>
+</li>
+<li><strong>Factores de riesgo:</strong>
+  <ul>
+    <li><em>TABACO</em> (×3-4, FR más importante; 50 % de los casos en varones, 30 % en mujeres).</li>
+    <li>Aminas aromáticas (anilinas, β-naftilamina, bencidina): trabajadores de tintes, gomas, peluquerías, pinturas.</li>
+    <li>Ciclofosfamida (acroleína → uropatía irritativa).</li>
+    <li>Radioterapia pélvica.</li>
+    <li>Infección crónica por <em>Schistosoma haematobium</em> → carcinoma escamoso.</li>
+    <li>Cistitis crónica, sondaje permanente.</li>
+    <li>Aristolochia (hierba china, también nefropatía).</li>
+  </ul>
+</li>
+<li><strong>Síntoma cardinal: <span class="tag warn">HEMATURIA MACROSCÓPICA MONOSINTOMÁTICA INDOLORA</span></strong>. <em>Toda hematuria en &gt; 40-50 a. o con factores de riesgo obliga a cistoscopia + citología</em>.</li>
+<li>Otros: hematuria microscópica, síntomas irritativos (polaquiuria, urgencia — sospechar CIS), masa pélvica, edema MMII (obstrucción venosa), uropatía obstructiva por invasión ureteral.</li>
+<li><strong>División clínica:</strong>
+  <ul>
+    <li><strong>NMIBC</strong> (no músculo-invasivo, 75 %): Ta, T1, Tis. <em>RTU vesical + BCG intravesical</em>.</li>
+    <li><strong>MIBC</strong> (músculo-invasivo, 25 %): ≥ T2. <em>Cistectomía radical + linfadenectomía + derivación urinaria</em>.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>7.1 Diagnóstico</h3>
+<ul>
+<li><strong>Cistoscopia</strong>: prueba diagnóstica de referencia. Visualiza la lesión y permite biopsia/RTU.</li>
+<li><strong>Citología urinaria</strong>: alta sensibilidad para tumores de alto grado y CIS; baja para bajo grado.</li>
+<li><strong>UroTC con fase excretora</strong>: estudia urotelio superior (cálices, uréter), estadia el tumor (extensión local), valora N y M.</li>
+<li>RMN: alternativa al TC para estadiar localmente.</li>
+<li>Biomarcadores urinarios (NMP22, UroVysion, BTA): rol limitado.</li>
+</ul>
+
+<h3>7.2 TNM del cáncer vesical (lo esencial)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>T</th><th>Significado</th></tr></thead>
+<tbody>
+<tr><td><strong>Ta</strong></td><td>Papilar no invasivo (confinado al epitelio)</td></tr>
+<tr><td><strong>Tis</strong></td><td>Carcinoma in situ (plano, alto grado, multifocal — pre-MIBC)</td></tr>
+<tr><td><strong>T1</strong></td><td>Invade <strong>lámina propia / submucosa</strong></td></tr>
+<tr><td><strong>T2a / T2b</strong></td><td>Invade músculo (superficial / profundo)</td></tr>
+<tr><td><strong>T3a / T3b</strong></td><td>Invade grasa perivesical (microscópica / macroscópica visible en imagen)</td></tr>
+<tr><td><strong>T4a / T4b</strong></td><td>Órganos vecinos (próstata, vagina, útero / pared pélvica o abdominal)</td></tr>
+</tbody></table></div>
+<p><strong>N:</strong> N0 = sin ganglios; N1 = un ganglio en pelvis verdadera; N2 = múltiples pélvicos; N3 = iliaco común.<br>
+<strong>M:</strong> M0 / M1 (ganglios distantes, hueso, hígado, pulmón).</p>
+
+<h3>7.3 Manejo del NMIBC (Ta, T1, Tis)</h3>
+<ol>
+<li><strong>RTU vesical</strong>: terapéutica y diagnóstica. Se reseca el tumor + muestra de músculo para asegurar estadificación.</li>
+<li><strong>Re-RTU a las 2-6 semanas</strong> en T1 alto grado o RTU incompleta (10-25 % infraestadificados).</li>
+<li><strong>Estratificación de riesgo (EAU 2024):</strong>
+  <ul>
+    <li><em>Bajo riesgo</em>: TaG1 único &lt; 3 cm, primario.</li>
+    <li><em>Intermedio</em>: resto, sin características de alto riesgo.</li>
+    <li><em>Alto riesgo</em>: T1, alto grado/G3, CIS, &gt; 3 cm, multifocal, recurrente.</li>
+    <li><em>Muy alto riesgo</em>: T1 alto grado + CIS, T1 con variantes histológicas, fracaso de BCG.</li>
+  </ul>
+</li>
+<li><strong>Terapia adyuvante intravesical:</strong>
+  <ul>
+    <li>Bajo riesgo: <em>instilación única postoperatoria</em> de mitomicina o epirubicina dentro de 6 h post-RTU.</li>
+    <li>Intermedio: <em>quimio intravesical</em> (mitomicina, epirubicina) 6-12 semanas + mantenimiento.</li>
+    <li>Alto/muy alto riesgo: <strong>BCG intravesical</strong> (inducción 6 semanas + mantenimiento 1-3 años, esquema SWOG). Alternativa: cistectomía radical en muy alto riesgo o fracaso de BCG.</li>
+  </ul>
+</li>
+<li><strong>Carcinoma in situ (Tis)</strong>: <em>BCG intravesical</em> es el tratamiento de elección.</li>
+</ol>
+
+<h3>7.4 Manejo del MIBC (≥ T2)</h3>
+<ol>
+<li><strong>QT neoadyuvante</strong> (cisplatino + gemcitabina o MVAC dosis densa): mejora supervivencia un 5-8 %. Indicada si función renal y estado general lo permiten.</li>
+<li><strong>Cistectomía radical + linfadenectomía pélvica ampliada</strong>:
+  <ul>
+    <li>En varón: cistoprostatectomía radical.</li>
+    <li>En mujer: cistectomía + histerectomía + anexectomía + pared anterior vaginal.</li>
+  </ul>
+</li>
+<li><strong>Derivación urinaria</strong>:
+  <ul>
+    <li><em>Cutánea no continente</em>: Bricker (conducto ileal) — la más sencilla y frecuente.</li>
+    <li><em>Cutánea continente</em>: Indiana, Kock (catéter intermitente).</li>
+    <li><em>Ortotópica</em>: neovejiga ileal (Studer, Hautmann) — preserva micción por uretra. Indicada en pacientes con buen estado y uretra libre de tumor.</li>
+  </ul>
+</li>
+<li>QT adyuvante si pT3-T4 o N+ y no recibió neoadyuvante.</li>
+<li><strong>Tratamiento alternativo conservador</strong> ("trimodal therapy"): RTU máxima + QT + RT con conservación vesical en seleccionados.</li>
+</ol>
+
+<h3>7.5 Enfermedad metastásica</h3>
+<ul>
+<li><strong>1ª línea:</strong> QT basada en cisplatino (gemcitabina + cisplatino o MVAC dosis densa).</li>
+<li><em>Cisplatino-no apto</em> (FR &lt; 60, ECOG &gt; 1, hipoacusia, neuropatía): carboplatino + gemcitabina o inmunoterapia.</li>
+<li><strong>Inmunoterapia (anti-PD-1/PD-L1)</strong>: pembrolizumab, nivolumab, atezolizumab, avelumab. Mantenimiento con avelumab tras respuesta a QT.</li>
+<li><strong>Anticuerpos conjugados (enfortumab vedotin, sacituzumab govitecan)</strong> en líneas posteriores.</li>
+<li>FGFR inhibidores (erdafitinib) si mutación FGFR3.</li>
+</ul>
+
+<h3>7.6 Tumores del urotelio alto (pelvis renal y uréter)</h3>
+<ul>
+<li>5-10 % de tumores uroteliales. Más en varones, edad media 70 a.</li>
+<li>Asociación a <em>síndrome de Lynch (HNPCC)</em>: defectos de reparación MMR.</li>
+<li>Clínica: hematuria + dolor lumbar (cólico por coágulos), masa.</li>
+<li>Diagnóstico: UroTC + ureteroscopia ± citología por lavado.</li>
+<li>Tratamiento: <em>nefroureterectomía con manguito vesical</em> (extirpación del riñón + uréter completo + rodete de vejiga alrededor del meato).</li>
+<li>Alternativa conservadora (tumor bajo grado, monorreno): ureteroscopia con láser.</li>
+</ul>
+
+<h3>7.7 Seguimiento</h3>
+<ul>
+<li>NMIBC: cistoscopia + citología cada 3 m (1er año), después espaciado según riesgo. UroTC anual en alto riesgo.</li>
+<li>MIBC postcistectomía: TC TAP cada 3-6 m los primeros 2-3 años.</li>
+</ul>
+
+<h3>7.8 Preguntas — U7</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Cistectomía radical + Tis + ganglios + sin estudio extensión — TNM</summary>
+<div class="qa-body">
+<p>Paciente de 56 años con hematuria, tumor vesical refractario a BCG. Se hace cistectomía radical y linfadenectomía pélvica e iliobturatriz. Histología: tumor que infiltra ampliamente la submucosa con áreas de carcinoma in situ + varios ganglios positivos en obturatriz e iliaca externa bilateral. NO se ha hecho estudio de extensión con imagen. ¿TNM?</p>
+<ol type="a">
+<li>pT2N1M1</li>
+<li>pT2N2M0</li>
+<li><strong>pT1N2Mx</strong></li>
+<li>pT1N2M0</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> "Infiltra ampliamente submucosa" = T1 (sin músculo). Múltiples ganglios pélvicos = N2. Sin estudio de imagen para metástasis a distancia = <em>Mx</em> (no M0).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Mujer fumadora con hematuria macroscópica — actitud</summary>
+<div class="qa-body">
+<p>Mujer de 57 años, fumadora de 15 cig/día, con varios episodios de hematuria macroscópica monosintomática con coágulos. Antecedente de litotricia hace 5 a. EF: cistocele moderado. Ecografía sin alteraciones salvo cistocele. ¿Actitud?</p>
+<ol type="a">
+<li>Tratamiento antibiótico al tratarse probablemente de una infección</li>
+<li>TC abdomino-pélvico sin contraste para descartar recidiva litiásica</li>
+<li>Colocación de malla anterior, al ser el cistocele la causa</li>
+<li><strong>Llevar a cabo una cistoscopia para descartar tumor de vejiga</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> <em>Hematuria macroscópica monosintomática + fumadora + edad &gt; 50</em> = cistoscopia obligatoria (cáncer vesical hasta demostrar lo contrario). El cistocele no produce hematuria. La litiasis ya estaría visible en eco.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Carcinoma urotelial con infiltración microscópica de grasa — TNM</summary>
+<div class="qa-body">
+<p>Paciente de 56 años. RTU vesical: carcinoma urotelial con infiltración microscópica de la grasa. ¿Diagnóstico?</p>
+<ol type="a">
+<li><strong>Carcinoma urotelial pT3a</strong></li>
+<li>Carcinoma urotelial pT2a</li>
+<li>Carcinoma urotelial pT3b</li>
+<li>Carcinoma urotelial pT2b</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Infiltración microscópica de grasa perivesical = pT3a (pT3b = macroscópica visible en imagen).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Tratamiento del carcinoma in situ de vejiga</summary>
+<div class="qa-body">
+<p>El tratamiento de elección para el carcinoma in situ de vejiga es:</p>
+<ol type="a">
+<li>Radioterapia conformada</li>
+<li>Quimioterapia intravesical con cisplatino</li>
+<li><strong>Administración de BCG intravesical</strong></li>
+<li>Quimioterapia sistémica</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tis (alto grado plano) → BCG intravesical (inducción + mantenimiento) tras RTU. Si refractario → cistectomía radical.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U8 =============== -->
+<section class="card" id="u8">
+<h2 class="section-title"><span class="num">U8</span>Infecciones urinarias inespecíficas · cistopatías</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Definiciones:</strong>
+  <ul>
+    <li><em>Bacteriuria significativa</em>: ≥ 10⁵ UFC/mL en chorro medio o ≥ 10³ en mujer sintomática o ≥ 10² en muestra por sonda.</li>
+    <li><em>ITU complicada</em>: anomalías estructurales/funcionales, comorbilidad (DM, IS, embarazo), varón, niño, ITU nosocomial, sonda.</li>
+    <li><em>ITU recurrente</em>: ≥ 3/año o ≥ 2/6 m.</li>
+    <li><em>ITU recidivante</em>: misma cepa (foco no erradicado).</li>
+    <li><em>Reinfección</em>: cepa diferente.</li>
+  </ul>
+</li>
+<li><strong>Etiología (orden de frecuencia):</strong>
+  <ul>
+    <li><strong>E. coli (75-90 %)</strong></li>
+    <li>Klebsiella pneumoniae</li>
+    <li>Proteus mirabilis (cálculos de estruvita)</li>
+    <li>Enterococcus faecalis</li>
+    <li>Staphylococcus saprophyticus (mujer joven, postcoital)</li>
+    <li>Pseudomonas, Serratia (nosocomial, sonda)</li>
+  </ul>
+</li>
+<li><strong>Vías de infección:</strong> ascendente (la más frecuente, 99 %), hematógena (TBC renal, S. aureus), linfática, contigüidad.</li>
+<li><strong>Factores defensivos del huésped:</strong> chorro miccional, pH ácido, mucina vesical (capa de glucosaminoglicanos), IgA secretora, péptidos antimicrobianos (defensinas, catelicidinas), descamación urotelial.</li>
+<li><strong>Factores de riesgo:</strong> mujer (uretra corta), menopausia (déficit estrogénico vaginal), actividad sexual, anticonceptivos espermicidas, embarazo, diabetes, anomalías anatómicas, sondaje, IS, edad avanzada.</li>
+</ul>
+</div>
+
+<h3>8.1 Cistitis aguda no complicada</h3>
+<ul>
+<li>Mujer no embarazada, premenopáusica, sin comorbilidades.</li>
+<li><strong>Clínica:</strong> <em>disuria + polaquiuria + tenesmo + urgencia ± hematuria terminal</em>, sin fiebre ni dolor lumbar.</li>
+<li><strong>Diagnóstico:</strong> clínica + tira reactiva (leucocitos + nitritos +). <em>NO se necesita urocultivo</em> en primer episodio típico.</li>
+<li><strong>Tratamiento empírico:</strong>
+  <ul>
+    <li><strong>1ª línea:</strong> <em>Fosfomicina trometamol 3 g VO dosis única</em> O nitrofurantoína 100 mg/12 h × 5 días.</li>
+    <li>Alternativa: pivmecillinam 400 mg/8 h × 3-5 días.</li>
+    <li><em>NO usar quinolonas como 1ª línea</em> (resistencias y efectos adversos).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.2 Pielonefritis aguda (PNA)</h3>
+<ul>
+<li><strong>Clínica:</strong> fiebre alta + escalofríos + dolor lumbar (Murphy renal +) + síntomas miccionales (no siempre).</li>
+<li><strong>Diagnóstico:</strong> tira + sedimento + urocultivo + hemocultivos (si fiebre alta) + analítica (leucocitosis, ↑ PCR/PCT).</li>
+<li><strong>Imagen:</strong>
+  <ul>
+    <li>Ecografía: descarta obstrucción/absceso. Indicada si PNA grave, mala evolución, hombre, diabético, monorreno.</li>
+    <li>TC con contraste: si sospecha de absceso o PN enfisematosa.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>No complicada, paciente estable</em>: ciprofloxacino oral 7 d o cefditoreno o cefuroxima axetilo 10 d.</li>
+    <li><em>Hospitalización</em> si: vómitos, hipotensión, embarazo, IR, dudas, complicada. <em>Ceftriaxona 1-2 g/d iv</em> o piperacilina-tazobactam si resistencias o nosocomial.</li>
+    <li><em>Alergia a β-lactámicos</em>: aztreonam (anafilaxia) o quinolona.</li>
+    <li>Duración: 7-14 días en total.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.3 ITU complicadas</h3>
+<ul>
+<li><strong>Anatómicas/funcionales:</strong> litiasis, HBP, vejiga neurógena, RVU, sonda permanente, trasplante renal.</li>
+<li><strong>Sistémicas:</strong> DM, IS, embarazo, IR, edad avanzada.</li>
+<li><strong>Pielonefritis enfisematosa</strong>:
+  <ul>
+    <li><em>Diabéticos en cetoacidosis</em>. E. coli (más frecuente), Klebsiella.</li>
+    <li>Gas en parénquima renal visible en TC (clasificación de Huang-Tseng I-IV).</li>
+    <li>Mortalidad 20-40 %. Tratamiento: ATB iv + drenaje percutáneo o nefrostomía. <em>Nefrectomía</em> en formas extensas (III-IV).</li>
+  </ul>
+</li>
+<li><strong>Absceso renal</strong>: corticomedular o perirrenal. Fiebre persistente bajo ATB. Eco/TC. Tratamiento: drenaje percutáneo + ATB iv prolongado.</li>
+<li><strong>Pionefrosis</strong>: distensión del sistema colector con pus. <em>Derivación urinaria URGENTE</em> + ATB.</li>
+</ul>
+
+<h3>8.4 ITU recurrente en mujer</h3>
+<ul>
+<li>Estudio: anamnesis, urocultivo, eco vesical y renal, glucemia. Cistoscopia si dudosa. Cuestionario de actividad sexual.</li>
+<li><strong>Profilaxis:</strong>
+  <ul>
+    <li>Higiénico-dietéticas: hidratación, micción postcoital, evitar espermicidas, ropa interior cómoda.</li>
+    <li>Estrógenos vaginales en postmenopáusica.</li>
+    <li>Arándano rojo: discutida eficacia.</li>
+    <li>D-manosa, probióticos (Lactobacillus): controvertida.</li>
+    <li><em>Profilaxis ATB continua</em> 6-12 m: nitrofurantoína 50-100 mg, fosfomicina 3 g cada 10 d, TMP-SMX a dosis bajas.</li>
+    <li>Profilaxis postcoital si ITU coital.</li>
+    <li>Vacunas (Uromune, Uro-Vaxom).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.5 ITU en el varón</h3>
+<ul>
+<li>SIEMPRE considerada <em>complicada</em>. Investigar HBP, próstata, anomalías, litiasis.</li>
+<li>Tratamiento: similar pero más prolongado (10-14 d). Si afecta a próstata (próstata caliente y dolorosa en TR) = prostatitis aguda (ver U13).</li>
+</ul>
+
+<h3>8.6 ITU en embarazo</h3>
+<ul>
+<li>Bacteriuria asintomática <em>SE TRATA</em> (riesgo de PNA en embarazo y de parto prematuro).</li>
+<li>Cultivos en cada trimestre.</li>
+<li>ATB seguros: <em>fosfomicina, nitrofurantoína (evitar en 3er trimestre), cefalosporinas, β-lactámicos</em>.</li>
+<li>Evitar: quinolonas, TMP-SMX (1er trimestre).</li>
+</ul>
+
+<h3>8.7 Bacteriuria asintomática (BAS)</h3>
+<ul>
+<li><strong>SE TRATA solo en:</strong>
+  <ul>
+    <li>Embarazo.</li>
+    <li>Niños con RVU.</li>
+    <li>Antes de cirugía urológica con manipulación de mucosa.</li>
+    <li>Trasplantado renal en los primeros meses (controvertido tras 3-6 m).</li>
+    <li>Neutropénico.</li>
+  </ul>
+</li>
+<li><strong>NO se trata:</strong> ancianos institucionalizados, diabéticos, ERC, sondados permanentes, mujer no embarazada.</li>
+</ul>
+
+<h3>8.8 Cistitis intersticial / síndrome doloroso vesical</h3>
+<ul>
+<li>Mujer 40-50 a. <em>Dolor pélvico crónico + polaquiuria + urgencia + nicturia</em>, urocultivos negativos repetidos.</li>
+<li>Diagnóstico de exclusión. Cistoscopia con hidrodistensión: <em>glomerulaciones, úlcera de Hunner</em>. Biopsia para descartar otros.</li>
+<li>Tratamiento escalonado: dieta (evitar café, picantes, cítricos), pentosán polisulfato (Elmiron), instilaciones intravesicales (DMSO, heparina, ácido hialurónico), amitriptilina, antihistamínicos, neuromodulación, ciclosporina, cistectomía (último recurso).</li>
+</ul>
+
+<h3>8.9 Preguntas — U8</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Cistitis simple en mujer joven — tratamiento</summary>
+<div class="qa-body">
+<p>Mujer de 24 años con escozor miccional, polaquiuria desde hace 24 h. Tira reactiva: leucocituria, microhematuria, nitritos positivos. ¿Qué recomendar?</p>
+<ol type="a">
+<li>Completar estudio con eco vesical y urocultivo, por infección recurrente</li>
+<li>Solicitar urocultivo e iniciar antibiótico amplio espectro</li>
+<li><strong>Dosis única de fosfomicina trometamol 3 g</strong></li>
+<li>Azitromicina 500 mg/24 h durante 5 días</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Cistitis simple aguda en mujer joven sin recurrencia (un episodio leve hace 3 a. no cuenta) → fosfomicina trometamol 3 g VO en dosis única (o nitrofurantoína 100 mg/12 h × 5 días). No requiere urocultivo de rutina.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Sedimento con células epiteliales abundantes y flora variada</summary>
+<div class="qa-body">
+<p>Mujer de 25 años con disuria y polaquiuria. Cultivo: "en el sedimento se observan muy abundantes células epiteliales de posible origen vaginal y flora muy variada". ¿Interpretación?</p>
+<ol type="a">
+<li>Probable infección urinaria de origen genital</li>
+<li>Bacteriuria asintomática, no requiere tratamiento</li>
+<li>Infección urinaria polimicrobiana</li>
+<li><strong>Las condiciones de recogida no han sido adecuadas y es poco apta para estudio</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Células escamosas + flora variada = <em>contaminación vaginal</em>. Hay que repetir la muestra con técnica adecuada (chorro medio tras lavado).</div>
+</div></details>
+
+</section>
+
+<!-- =============== U9 =============== -->
+<section class="card" id="u9">
+<h2 class="section-title"><span class="num">U9</span>Infecciones específicas: TBC urogenital, uretritis y ETS</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>"Infecciones específicas" del aparato urinario: <em>TBC urogenital</em>, schistosomiasis, brucelosis, sífilis, infecciones por Mycoplasma/Ureaplasma, Trichomonas, gonococo.</li>
+<li><strong>TBC urogenital</strong> = segunda localización extrapulmonar más frecuente (15-20 % de TBC extrapulmonares). Reactivación tardía (10-30 años post-primoinfección).</li>
+<li><strong>Diagnóstico:</strong> tinción ácido-alcohol resistente (Auramina/Ziehl-Neelsen) + <em>cultivo en Löwenstein-Jensen</em> (gold standard, lento: 4-8 sem) de 3-6 muestras de primera orina de la mañana, o <em>PCR (Xpert MTB/RIF)</em>.</li>
+<li><strong>Tratamiento</strong>: HRZE × 2 meses + HR × 4 meses + <em>cirugía si secuelas</em> (estenosis, vejiga retraída, riñón no funcionante).</li>
+</ul>
+</div>
+
+<h3>9.1 TBC urogenital</h3>
+
+<h4>Fisiopatología</h4>
+<p>El bacilo llega al riñón por <em>vía hematógena</em> desde un foco pulmonar primario. Se siembra en la cortical renal, donde forma microgranulomas. Tras años de latencia, se reactiva en la médula → caseificación → comunicación con la vía urinaria → siembra descendente del bacilo en uréter, vejiga, próstata, epidídimo. Las lesiones ulcerocaseosas se reparan con fibrosis → estenosis (pieloureteral, ureteral distal) y retracción vesical.</p>
+
+<h4>Manifestaciones clínicas</h4>
+<ul>
+<li>Inicio insidioso, evolución crónica. Mayoría asintomática durante años.</li>
+<li><em>Síntomas urinarios bajos</em>: polaquiuria, urgencia, disuria, hematuria terminal, dolor suprapúbico. <strong>Cultivos negativos repetidos en paciente con síndrome cistítico crónico → sospechar TBC</strong>.</li>
+<li>Dolor lumbar tipo cólico (por estenosis ureteral).</li>
+<li>Síntomas constitucionales (fiebre, sudores, pérdida de peso).</li>
+<li>Afectación genital (varón): epididimitis tórpida con nodularidad indolora, fístulas escrotales.</li>
+</ul>
+
+<h4>Localización vesical</h4>
+<p><strong>Trígono y proximidades de los orificios ureterales</strong> (zonas donde aterriza la orina con bacilos desde el uréter). Lesiones evolutivas:</p>
+<ol>
+<li>Eritema periorificial.</li>
+<li>Edema bulloso.</li>
+<li>Granulomas (tubérculos), <em>"orificio en boca de pez"</em>.</li>
+<li>Ulceración.</li>
+<li>Estenosis o reflujo del meato.</li>
+<li><strong>Vejiga pequeña / retraída</strong>: fibrosis terminal con capacidad &lt; 100 mL, polaquiuria invalidante.</li>
+</ol>
+
+<h4>Diagnóstico</h4>
+<ul>
+<li><strong>Microbiológico:</strong>
+  <ul>
+    <li>Tinción Auramina-rodamina (más sensible) o Ziehl-Neelsen — solo positiva con alta carga bacilar.</li>
+    <li><strong>Cultivo en Löwenstein-Jensen</strong> de 3-6 muestras de <em>primera orina de la mañana</em> (gold standard pero lento).</li>
+    <li><em>PCR (Xpert MTB/RIF)</em>: rápida, detecta también resistencia a rifampicina.</li>
+  </ul>
+</li>
+<li><strong>Imagen:</strong>
+  <ul>
+    <li>UroTC: calcificaciones renales irregulares (40 %), cavidades caseosas, hidronefrosis con estenosis ureterales múltiples ("uréter arrosariado" o "uréter en tubería de pipa"), vejiga pequeña.</li>
+    <li>Urografía intravenosa (clásica): cálices "comidos por polilla", riñón excluido, estenosis pieloureteral.</li>
+  </ul>
+</li>
+<li><strong>Cistoscopia con biopsia:</strong> granulomas con necrosis caseosa + Ziehl en biopsia.</li>
+<li>Mantoux/IGRA y Rx tórax (frecuente TBC pulmonar latente o curada asociada).</li>
+</ul>
+
+<h4>Tratamiento</h4>
+<ul>
+<li><strong>Farmacológico (SIEMPRE primero)</strong>:
+  <ul>
+    <li>Fase intensiva (2 m): <em>isoniazida (H) + rifampicina (R) + pirazinamida (Z) + etambutol (E)</em>.</li>
+    <li>Fase de continuación (4 m): <em>H + R</em>.</li>
+    <li>Total: 6 meses (puede prolongarse a 9-12 en formas graves o secuelas).</li>
+    <li>Adultos en TBC genitourinaria <em>no necesitan prolongación rutinaria</em> &gt; 6 m si responde bien.</li>
+  </ul>
+</li>
+<li><strong>Quirúrgico (complementario o para secuelas)</strong>:
+  <ul>
+    <li>Tras 4-6 sem de farmacoterapia (esperar para reducir inflamación).</li>
+    <li>Doble J o reimplante en estenosis ureteral.</li>
+    <li>Ampliación vesical (cistoplastia con segmento intestinal) en vejiga retraída.</li>
+    <li>Nefrectomía en riñón no funcionante con dolor o hipertensión.</li>
+  </ul>
+</li>
+<li><strong>Si no se identifica el bacilo</strong> pero la sospecha es alta: NO iniciar tratamiento sin confirmar (toxicidad farmacológica). Repetir muestras + biopsia + descartar otras causas (schistosomiasis, malacoplaquia, tumores).</li>
+</ul>
+
+<h3>9.2 Schistosomiasis urinaria</h3>
+<ul>
+<li><strong>Etiología:</strong> <em>Schistosoma haematobium</em> (también S. mansoni intestinal).</li>
+<li><strong>Endémica</strong> en África subsahariana, Egipto, Mali, Libia, Oriente Medio.</li>
+<li><strong>Ciclo:</strong> larvas (cercarias) penetran piel en agua dulce → migran a vénulas vesicales → adultos depositan huevos en submucosa vesical → reacción granulomatosa.</li>
+<li><strong>Clínica:</strong> hematuria terminal indolora (clásica en niños africanos), polaquiuria, disuria. Crónica: <em>fibrosis vesical, calcificaciones vesicales</em> "vejiga con cáscara de huevo" en Rx, <em>estenosis ureteral distal con ureterohidronefrosis</em>.</li>
+<li><strong>Complicación:</strong> <em>carcinoma escamoso de vejiga</em>.</li>
+<li><strong>Diagnóstico:</strong> huevos con espolón terminal en orina (recogida postejercicio en la última micción de la tarde — pregunta clave). Serología, PCR. Biopsia vesical: granulomas con huevos calcificados.</li>
+<li><strong>Tratamiento:</strong> <em>praziquantel 40 mg/kg VO en dosis única</em>.</li>
+</ul>
+
+<h3>9.3 Uretritis (ETS más frecuente)</h3>
+<div class="compare">
+<div>
+<h4>Gonocócica (GU)</h4>
+<ul>
+<li><em>Neisseria gonorrhoeae</em> (diplococo Gram−)</li>
+<li>Incubación 2-7 días</li>
+<li>Secreción purulenta abundante, disuria intensa</li>
+<li>Diagnóstico: Gram (diplococos intracelulares), PCR de orina/exudado</li>
+<li>Tratamiento: <strong>ceftriaxona 500 mg IM DU + azitromicina 1 g VO DU</strong> (cubre coinfección con Chlamydia)</li>
+<li>Complicaciones: epididimitis, prostatitis, infertilidad, artritis gonocócica</li>
+</ul>
+</div>
+<div>
+<h4>No gonocócica (UNG)</h4>
+<ul>
+<li><em>Chlamydia trachomatis</em> (la más frecuente; serotipos D-K)</li>
+<li>Otros: <em>Mycoplasma genitalium</em>, Ureaplasma urealyticum, Trichomonas vaginalis</li>
+<li>Incubación más larga (1-3 semanas)</li>
+<li>Secreción mucoide o ausente, disuria leve, asintomático en 50 % varones / 80 % mujeres</li>
+<li>Tratamiento: <strong>doxiciclina 100 mg/12 h × 7 días</strong> (Chlamydia) · Mycoplasma genitalium: azitromicina o moxifloxacino</li>
+<li>Complicaciones: salpingitis (mujer), epididimitis, síndrome de Reiter, linfogranuloma venéreo (serotipos L1-L3)</li>
+</ul>
+</div>
+</div>
+
+<h3>9.4 Orquiepididimitis ETS</h3>
+<ul>
+<li><strong>&lt; 35 años (ETS):</strong> Chlamydia (la más frecuente), gonococo, Mycoplasma.</li>
+<li><strong>&gt; 35 años (enterobacterias):</strong> E. coli, Klebsiella (asociadas a HBP, ITU). Cubrir con quinolona o cefalosporina.</li>
+<li>Clínica: dolor escrotal, fiebre, signo de Prehn (+, alivio con elevación), reflejo cremastérico conservado.</li>
+<li>Eco Doppler: hipervascularización del epidídimo (vs ausencia de flujo en torsión).</li>
+</ul>
+
+<h3>9.5 Sífilis genital</h3>
+<ul>
+<li>Treponema pallidum. <em>Chancro</em> indoloro indurado en pene/vulva (sífilis primaria) + adenopatía regional indolora.</li>
+<li>Tratamiento: penicilina G benzatínica IM 2,4 millones DU (precoz) o 3 dosis semanales (tardía/desconocida).</li>
+</ul>
+
+<h3>9.6 Herpes genital</h3>
+<ul>
+<li>VHS-2 (mayoría) y VHS-1.</li>
+<li>Vesículas dolorosas agrupadas + adenopatía regional dolorosa.</li>
+<li>Tratamiento: aciclovir/valaciclovir oral 7-10 días.</li>
+</ul>
+
+<h3>9.7 Condilomas acuminados</h3>
+<ul>
+<li>HPV 6 y 11 (bajo riesgo).</li>
+<li>Lesiones verrucosas múltiples en genitales y perineo.</li>
+<li>Tratamiento: imiquimod, podofilino, crioterapia, electrocoagulación, láser.</li>
+<li>Vacuna nonavalente HPV preventiva.</li>
+</ul>
+
+<h3>9.8 Preguntas — U9</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Síndrome cistítico crónico + Libia + Auramina y Löwenstein positivos</summary>
+<div class="qa-body">
+<p>Paciente de 45 años que viajó hace 2 a. a Libia, con síndrome cistítico de 2 meses con cultivos negativos. Auramina y Löwenstein positivos. Urografía: ureterohidronefrosis grado II hasta uréter yuxtavesical con estenosis. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Infección por <em>Schistosoma haematobium</em></li>
+<li><strong>Infección por <em>M. tuberculosis</em></strong></li>
+<li>A y B son correctas</li>
+<li>Ninguna es correcta</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Auramina (tinción ácido-alcohol resistente) + Löwenstein-Jensen (cultivo específico) confirman M. tuberculosis. La estenosis ureteral distal con dilatación supra es típica de TBC genitourinaria. Schistosoma se diagnostica por huevos en orina (no estas técnicas).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Localización vesical más frecuente del bacilo TBC</summary>
+<div class="qa-body">
+<p>¿Cuál es la localización más frecuente a nivel vesical del <em>M. tuberculosis</em>?</p>
+<ol type="a">
+<li>Cara anterior</li>
+<li>Cara lateral</li>
+<li><strong>Trígono - proximidades de los orificios ureterales</strong></li>
+<li>Ninguna de ellas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Por descenso de bacilos desde el riñón a través del uréter → siembra inicial en el trígono y áreas periureterales. Lesiones ulcerosas → fibrosis → estenosis ureteral y vejiga pequeña.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Orquitis por transmisión sexual — bacteria más frecuente</summary>
+<div class="qa-body">
+<p>¿Cuál es la bacteria más frecuentemente aislada en orquitis por transmisión sexual?</p>
+<ol type="a">
+<li>Ureaplasma urealyticum</li>
+<li><strong>Chlamydia trachomatis</strong></li>
+<li>Mycoplasma hominis</li>
+<li>Pseudomona aeruginosa</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En jóvenes (&lt; 35 a.) sexualmente activos, Chlamydia es la causa más frecuente. En mayores predominan enterobacterias por contigüidad con prostatitis/cistitis.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) TBC urinaria — conducta sin identificación del bacilo</summary>
+<div class="qa-body">
+<p>Paciente con sospecha clínica y radiológica de TBC urinaria pero sin identificación del bacilo. ¿Conducta?</p>
+<ol type="a">
+<li>Iniciar tratamiento farmacológico específico para TBC</li>
+<li>No se debe iniciar tratamiento</li>
+<li>Descartar otras patologías úlcero-estenosantes que puedan dar imágenes similares a la TBC</li>
+<li><strong>B y C son correctas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Sin confirmación microbiológica NO se inicia tratamiento (tóxico, prolongado). Hay que descartar otras causas (tumores, schistosomiasis, malacoplaquia) y obtener material para diagnóstico (PCR, biopsia, cultivos repetidos).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Tratamiento de la TBC genitourinaria</summary>
+<div class="qa-body">
+<p>Sobre el tratamiento de la TBC urinaria:</p>
+<ol type="a">
+<li>El tratamiento quirúrgico es siempre el primero de elección</li>
+<li>Los resultados del tratamiento farmacológico no son buenos por alta tasa de recidivas</li>
+<li><strong>El tratamiento siempre es farmacológico; el quirúrgico queda como complemento o para secuelas</strong></li>
+<li>Todas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tratamiento farmacológico estándar (HRZE 2 m + HR 4 m). La cirugía se reserva para secuelas (estenosis ureteral, vejiga retraída) o complicaciones (riñón excluido no funcionante).</div>
+</div></details>
+
+</section>
+
+<!-- =============== U10 =============== -->
+<section class="card" id="u10">
+<h2 class="section-title"><span class="num">U10</span>Urolitiasis</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Prevalencia:</strong> 10-15 % de la población a lo largo de la vida. Recurrencia 50 % a 5-10 años.</li>
+<li><strong>Pico de incidencia:</strong> 30-50 años. Predominio masculino 3:1. <em>Causa más frecuente de obstrucción urinaria en el varón joven</em>.</li>
+<li><strong>Patogenia:</strong> sobresaturación urinaria + déficit de inhibidores (citrato, magnesio) + factores de promoción (núcleos de cristalización, infección) → cristalización → agregación → retención del cristal en epitelio papilar (placas de Randall) → crecimiento del cálculo.</li>
+<li><strong>Factores de riesgo:</strong>
+  <ul>
+    <li>Genética / familiar (cistinuria, hiperoxaluria, ATR).</li>
+    <li>Climáticos (calor, sudoración profusa).</li>
+    <li>Dieta: ↑ proteínas animales, ↑ sodio, ↑ oxalato (chocolate, espinacas, té, nueces), bajo aporte de líquido, ↑ azúcar.</li>
+    <li>Síndrome metabólico (DM2, obesidad).</li>
+    <li>Hiperparatiroidismo primario (cálculos cálcicos).</li>
+    <li>Acidosis tubular renal distal (cálculos fosfato cálcico).</li>
+    <li>Infecciones urinarias por gérmenes ureasa-positivos.</li>
+    <li>Cirugía bariátrica (hiperoxaluria entérica).</li>
+    <li>Fármacos: indinavir, sulfamidas, triamtereno, topiramato.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>10.1 Composición y características de los cálculos</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Frecuencia</th><th>pH urinario</th><th>Radiopacidad (Rx)</th><th>TC</th><th>Notas</th></tr></thead>
+<tbody>
+<tr><td><strong>Oxalato cálcico (monohidrato/dihidrato)</strong></td><td>70-80 %</td><td>5,5-6,5</td><td><strong>Radiopaco</strong></td><td>1.000-1.500 UH</td><td>Más frecuente. Hipercalciuria, hiperoxaluria, hipocitraturia. Espigado (whewellita) o piramidal (weddellita)</td></tr>
+<tr><td>Fosfato cálcico (hidroxiapatita, brushita)</td><td>5-10 %</td><td><strong>&gt; 6,5 alcalino</strong></td><td>Radiopaco intenso</td><td>1.500 UH</td><td>ATR distal, hiperparatiroidismo primario, infección de ureasa con cálculos mixtos</td></tr>
+<tr><td><strong>Ácido úrico</strong></td><td>5-10 %</td><td><strong>&lt; 5,5 ácido</strong></td><td><strong>Radiotransparente</strong></td><td>500-700 UH (sí visible)</td><td>Gota, síndrome de Lesch-Nyhan, lisis tumoral, dieta hiperproteica, DM. <em>Disuelve con alcalinización urinaria</em></td></tr>
+<tr><td><strong>Estruvita (fosfato amónico-magnésico)</strong></td><td>5-15 %</td><td><strong>&gt; 7 alcalino</strong></td><td>Radiopacidad baja-moderada</td><td>—</td><td>"Cálculo coraliforme" por <em>infección por bacterias productoras de ureasa</em> (Proteus, Klebsiella, Pseudomonas, Ureaplasma). Mujer postmenopáusica, vejiga neurógena. Cristales en "tapa de ataúd"</td></tr>
+<tr><td>Cistina</td><td>1-3 %</td><td>&lt; 7</td><td>Tenue radiopaca (sulfuro)</td><td>—</td><td>Cistinuria AR. Inicio infantil. Cristales <strong>hexagonales</strong> patognomónicos. Bilateral, recurrente</td></tr>
+<tr><td>Otros (xantina, indinavir)</td><td>&lt; 1 %</td><td>—</td><td>Radiotransparentes</td><td>Variable</td><td>Raros</td></tr>
+</tbody></table></div>
+
+<h3>10.2 Clínica</h3>
+
+<h4>Cólico nefrítico clásico</h4>
+<ul>
+<li><strong>Dolor lumbar agudo</strong> irradiado hacia fosa iliaca, ingle, genitales y cara interna del muslo (según altura).</li>
+<li>Intenso, cólico (en oleadas), <strong>el paciente está agitado, no encuentra postura</strong> (a diferencia del peritonitis donde está quieto).</li>
+<li>Síntomas neurovegetativos: náuseas, vómitos, sudoración, palidez.</li>
+<li>Hematuria macroscópica o microscópica (85 %).</li>
+<li>Síntomas miccionales si cálculo en uréter distal (tenesmo, polaquiuria).</li>
+<li><strong>Sin fiebre ni leucocitosis</strong> en cólico no complicado.</li>
+</ul>
+
+<h4>Cólico complicado — emergencia</h4>
+<p>Sospechar ante cualquier combinación de:</p>
+<ul>
+<li><strong>Fiebre + escalofríos</strong> (pielonefritis obstructiva → sepsis).</li>
+<li>Anuria (cálculo bilateral o monorreno).</li>
+<li>Insuficiencia renal aguda.</li>
+<li>Refractariedad a analgesia.</li>
+<li>Embarazo.</li>
+<li>Mal estado general / hipotensión.</li>
+</ul>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🚨</span>Cólico nefrítico complicado</div>
+<p style="margin:0">SIEMPRE requiere <em>derivación urinaria urgente</em> (doble J o nefrostomía percutánea) + ATB iv + analgesia. <strong>NO esperar a tratar el cálculo</strong>. La LEOC o ureteroscopia se difieren 4-6 sem tras curación.</p>
+</div>
+
+<h3>10.3 Diagnóstico</h3>
+<ul>
+<li><strong>TAC sin contraste de baja dosis</strong> = <em>gold standard</em>. Sensibilidad y especificidad &gt; 95 %. Detecta cálculos &gt; 1 mm de cualquier composición (incluso radiotransparentes en Rx). Mide tamaño, localización, densidad (UH), hidronefrosis.</li>
+<li><strong>Ecografía:</strong> primera prueba en embarazada y niños. Sensibilidad menor para uréter medio.</li>
+<li><strong>Rx simple de abdomen</strong>: solo detecta cálculos radiopacos (cálcicos, estruvita, cistina). Útil para seguimiento.</li>
+<li><strong>UroTC con contraste</strong>: estudio anatómico funcional cuando hay duda diagnóstica.</li>
+<li><strong>Analítica:</strong> hemograma, función renal, calcio, sodio, potasio, PCR; sedimento + urocultivo.</li>
+<li><strong>Estudio metabólico</strong> (cálculos recurrentes, pediátricos, monorrenos): análisis del cálculo, calciuria/oxaluria/citraturia/uricuria en orina de 24 h, calcemia, PTH, ácido úrico, pH urinario.</li>
+</ul>
+
+<h3>10.4 Tratamiento — fase aguda</h3>
+
+<h4>Cólico simple</h4>
+<ul>
+<li><strong>Analgesia</strong>: AINE (diclofenaco 75 mg im o ketorolaco 30 mg iv) — 1ª línea. Metamizol iv. Opioides (tramadol, petidina) si refractario o AINE contraindicado.</li>
+<li>Antieméticos (metoclopramida, ondansetrón).</li>
+<li>Hidratación moderada (NO forzar diuresis, no ayuda y aumenta el dolor).</li>
+<li><strong>Tratamiento médico expulsivo (MET)</strong>: <em>tamsulosina 0,4 mg/d</em> hasta 4-6 semanas — facilita expulsión de cálculos ureterales 5-10 mm en uréter distal. Acompañar con AINE/analgesia.</li>
+<li>El 80 % de los cálculos &lt; 5 mm se expulsan espontáneamente.</li>
+</ul>
+
+<h4>Cólico complicado</h4>
+<p>Derivación urinaria urgente (doble J o NPC) + ATB iv (ceftriaxona, piperacilina-tazobactam) + analgesia. Internar al paciente.</p>
+
+<h3>10.5 Tratamiento — eliminación del cálculo (electivo)</h3>
+
+<h4>Litotricia extracorpórea por ondas de choque (LEOC)</h4>
+<ul>
+<li><strong>Mecanismo:</strong> ondas de choque generadas externamente (electrohidráulico, electromagnético, piezoeléctrico) → focalizadas en el cálculo (eco o fluoroscopia) → fragmentan en partículas &lt; 4 mm que se expulsan espontáneamente.</li>
+<li><strong>Indicación de elección:</strong> cálculos &lt; 2 cm pielocaliciales o ureterales proximales radiopacos.</li>
+<li><strong>Limitaciones:</strong> cálculos &gt; 2 cm (preferir NLP), cálculos duros (&gt; 1.000 UH, oxalato cálcico monohidrato, cistina), obesidad mórbida (distancia piel-cálculo &gt; 11 cm).</li>
+<li><strong>Contraindicaciones ABSOLUTAS:</strong>
+  <ul>
+    <li><span class="tag danger">EMBARAZO</span></li>
+    <li>Sepsis urinaria activa con obstrucción no resuelta</li>
+    <li>Coagulopatía no corregida</li>
+    <li>Obstrucción distal al cálculo</li>
+    <li>Aneurisma aórtico/iliaco en línea de tiro</li>
+  </ul>
+</li>
+<li><strong>Contraindicaciones relativas:</strong> HTA no controlada, marcapasos (cardio próximo), obesidad mórbida, deformidad esquelética, ITU activa (necesita ATB previo).</li>
+<li><strong>Complicaciones:</strong> hematuria (90 %, autolimitada), cólico por fragmentos, "Steinstrasse" (apilamiento de fragmentos en uréter — &lt; 5 %), hematoma perirrenal, infección.</li>
+</ul>
+
+<h4>Ureteroscopia (URS) + láser (Ho:YAG, Tm:YAG)</h4>
+<ul>
+<li><strong>Indicaciones:</strong>
+  <ul>
+    <li>Cálculos ureterales distales (1ª elección actual).</li>
+    <li>Cálculos pielocaliciales (URS retrógrada flexible = "RIRS").</li>
+    <li>Cálculos no expulsables tras LEOC fallida.</li>
+    <li>Cálculos en embarazo (con cobertura ATB).</li>
+    <li>Cálculos duros (cistina, oxalato monohidrato).</li>
+    <li>Cálculos en diverticulo calicial.</li>
+  </ul>
+</li>
+<li>Ventaja: visión directa, alta tasa de éxito (90-95 %), puede combinarse con láser para fragmentación.</li>
+</ul>
+
+<h4>Nefrolitotomía percutánea (NLP)</h4>
+<ul>
+<li><strong>Indicación principal:</strong> cálculos renales &gt; 2 cm, coraliformes, complejos, fracaso de LEOC/URS.</li>
+<li>Acceso percutáneo al sistema colector + litotricia intrarrenal (ultrasónica, neumática, láser).</li>
+<li>Complicaciones: sangrado, sepsis, lesión pleural (calicial superior), lesión de órganos vecinos.</li>
+</ul>
+
+<h4>Cirugía abierta o laparoscópica</h4>
+<p>Indicación excepcional: cálculos coraliformes complejos, anatomía aberrante, simultaneidad con otra cirugía.</p>
+
+<h3>10.6 Prevención de recurrencias (cálculos cálcicos)</h3>
+<ul>
+<li><strong>Hidratación abundante:</strong> &gt; 2,5-3 L/día (objetivo diuresis &gt; 2 L/d).</li>
+<li><strong>Dieta:</strong>
+  <ul>
+    <li>Restricción de sodio (&lt; 5 g/d).</li>
+    <li>Restricción de proteínas animales.</li>
+    <li>Limitar alimentos ricos en oxalato (espinacas, ruibarbo, té negro, chocolate, frutos secos).</li>
+    <li>Aporte normal de calcio (no restringir).</li>
+    <li>Aumentar cítricos (citrato).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento farmacológico</strong>:
+  <ul>
+    <li><em>Citrato potásico</em>: hipocitraturia, ATR, ácido úrico.</li>
+    <li><em>Tiazidas</em>: hipercalciuria idiopática.</li>
+    <li><em>Alopurinol</em>: hiperuricosuria.</li>
+    <li><em>Magnesio</em>: hipomagnesiuria.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>10.7 Tratamiento específico por composición</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Ácido úrico</span><span class="v"><em>Alcalinización urinaria con citrato potásico</em> (pH objetivo 6,5-7) → disuelve el cálculo. Hidratación. Alopurinol si hiperuricemia.</span></div>
+<div class="kv"><span class="k">Cistina</span><span class="v">Alcalinización + hidratación + restricción de metionina. Tiopronina o D-penicilamina en refractarios.</span></div>
+<div class="kv"><span class="k">Estruvita</span><span class="v">Eliminación quirúrgica completa del cálculo + ATB prolongada según urocultivo. Inhibidor de ureasa (ácido acetohidroxámico) en casos refractarios.</span></div>
+<div class="kv"><span class="k">Hipercalciuria idiopática</span><span class="v">Tiazida + dieta hiposódica + citrato</span></div>
+<div class="kv"><span class="k">Hiperoxaluria</span><span class="v">Restricción de oxalato + calcio con las comidas (precipita oxalato en intestino) + piridoxina (vit B6)</span></div>
+</div>
+
+<h3>10.8 Preguntas — U10</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Cólico nefrítico complicado tras LEOC — actitud</summary>
+<div class="qa-body">
+<p>Mujer de 36 años, 3 días tras LEOC. Mal estado general, dolor en fosa renal izquierda, fiebre 39,2 ºC. Rx: cálculos pequeños en uréter distal. Eco: dilatación grado II pielocalicial izquierda. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Ureteroscopia urgente por uropatía obstructiva litiásica</li>
+<li>Ingreso con hidratación iv y antibiótico por sospecha de ITU</li>
+<li><strong>Derivación urinaria urgente (cateterismo ureteral o nefrostomía percutánea) por sospecha de uropatía obstructiva complicada</strong></li>
+<li>Nueva sesión de LEOC tras tratamiento sintomático</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> <em>Pielonefritis obstructiva</em> (fiebre + obstrucción) = urgencia urológica. Primero <em>derivación urgente (doble J o NPC)</em> + ATB iv. NO ureteroscopia ni LEOC inmediata (riesgo de sepsis).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Contraindicación absoluta de LEOC</summary>
+<div class="qa-body">
+<p>¿Cuál es contraindicación ABSOLUTA de la LEOC?</p>
+<ol type="a">
+<li>Alteraciones de la coagulación</li>
+<li>HTA descontrolada</li>
+<li><strong>Embarazo</strong></li>
+<li>Enfermedad coronaria</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> El embarazo es contraindicación ABSOLUTA (riesgo fetal). Las demás son contraindicaciones relativas que se pueden corregir o evaluar.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Diabético con HBP + fiebre + cristales de estruvita + pH 8,5</summary>
+<div class="qa-body">
+<p>Hombre de 66 años con HBP, fiebre con escalofríos. Orina: pH 8,5, cristales de estruvita (MgNH₄PO₄). ¿Respuesta correcta?</p>
+<ol type="a">
+<li>Padece una acidosis tubular que le impide acidificar la orina</li>
+<li>El pH urinario, normal, descarta una infección</li>
+<li>Cualquier infección bacteriana urinaria eleva el pH</li>
+<li><strong>Debe sospecharse infección urinaria por gérmenes que degradan la urea</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Estruvita + pH alcalino = bacterias <em>productoras de ureasa</em> (Proteus mirabilis sobre todo, también Klebsiella, Pseudomonas, Ureaplasma). Degradan urea → NH₃ → ↑ pH → precipita el fosfato amónico-magnésico → cálculo coraliforme.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Urolitiasis — FALSA</summary>
+<div class="qa-body">
+<p>En relación con la urolitiasis, señale la FALSA:</p>
+<ol type="a">
+<li>Las litiasis de ácido úrico responden bien a la alcalinización de la orina</li>
+<li><strong>La LEOC es el método elegido para la mayoría de cálculos no expulsables, independientemente de su tamaño</strong></li>
+<li>La urolitiasis es la causa más frecuente de obstrucción urinaria en el varón joven</li>
+<li>Las litiasis de fosfato amónico-magnésico son de radiopacidad baja y frecuentemente constituyen un foco continuado de sepsis</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La LEOC NO es para todos los tamaños. Para cálculos &gt; 2 cm se prefiere <em>nefrolitotomía percutánea</em>. Para ureterales distales (en mujer) se prefiere <em>ureteroscopia</em>.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Cálculos de ácido úrico — características</summary>
+<div class="qa-body">
+<p>Los cálculos urinarios de ácido úrico se caracterizan por:</p>
+<ol type="a">
+<li>No visualizarse en control ecográfico</li>
+<li><strong>Ser radiotransparentes</strong></li>
+<li>Son difíciles de visualizar en TAC</li>
+<li>Precipitan en orina con pH alcalino</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los cálculos de ácido úrico son <em>radiotransparentes en Rx</em>, pero <em>visibles en ecografía y TAC sin contraste</em>. Precipitan en orina ÁCIDA (pH &lt; 5,5), no alcalina.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U11 =============== -->
+<section class="card" id="u11">
+<h2 class="section-title"><span class="num">U11</span>Incontinencia urinaria y vejiga hiperactiva</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Definición ICS:</strong> escape involuntario de orina objetivable y que origina problemas higiénicos y/o sociales.</li>
+<li><strong>Prevalencia:</strong> 25-45 % de las mujeres adultas (↑ con edad y paridad), 10-15 % de los varones (↑↑ tras prostatectomía radical).</li>
+<li><strong>Fisiología miccional:</strong>
+  <ul>
+    <li><em>Fase de llenado</em>: relajación del detrusor (β3-adrenérgico) + contracción del esfínter uretral interno (α1) y externo (somático).</li>
+    <li><em>Fase de vaciado</em>: contracción del detrusor (parasimpática M3) + relajación coordinada del esfínter.</li>
+    <li>Centro miccional pontino (Barrington) coordina la micción. Lesión por encima → vejiga hiperrefléxica; por debajo (cono medular, periférica) → vejiga arrefléxica.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>11.1 Clasificación clínica</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Mecanismo</th><th>Clínica</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Esfuerzo (estrés)</strong></td><td>Hipermovilidad uretral o insuficiencia esfinteriana</td><td>Pérdida al toser, saltar, reír, esfuerzo físico. Mujer multípara, postmenopáusica</td><td>Kegel · pesarios · estrógenos vaginales · <em>cabestrillo suburetral TVT/TOT</em> · esfínter artificial (varón post-prostatectomía)</td></tr>
+<tr><td><strong>Urgencia</strong></td><td>Vejiga hiperactiva (hiperactividad del detrusor)</td><td>Urgencia + polaquiuria + nicturia ± fuga. <em>Frecuencia miccional aumentada</em></td><td>Reeducación miccional · <em>anticolinérgicos</em> (oxibutinina, solifenacina, tolterodina, fesoterodina) · <em>β3-agonistas</em> (mirabegrón) · toxina botulínica intravesical · neuromodulación tibial / sacra</td></tr>
+<tr><td><strong>Mixta</strong></td><td>Esfuerzo + urgencia</td><td>Combinación</td><td>Tratar el componente dominante</td></tr>
+<tr><td><strong>Rebosamiento</strong></td><td>Vejiga distendida con residuo elevado por: obstrucción crónica (HBP, estenosis), detrusor hipocontráctil (vejiga neurógena), neuropatía diabética</td><td>Goteo continuo, vaciado incompleto, globo vesical</td><td>Tratar causa obstructiva · <em>cateterismo intermitente limpio</em> · sondaje permanente (último recurso)</td></tr>
+<tr><td><strong>Funcional</strong></td><td>Limitación física/cognitiva (demencia, inmovilidad)</td><td>Pérdidas por incapacidad de llegar al WC</td><td>Adaptación entorno · pañal · sonda</td></tr>
+<tr><td><strong>Total / continua</strong></td><td>Fístula urogenital (post-cirugía), uréter ectópico</td><td>Pérdida continua, mojado constante</td><td>Cirugía correctora</td></tr>
+</tbody></table></div>
+
+<h3>11.2 Diagnóstico</h3>
+<ul>
+<li><strong>Historia clínica:</strong> tipo, momento, factores desencadenantes, AP obstétricos, cirugías previas, fármacos.</li>
+<li><strong>Diario miccional</strong> de 3-7 días: frecuencia, volumen, episodios de fuga.</li>
+<li><strong>Cuestionarios validados:</strong> ICIQ-SF, OAB-SS.</li>
+<li><strong>Exploración:</strong> exploración ginecológica con valsalva, prolapsos (POP-Q), TR (próstata), ECF neurológica (sensibilidad perianal, reflejo bulbocavernoso, tono anal).</li>
+<li><strong>Pruebas:</strong>
+  <ul>
+    <li>Tira reactiva ± urocultivo (descartar ITU).</li>
+    <li>Ecografía vesical con residuo postmiccional.</li>
+    <li><em>Pad-test</em> (test del pañal): cuantifica las pérdidas en 1 h o 24 h.</li>
+    <li><strong>Urodinamia</strong> (gold standard): flujometría + cistomanometría + perfil uretral + EMG. Indicada en casos complejos, mixtos, recidivantes, antes de cirugía.</li>
+    <li>Cistoscopia si sospecha de fístula o tumor.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>11.3 Vejiga hiperactiva (VHA)</h3>
+<ul>
+<li><strong>Definición ICS:</strong> síndrome clínico = <em>urgencia miccional</em> (deseo súbito e imperioso difícil de inhibir) + <em>polaquiuria diurna</em> + <em>nicturia</em> ± <em>incontinencia de urgencia</em>, en ausencia de causa metabólica o infección.</li>
+<li><strong>Etiología:</strong>
+  <ul>
+    <li>Idiopática (más frecuente).</li>
+    <li>Neurogénica (ACV, EM, Parkinson, lesiones medulares suprasacras).</li>
+    <li>Obstructiva (HBP — fase irritativa).</li>
+    <li>Inflamatoria (cistitis, litiasis).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento escalonado:</strong>
+  <ol>
+    <li>Conductual: reeducación miccional, micción programada, ejercicios pélvicos, reducción de cafeína/alcohol, control de peso.</li>
+    <li>Farmacológico:
+      <ul>
+        <li><em>Anticolinérgicos</em> (M3): oxibutinina (efectos centrales en ancianos), tolterodina, solifenacina, fesoterodina, darifenacina. Efectos adversos: sequedad de boca, estreñimiento, deterioro cognitivo, retención.</li>
+        <li><em>β3-agonistas</em>: mirabegrón 50 mg/d. Sin efectos anticolinérgicos. Cuidado en HTA.</li>
+      </ul>
+    </li>
+    <li>Toxina botulínica intravesical (200 U) cada 6-9 meses. Riesgo: retención (cateterismo intermitente temporal).</li>
+    <li>Neuromodulación tibial percutánea (PTNS) o sacra (Interstim).</li>
+    <li>Quirúrgico (excepcional): ampliación vesical, derivación.</li>
+  </ol>
+</li>
+</ul>
+
+<h3>11.4 Preguntas — U11</h3>
+
+<details class="qa"><summary>1. (Ord 2025/Extra 2025) Incontinencia de orina — FALSA</summary>
+<div class="qa-body">
+<p>Respecto a la incontinencia de orina, señale la FALSA:</p>
+<ol type="a">
+<li>En la incontinencia urinaria de esfuerzo, un factor precipitante es el ejercicio físico</li>
+<li><strong>En la incontinencia de urgencia la frecuencia miccional es normal</strong></li>
+<li>La prueba más fiable para establecer un diagnóstico exacto del tipo de incontinencia es el estudio urodinámico</li>
+<li>En el tratamiento de la incontinencia de orina de urgencia se utilizan medicamentos anticolinérgicos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> En la incontinencia de urgencia la frecuencia miccional está <em>AUMENTADA</em> (polaquiuria, nicturia). Es síntoma cardinal junto con el deseo imperioso.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Incontinencia por rebosamiento — verdadero</summary>
+<div class="qa-body">
+<p>En la incontinencia urinaria por rebosamiento es cierto:</p>
+<ol type="a">
+<li><strong>Son posibles causas: obstrucción crónica del tracto urinario inferior, inhibición del reflejo miccional, alteraciones neurológicas, sobredistensión postparto, cambios en la vascularización vesical</strong></li>
+<li>En su tratamiento no se emplean técnicas de estímulo del vaciamiento</li>
+<li>La sonda vesical permanente es la alternativa más recomendable</li>
+<li>Los fármacos colinérgicos son terapia recomendada por sus escasos efectos secundarios</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> La rebosamiento tiene múltiples causas. Tratamiento: tratar la causa + maniobras de Credé/Valsalva + <em>cateterismo intermitente limpio</em> (1ª elección, no la sonda permanente).</div>
+</div></details>
+
+</section>
+
+<!-- =============== U12 =============== -->
+<section class="card" id="u12">
+<h2 class="section-title"><span class="num">U12</span>Vejiga neurógena</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Definición:</strong> disfunción vesical por lesión del sistema nervioso (cerebral, medular o periférica) que afecta a las fases de llenado/vaciado.</li>
+<li><strong>Recuerdo neuroanatómico:</strong>
+  <ul>
+    <li><em>Centro miccional pontino (Barrington)</em>: coordina la micción.</li>
+    <li><em>Centro simpático D10-L2</em>: relajación del detrusor, contracción esfinteriana (continencia).</li>
+    <li><em>Centro parasimpático S2-S4</em>: contracción del detrusor (vaciado).</li>
+    <li><em>Centro somático del pudendo (núcleo de Onuf, S2-S4)</em>: esfínter externo voluntario.</li>
+  </ul>
+</li>
+<li><strong>Tipos según topografía:</strong>
+  <ul>
+    <li><em>Lesión SUPRAMEDULAR</em> (encima del puente): hiperrefléxica con coordinación esfinteriana conservada (ACV, demencia, Parkinson, tumor cerebral).</li>
+    <li><em>Lesión MEDULAR SUPRASACRA</em> (entre puente y S2): hiperrefléxica + <em>disinergia detrusor-esfínter</em> (sin coordinación). Esclerosis múltiple, lesión medular cervical/dorsal.</li>
+    <li><em>Lesión SACRA o PERIFÉRICA</em> (cono medular, cola de caballo, plexo, periférica): arrefléxica/flácida. Diabetes, cirugía pélvica radical, mielomeningocele bajo, lesión S2-S4.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>12.1 Vejiga hiperrefléxica vs arrefléxica</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Característica</th><th>Hiperrefléxica (espástica)</th><th>Arrefléxica (flácida)</th></tr></thead>
+<tbody>
+<tr><td>Topografía</td><td>Supramedular o medular suprasacra</td><td>Sacra o periférica</td></tr>
+<tr><td>Etiología típica</td><td>EM, lesión medular alta, ACV, mielomeningocele alto</td><td>Cola de caballo, neuropatía diabética, cirugía pélvica radical (cáncer recto), mielomeningocele bajo</td></tr>
+<tr><td>Detrusor</td><td>Hiperactivo, contracciones no inhibidas</td><td>Acontráctil / hipocontráctil</td></tr>
+<tr><td>Esfínter</td><td>Disinergia detrusor-esfínter externo (DESD) si lesión medular</td><td>Hipotónico (denervación)</td></tr>
+<tr><td>Clínica</td><td>Polaquiuria, urgencia, incontinencia, vaciado incompleto si DESD</td><td>Retención urinaria, rebosamiento, infecciones</td></tr>
+<tr><td>Reflejo bulbocavernoso</td><td><strong>POSITIVO</strong></td><td><strong>NEGATIVO</strong></td></tr>
+<tr><td>Test del agua helada (Bors)</td><td><strong>POSITIVO</strong> (contracción del detrusor)</td><td><strong>NEGATIVO</strong></td></tr>
+<tr><td>Urodinamia</td><td>Contracciones no inhibidas, capacidad vesical reducida, presión vesical elevada</td><td>Detrusor acontráctil, capacidad aumentada, residuo elevado</td></tr>
+<tr><td>Tratamiento</td><td>Anticolinérgicos + cateterismo intermitente; toxina botulínica; neuromodulación; ampliación vesical</td><td><em>Cateterismo intermitente limpio</em> (1ª elección); maniobras de Credé/Valsalva (controvertidas); sonda permanente solo último recurso</td></tr>
+</tbody></table></div>
+
+<h3>12.2 Pruebas diagnósticas</h3>
+<ul>
+<li><strong>Urodinamia</strong> = pilar diagnóstico. Cistomanometría + flujometría + EMG perineal + perfil uretral. Detecta: contracciones no inhibidas, capacidad, complianza, presión de fuga del detrusor (DLPP — &gt; 40 cm H₂O = riesgo de daño renal alto), DESD.</li>
+<li><strong>Ecografía vesical/renal con residuo postmiccional.</strong></li>
+<li><strong>CUMS</strong>: si RVU sospechado.</li>
+<li><strong>Renograma:</strong> función renal diferencial si hidronefrosis.</li>
+<li><strong>Exploración:</strong>
+  <ul>
+    <li><em>Reflejo bulbocavernoso</em>: contracción del esfínter anal al pellizcar el glande/clítoris. Indica integridad del arco reflejo sacro (S2-S4).</li>
+    <li><em>Test del agua helada (Bors)</em>: 60 mL de suero a 4 °C en vejiga. Contracción del detrusor (+) en lesiones supramedulares.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>12.3 Factores de mal pronóstico (riesgo de daño renal alto)</h3>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">⚠</span>Vigilar</div>
+<ul style="margin:6px 0">
+<li><strong>Presión de fuga del detrusor (DLPP) &gt; 40 cm H₂O</strong> (McGuire) — riesgo de daño parenquimatoso.</li>
+<li>Reflujo vesicoureteral secundario.</li>
+<li>Hidronefrosis.</li>
+<li>ITU recurrentes (sobre todo PNA).</li>
+<li>Disinergia detrusor-esfínter.</li>
+<li>Mala complianza vesical (&lt; 20 mL/cm H₂O).</li>
+</ul>
+</div>
+
+<h3>12.4 Tratamiento — objetivos</h3>
+<ol>
+<li><strong>Proteger tracto urinario superior</strong> (lo más importante): mantener presiones vesicales bajas.</li>
+<li>Lograr continencia social.</li>
+<li>Vaciado completo y a baja presión.</li>
+<li>Prevenir ITU.</li>
+</ol>
+
+<h4>Manejo conservador</h4>
+<ul>
+<li>Reeducación miccional, biofeedback.</li>
+<li><strong>Cateterismo intermitente limpio</strong> (CIL) cada 4-6 h: la opción más fisiológica en vejiga arrefléxica y en muchas hiperrefléxicas tras anticolinérgicos.</li>
+<li>Maniobras de vaciamiento (Credé, Valsalva): controvertidas, pueden aumentar la presión.</li>
+</ul>
+
+<h4>Farmacológico</h4>
+<ul>
+<li><strong>Hiperrefléxica:</strong> anticolinérgicos M3 (oxibutinina, solifenacina, tolterodina) + β3-agonistas (mirabegrón).</li>
+<li><strong>Arrefléxica:</strong> sin tratamiento farmacológico eficaz (CIL).</li>
+<li>α-bloqueantes para facilitar vaciado vesical (tamsulosina) en DESD parcial.</li>
+</ul>
+
+<h4>Procedimientos</h4>
+<ul>
+<li><strong>Toxina botulínica intravesical</strong> (200 U) en vejiga neurogénica hiperrefléxica refractaria a anticolinérgicos. Cada 6-9 meses. Riesgo: retención (CIL temporal).</li>
+<li><strong>Neuromodulación:</strong> sacra (Interstim), tibial percutánea (PTNS).</li>
+<li><strong>Ampliación vesical</strong> con segmento intestinal (enterocistoplastia de Hautmann) en vejiga retraída con mala complianza.</li>
+<li><strong>Derivación urinaria</strong>: conducto ileal (Bricker), continente (Mitrofanoff con apéndice).</li>
+<li><strong>Esfínter urinario artificial</strong> en insuficiencia esfinteriana.</li>
+</ul>
+
+<h3>12.5 Seguimiento</h3>
+<ul>
+<li>Eco + creatinina cada 6-12 m.</li>
+<li>Urodinamia periódica (cada 1-2 años).</li>
+<li>Cistografía si ITU recurrente o hidronefrosis.</li>
+<li>Cribado de cáncer vesical en pacientes con sonda permanente &gt; 10 años (cistoscopia).</li>
+</ul>
+
+<h3>12.6 Preguntas — U12</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Esclerosis múltiple + vejiga hiperrefléxica — reflejo bulbocavernoso</summary>
+<div class="qa-body">
+<p>Mujer de 36 años con esclerosis múltiple, estudio urodinámico con ondas del detrusor compatible con vejiga hiperrefléxica. ¿Cómo sería el reflejo bulbocavernoso?</p>
+<ol type="a">
+<li>Negativo</li>
+<li><strong>Positivo</strong></li>
+<li>No se utiliza para el diagnóstico de vejiga hiperrefléxica</li>
+<li>Solo es positivo en la vejiga arrefléxica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Reflejo bulbocavernoso (+) en lesiones supramedulares (vejiga hiperrefléxica). En lesiones del cono medular / cola de caballo (vejiga arrefléxica) es negativo.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Vejiga neurógena — factores de mal pronóstico</summary>
+<div class="qa-body">
+<p>En la vejiga neurógena, ¿qué factores son de mal pronóstico?</p>
+<ol type="a">
+<li>Vejiga arrefléxica</li>
+<li><strong>Presión de fuga &gt; 40 cm de agua</strong></li>
+<li>Detrusor arrefléxico</li>
+<li>Todas las anteriores</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La presión de fuga &gt; 40 cm H₂O = riesgo alto de daño renal por reflujo y nefropatía obstructiva. Es el factor pronóstico más importante (regla de McGuire).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Diabética con retención + neuropatía + detrusor acontráctil</summary>
+<div class="qa-body">
+<p>Maestra de 74 años con DM, retenciones urinarias, sin incontinencia de esfuerzo. Neuropatía sensitiva en MMII. Residuo 400 mL. Valsalva no provoca pérdida. Urodinamia: detrusor acontráctil sin obstrucción. Fármacos sin efecto. ¿Opción más apropiada?</p>
+<ol type="a">
+<li><strong>Sondajes intermitentes</strong></li>
+<li>Sonda urinaria permanente</li>
+<li>Dilatación uretral</li>
+<li>Ureterotomía transuretral</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Vejiga arrefléxica diabética (neuropatía autonómica) con detrusor sin contractilidad = cateterismo intermitente limpio cada 4-6 h (de elección). La sonda permanente es 2ª línea (más infecciones, deterioro vesical).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Vejiga arrefléxica — test del agua helada</summary>
+<div class="qa-body">
+<p>Mujer 66 a. con cirugía pélvica radical (cáncer recto-sigma) y vejiga arrefléxica en urodinamia. ¿Cómo sería el test del agua helada?</p>
+<ol type="a">
+<li><strong>Negativo</strong></li>
+<li>Positivo</li>
+<li>Esta exploración no se utiliza</li>
+<li>Es negativo igual que en la hiperrefléxica</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Test del agua helada (Bors): se introduce 60 mL de suero frío en vejiga. Positivo (contracción enérgica del detrusor) en lesiones <em>supramedulares</em> (hiperrefléxicas). <em>Negativo</em> en lesiones sacras/periféricas (arrefléxica).</div>
+</div></details>
+
+</section>
+
+<!-- =============== U13 =============== -->
+<section class="card" id="u13">
+<h2 class="section-title"><span class="num">U13</span>HBP · prostatitis aguda y crónica</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Hiperplasia benigna de próstata (HBP)</strong>: hiperplasia nodular benigna originada en la <em>zona transicional</em> de la próstata (a diferencia del adenocarcinoma, que aparece en la zona periférica). Hormonodependiente (andrógenos, DHT).</li>
+<li><strong>Epidemiología:</strong> aumenta con la edad — 50 % de varones &gt; 50 a., 80 % &gt; 80 a. Sólo el 50 % desarrolla síntomas.</li>
+<li><strong>Fisiopatología:</strong> componente <em>estático</em> (volumen prostático que comprime la uretra) + componente <em>dinámico</em> (tono α1-adrenérgico del músculo liso del cuello vesical y próstata).</li>
+<li><strong>Síntomas STUI (LUTS):</strong>
+  <ul>
+    <li><em>Obstructivos / de vaciado</em>: chorro débil, dificultad inicial, esfuerzo, vaciado incompleto, micción intermitente, goteo postmiccional.</li>
+    <li><em>Irritativos / de llenado</em>: polaquiuria diurna y nocturna, urgencia, incontinencia de urgencia.</li>
+  </ul>
+</li>
+<li><strong>Escalas:</strong>
+  <ul>
+    <li><strong>IPSS</strong> (International Prostate Symptom Score, 0-35): leve 0-7 / moderado 8-19 / grave 20-35.</li>
+    <li>Calidad de vida (QoL) 0-6.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>13.1 Evaluación diagnóstica</h3>
+<ul>
+<li><strong>Anamnesis + IPSS + QoL.</strong></li>
+<li><strong>Exploración:</strong>
+  <ul>
+    <li>Tacto rectal: próstata aumentada de tamaño, lisa, simétrica, elástica, sin nódulos. Estimar volumen (I &lt; 30 cc; II 30-60; III 60-90; IV &gt; 90).</li>
+    <li>Sospecha de cáncer: induración, nódulo, asimetría.</li>
+  </ul>
+</li>
+<li><strong>Pruebas:</strong>
+  <ul>
+    <li>Tira urinaria + sedimento (descartar ITU, hematuria → estudio adicional).</li>
+    <li>Creatinina sérica (función renal).</li>
+    <li>PSA (decisión compartida; útil para detectar cáncer y para estratificar progresión).</li>
+    <li>Flujometría: chorro débil (Qmáx &lt; 10 mL/s sugiere obstrucción).</li>
+    <li>Ecografía vesical + medición de residuo postmiccional + volumen prostático.</li>
+    <li>Cistoscopia: en casos seleccionados (hematuria, sospecha de tumor, retención).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>13.2 Tratamiento médico</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Grupo</th><th>Fármacos</th><th>Mecanismo</th><th>Inicio efecto</th><th>Efectos adversos</th></tr></thead>
+<tbody>
+<tr><td><strong>α-bloqueantes</strong></td><td>Tamsulosina · alfuzosina · silodosina · doxazosina · terazosina</td><td>Relajan el músculo liso (α1 cuello vesical y próstata) → reducen componente dinámico</td><td>Días-semanas</td><td><em>Hipotensión ortostática</em> (sobre todo no selectivos como doxazosina), <em>eyaculación retrógrada</em>, congestión nasal, <strong>síndrome del iris flácido intraoperatorio</strong> (cirugía de cataratas con tamsulosina — avisar al oftalmólogo)</td></tr>
+<tr><td><strong>5-α-reductasa</strong></td><td>Finasterida · dutasterida</td><td>Bloquean conversión T→DHT, reducen volumen prostático (componente estático)</td><td>3-6 meses</td><td>Disfunción eréctil, ↓ libido, ginecomastia, <em>reducen el PSA al 50 %</em> (multiplicar por 2 para interpretar)</td></tr>
+<tr><td><strong>Anticolinérgicos / β3-agonistas</strong></td><td>Solifenacina, mirabegrón</td><td>Tratan componente irritativo (urgencia, polaquiuria)</td><td>Semanas</td><td>Sequedad de boca; vigilar retención si residuo elevado</td></tr>
+<tr><td><strong>Inhibidores PDE-5</strong></td><td>Tadalafilo 5 mg/d</td><td>Relajan músculo liso y mejoran perfusión</td><td>Semanas</td><td>Útil si coexiste DE. Contraindicado con nitritos</td></tr>
+<tr><td>Fitoterapia</td><td>Serenoa repens, Pygeum</td><td>Variable, eficacia limitada</td><td>—</td><td>Pocos efectos adversos</td></tr>
+<tr><td>Combinaciones</td><td>α-bloq + 5-ARI · α-bloq + antimuscarínico</td><td>—</td><td>—</td><td>Sinergia en próstatas grandes y/o STUI mixtos</td></tr>
+</tbody></table></div>
+
+<h3>13.3 Indicaciones absolutas de cirugía</h3>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🔪</span>Cuándo operar SÍ o SÍ</div>
+<ul style="margin:6px 0">
+<li><strong>Retención urinaria aguda recurrente</strong> (tras intento de retirada de sonda)</li>
+<li><strong>ITU de repetición</strong> por residuo elevado</li>
+<li><strong>Litiasis vesical secundaria</strong></li>
+<li><strong>Hematuria macroscópica recidivante</strong> de origen prostático</li>
+<li><strong>Hidronefrosis con deterioro de la función renal</strong></li>
+<li>Divertículos vesicales grandes</li>
+<li>Fracaso del tratamiento médico óptimo</li>
+</ul>
+</div>
+
+<h3>13.4 Técnicas quirúrgicas</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Técnica</th><th>Próstata</th><th>Notas</th></tr></thead>
+<tbody>
+<tr><td><strong>RTU-P</strong> (resección transuretral)</td><td>30-80 cc</td><td>Gold standard clásico. Resección monopolar (riesgo de síndrome de reabsorción de glicina/agua) o bipolar (con suero, sin síndrome).</td></tr>
+<tr><td>Incisión transuretral (TUIP)</td><td>&lt; 30 cc</td><td>Próstatas pequeñas sin lóbulo medio.</td></tr>
+<tr><td>Adenomectomía abierta o laparoscópica/robótica</td><td>&gt; 80-100 cc</td><td>Próstatas voluminosas. Mayor sangrado.</td></tr>
+<tr><td><strong>HoLEP</strong> (enucleación con láser Holmium)</td><td>Cualquier tamaño</td><td>Comparable a adenomectomía pero menos invasiva. Tendencia actual.</td></tr>
+<tr><td>Vaporización con láser <strong>GreenLight (KTP)</strong></td><td>40-80 cc</td><td>Útil en pacientes anticoagulados, menos sangrado.</td></tr>
+<tr><td><strong>Aquablation, Urolift, Rezum</strong></td><td>30-80 cc</td><td>Mínimamente invasivas, preservan eyaculación.</td></tr>
+<tr><td>Embolización de arteria prostática</td><td>Volúmenes grandes</td><td>Por radiología intervencionista, en pacientes de alto riesgo quirúrgico.</td></tr>
+</tbody></table></div>
+
+<p><strong>Efectos secundarios postquirúrgicos:</strong> eyaculación retrógrada (65 % de RTU-P), incontinencia transitoria, disfunción eréctil (10-20 %), estenosis uretral o de cuello vesical, esclerosis del cuello.</p>
+
+<h3>13.5 Retención aguda de orina (RAO)</h3>
+<ul>
+<li>Incapacidad súbita de vaciar la vejiga, dolor suprapúbico, globo vesical palpable.</li>
+<li>Causa más frecuente: HBP descompensada (estreñimiento, fármacos anticolinérgicos, post-anestesia, etilismo, infección urinaria).</li>
+<li>Tratamiento: sondaje vesical inmediato + medición del volumen (descomprimir lentamente si &gt; 800 mL para evitar hematuria ex vacuo).</li>
+<li>Iniciar α-bloqueante 3-4 días antes de intentar retirar la sonda.</li>
+<li>Si fracaso de la retirada → cirugía (RTU-P).</li>
+</ul>
+
+<h3>13.6 Prostatitis</h3>
+
+<h4>Clasificación NIH</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Categoría</th><th>Tipo</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td>I</td><td>Prostatitis aguda bacteriana</td><td>Inicio agudo, fiebre, sepsis posible</td></tr>
+<tr><td>II</td><td>Prostatitis crónica bacteriana</td><td>ITU recurrente con el mismo germen, &gt; 3 meses</td></tr>
+<tr><td>III-A</td><td>Prostatitis crónica abacteriana inflamatoria (síndrome de dolor pélvico crónico inflamatorio)</td><td>Leucocitos en EPS sin germen</td></tr>
+<tr><td>III-B</td><td>Síndrome de dolor pélvico crónico no inflamatorio</td><td>Sin leucocitos ni germen</td></tr>
+<tr><td>IV</td><td>Prostatitis asintomática inflamatoria</td><td>Hallazgo casual en biopsia o RTU</td></tr>
+</tbody></table></div>
+
+<h4>Prostatitis aguda bacteriana (categoría I)</h4>
+<ul>
+<li>Clínica: fiebre alta + escalofríos + dolor perineal + STUI + retención.</li>
+<li>EF: <em>próstata muy dolorosa, caliente, blanda</em> al TR.</li>
+<li><strong>NO MASAJE PROSTÁTICO (riesgo de sepsis), NO sondaje uretral</strong> (talla suprapúbica si retención).</li>
+<li>Etiología: <em>E. coli</em>, enterobacterias.</li>
+<li>Tratamiento: <em>ciprofloxacino o cefalosporina iv</em>, 4-6 semanas. ATB con buena penetración prostática (quinolonas, TMP-SMX, doxiciclina). Si sepsis: piperacilina-tazobactam o carbapenem.</li>
+</ul>
+
+<h4>Prostatitis crónica bacteriana (categoría II)</h4>
+<ul>
+<li>Síntomas miccionales + dolor perineal &gt; 3 meses. ITU recurrentes con la <em>misma cepa bacteriana</em>.</li>
+<li><strong>Diagnóstico: test de Meares-Stamey de 4 vasos</strong>:
+  <ul>
+    <li>VB1: primer chorro (uretra).</li>
+    <li>VB2: chorro medio (vejiga).</li>
+    <li>EPS: secreción prostática tras masaje.</li>
+    <li>VB3: orina post-masaje.</li>
+    <li>Diagnóstico si bacterias en <em>EPS o VB3 &gt; 10× VB1 y VB2</em>.</li>
+  </ul>
+</li>
+<li>Tratamiento: <em>quinolona oral 4-6 semanas</em> (cipro o levofloxacino) o TMP-SMX 12 sem.</li>
+</ul>
+
+<h4>Categoría III (CP/CPPS)</h4>
+<p>Más frecuente. Manejo multidisciplinar: α-bloqueantes, AINE, fisioterapia pélvica, ansiolíticos, tratamiento neuropático.</p>
+
+<h3>13.7 Preguntas — U13</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Test de Stamey — para qué se realiza</summary>
+<div class="qa-body">
+<p>En el estudio de las infecciones genitourinarias, el test de Stamey se realiza para confirmar el diagnóstico de:</p>
+<ol type="a">
+<li>Epididimitis gonocócica</li>
+<li>Uretritis por clamidias</li>
+<li><strong>Prostatitis crónica</strong></li>
+<li>Pielonefritis enfisematosa</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Test de Stamey/Meares-Stamey = recogida fraccionada de orina + secreción prostática post-masaje. Diagnóstico de prostatitis bacteriana crónica (NIH categoría II).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) HBP y cirugía — afirmación cierta</summary>
+<div class="qa-body">
+<p>Varón de 57 a. busca info sobre cirugía de STUI por HBP. ¿Cuál es cierto?</p>
+<ol type="a">
+<li><strong>Entre las indicaciones absolutas para cirugía por STUI por HBP están las ITU de repetición, la litiasis vesical y la hematuria recidivante</strong></li>
+<li>Los stents prostáticos son opción para jóvenes con escasos síntomas</li>
+<li>El paciente intervenido precisa seguimiento muy exhaustivo cada 3-6 meses</li>
+<li>La disfunción eréctil es la norma tras cirugía</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Indicaciones absolutas de cirugía: retención recurrente, ITU recurrente, litiasis vesical, hematuria recidivante, hidronefrosis con IR. Los stents son rara excepción. La DE no es la norma (sí la eyaculación retrógrada en 65 % de RTU-P).</div>
+</div></details>
+
+</section>
+
+<!-- =============== U14 =============== -->
+<section class="card" id="u14">
+<h2 class="section-title"><span class="num">U14</span>Cáncer de próstata</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Cáncer más frecuente en el varón</strong> y 2ª causa de muerte oncológica masculina.</li>
+<li><strong>Histología:</strong> &gt; 95 % adenocarcinoma originado en la <em>zona periférica</em> (a diferencia de HBP en zona transicional).</li>
+<li><strong>Factores de riesgo:</strong>
+  <ul>
+    <li>Edad (raro &lt; 50 a., incidencia ↑↑ con edad).</li>
+    <li>Raza negra (incidencia y mortalidad mayores).</li>
+    <li>Antecedentes familiares (RR × 2 si 1 familiar 1er grado; × 5-11 si síndrome hereditario).</li>
+    <li>Mutaciones BRCA1/2, HOXB13, síndrome de Lynch.</li>
+    <li>Dieta rica en grasas, baja actividad física.</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Localizado: <em>asintomático</em> en la mayoría. Detectado por PSA elevado o TR sospechoso.</li>
+    <li>Localmente avanzado: STUI (similar HBP), hematuria, hemospermia.</li>
+    <li>Metastásico: dolor óseo (metástasis blásticas — pelvis, columna lumbar, fémur), anemia, compresión medular, edema MMII, IR obstructiva, síndrome general.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> elevación de PSA → <em>RMN multiparamétrica</em> (PI-RADS 1-5) → biopsia transperineal/transrectal si PI-RADS ≥ 3 → estadiaje según riesgo.</li>
+</ul>
+</div>
+
+<h3>14.1 Cribado / detección precoz</h3>
+<ul>
+<li>Recomendado <em>compartido con el paciente</em> tras información (sobrediagnóstico).</li>
+<li>Edad de inicio: <strong>50 años</strong> en población general; <strong>45 años</strong> si raza negra o antecedentes familiares (1er grado). 40 a. si BRCA2.</li>
+<li>PSA + TR cada 1-2 años. Cese del cribado en &gt; 70 a. o esperanza &lt; 10-15 a.</li>
+</ul>
+
+<h3>14.2 PSA (antígeno prostático específico)</h3>
+<ul>
+<li>Producido por epitelio prostático. Valor normal &lt; 4 ng/mL (varía con edad).</li>
+<li>NO específico de cáncer: ↑ también en HBP, prostatitis, retención, sondaje, masaje, eyaculación reciente, biopsia.</li>
+<li><strong>Aspectos útiles:</strong>
+  <ul>
+    <li>Densidad de PSA: PSA / volumen prostático. &gt; 0,15 → sospecha.</li>
+    <li>Velocidad de PSA: ↑ &gt; 0,75 ng/mL/año → sospecha.</li>
+    <li>Ratio PSA libre/total: &lt; 15 % sugiere cáncer.</li>
+    <li>PSA-DT (tiempo de duplicación) post-tratamiento.</li>
+    <li>5-α-reductasa reduce el PSA al 50 %: <em>multiplicar el valor por 2 para interpretar</em>.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>14.3 Diagnóstico</h3>
+<ol>
+<li><strong>PSA + TR.</strong></li>
+<li><strong>RMN multiparamétrica de próstata (mp-MRI)</strong> con score <em>PI-RADS</em>:
+  <ul>
+    <li>PI-RADS 1: clínicamente significativo muy improbable.</li>
+    <li>PI-RADS 2: improbable.</li>
+    <li>PI-RADS 3: indeterminado.</li>
+    <li>PI-RADS 4: probable.</li>
+    <li>PI-RADS 5: muy probable.</li>
+  </ul>
+</li>
+<li><strong>Biopsia prostática</strong> (≥ 12 cilindros) si PI-RADS ≥ 3 o sospecha alta. Vías: <em>transperineal (preferida actual, menor infección)</em> o transrectal con cobertura ATB (ciprofloxacino). Biopsia dirigida + sistemática.</li>
+<li>Análisis histológico: <em>Gleason / ISUP</em>:</li>
+</ol>
+<div class="table-wrap"><table>
+<thead><tr><th>Gleason</th><th>ISUP</th><th>Significado</th></tr></thead>
+<tbody>
+<tr><td>≤ 6 (3+3)</td><td>1</td><td>Bien diferenciado</td></tr>
+<tr><td>7 (3+4)</td><td>2</td><td>Predominio bien diferenciado</td></tr>
+<tr><td>7 (4+3)</td><td>3</td><td>Predominio moderadamente diferenciado</td></tr>
+<tr><td>8 (4+4)</td><td>4</td><td>Pobremente diferenciado</td></tr>
+<tr><td>9-10</td><td>5</td><td>Indiferenciado</td></tr>
+</tbody></table></div>
+
+<h3>14.4 Estadificación</h3>
+<ul>
+<li><strong>TNM:</strong>
+  <ul>
+    <li>cT1: no palpable, hallazgo en biopsia / RTU (T1c = elevación PSA).</li>
+    <li>cT2: limitado a la próstata (T2a uno-medio lóbulo, T2b lóbulo entero, T2c bilateral).</li>
+    <li>cT3: extracapsular (T3a) o vesículas seminales (T3b).</li>
+    <li>cT4: invade órganos vecinos (cuello vesical, recto, elevador del ano).</li>
+  </ul>
+</li>
+<li>Estudio de extensión en riesgo intermedio/alto: TC TAP + gammagrafía ósea + PSMA-PET en avanzados.</li>
+</ul>
+
+<h3>14.5 Clasificación de riesgo (D'Amico / EAU)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Riesgo</th><th>Criterios</th></tr></thead>
+<tbody>
+<tr><td><strong>Bajo</strong></td><td>Gleason ≤ 6 (ISUP 1) <em>Y</em> cT1-cT2a <em>Y</em> PSA &lt; 10</td></tr>
+<tr><td><strong>Intermedio</strong></td><td>Gleason 7 (ISUP 2-3) <em>O</em> PSA 10-20 <em>O</em> cT2b</td></tr>
+<tr><td><strong>Alto</strong></td><td>Gleason ≥ 8 (ISUP 4-5) <em>O</em> PSA &gt; 20 <em>O</em> cT2c</td></tr>
+<tr><td><strong>Muy alto</strong></td><td>cT3-T4 o N+</td></tr>
+</tbody></table></div>
+
+<h3>14.6 Tratamiento de la enfermedad localizada</h3>
+
+<h4>Vigilancia activa</h4>
+<p>Indicada en cáncer de <em>bajo riesgo</em> (Gleason 6) con esperanza de vida &gt; 10 años. PSA cada 3-6 m + TR + RM ± biopsia de control. Trata cuando hay progresión clínica/biológica.</p>
+
+<h4>Observación expectante (watchful waiting)</h4>
+<p>Pacientes con esperanza de vida limitada. Tratamiento sintomático cuando aparece progresión clínica.</p>
+
+<h4>Prostatectomía radical</h4>
+<ul>
+<li>Indicación: cáncer localizado de riesgo intermedio o alto con esperanza de vida &gt; 10 a.</li>
+<li>Vías: <em>laparoscópica robótica (preferida), laparoscópica, abierta retropúbica</em>.</li>
+<li>Extirpación: próstata completa + vesículas seminales + linfadenectomía pélvica en intermedio/alto.</li>
+<li>Preservación de bandas neurovasculares para preservar función eréctil (si es posible oncológicamente).</li>
+<li>Complicaciones: incontinencia (5-20 %), DE (40-70 %), estenosis del cuello, infertilidad.</li>
+</ul>
+
+<h4>Radioterapia externa (3D, IMRT, SBRT)</h4>
+<ul>
+<li>Indicación: cáncer localizado intermedio/alto + ADT 6 meses (intermedio) o 24-36 meses (alto).</li>
+<li>Alternativa a cirugía con resultados oncológicos similares.</li>
+<li>Complicaciones: proctitis rádica, cistitis rádica, DE tardía.</li>
+</ul>
+
+<h4>Braquiterapia</h4>
+<ul>
+<li>Baja tasa de dosis (LDR — semillas permanentes de I-125): cáncer de bajo riesgo y próstatas &lt; 50 cc.</li>
+<li>Alta tasa de dosis (HDR — boost en alto riesgo + RT externa).</li>
+</ul>
+
+<h3>14.7 Tratamiento de la enfermedad avanzada</h3>
+
+<h4>Bloqueo androgénico (ADT)</h4>
+<ul>
+<li>Andrógenos = "alimento" del cáncer prostático. La castración (médica o quirúrgica) induce respuesta inicial en &gt; 80 % de pacientes.</li>
+<li><strong>Análogos de LHRH/GnRH</strong> (leuprorelin, goserelina, triptorelina): castración farmacológica. <em>Riesgo de "flare-up"</em> al inicio (↑ transitorio de testosterona y empeoramiento clínico) → cubrir con antiandrógeno 4 sem antes y durante el primer mes.</li>
+<li><strong>Antagonistas de GnRH</strong> (degarelix, relugolix oral): sin flare-up, supresión rápida.</li>
+<li><strong>Antiandrógenos</strong> (bicalutamida, flutamida): bloquean receptor androgénico.</li>
+<li><em>Castración quirúrgica</em>: orquiectomía bilateral (subcapsular o total). Definitiva, sin compliance.</li>
+<li>Efectos del ADT: sofocos, ↓ libido, DE, osteoporosis (↑ riesgo de fracturas), ginecomastia, anemia, fatiga, ↑ riesgo CV y metabólico, depresión.</li>
+</ul>
+
+<h4>Cáncer hormonosensible metastásico</h4>
+<ul>
+<li>ADT + uno de los siguientes para mejor supervivencia:
+  <ul>
+    <li><em>Docetaxel</em> 6 ciclos.</li>
+    <li><em>Inhibidores de la síntesis androgénica</em>: abiraterona + prednisona.</li>
+    <li><em>Antagonistas del receptor androgénico de 2ª generación</em>: apalutamida, enzalutamida, darolutamida.</li>
+  </ul>
+</li>
+</ul>
+
+<h4>Cáncer resistente a la castración (CRPC)</h4>
+<ul>
+<li>Progresión a pesar de testosterona en niveles de castración (&lt; 50 ng/dL).</li>
+<li>Tratamientos: docetaxel, cabazitaxel, abiraterona, enzalutamida, radium-223 (Xofigo) si solo metástasis óseas, Lu-177-PSMA (radioligando), inmunoterapia (sipuleucel-T).</li>
+<li>Inhibidores de PARP (olaparib, rucaparib) en mutación BRCA1/2.</li>
+</ul>
+
+<h3>14.8 Pronóstico</h3>
+<ul>
+<li>Supervivencia a 5 años: localizado 100 %, regional 100 %, metastásico ≈ 30 %.</li>
+<li>Mayoría de pacientes con cáncer localizado mueren <em>con</em> el cáncer y no <em>por</em> el cáncer (otra causa).</li>
+</ul>
+
+<h3>14.9 Preguntas — U14</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Cáncer de próstata de alto riesgo</summary>
+<div class="qa-body">
+<p>Un paciente tiene cáncer de próstata de alto riesgo si tiene:</p>
+<ol type="a">
+<li>Gleason &lt; 7 y cT1-cT2a y PSA &lt; 10</li>
+<li>Gleason 7 o PSA 10-20 o cT2b</li>
+<li><strong>Gleason &gt; 7 o PSA &gt; 20 o cT2c</strong></li>
+<li>Son ciertas b y c</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Definición de alto riesgo (D'Amico). Opción a = bajo riesgo. Opción b = intermedio. Opción d no es correcta porque la "b" describe intermedio.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Cáncer de próstata de riesgo intermedio</summary>
+<div class="qa-body">
+<p>Un paciente tiene cáncer de próstata de riesgo intermedio si tiene:</p>
+<ol type="a">
+<li>Gleason &lt; 7 y cT1-cT2a y PSA &lt; 10</li>
+<li><strong>Gleason 7 o PSA 10-20 o cT2b</strong></li>
+<li>Gleason &gt; 7 o PSA &gt; 20 o cT2c</li>
+<li>Son ciertas b y c</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Definición de riesgo intermedio.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) PSA ascendente — actitud</summary>
+<div class="qa-body">
+<p>Paciente de 59 años: PSA hace 6 m = 4,1; ahora = 5,1 ng/mL. ¿Qué deberíamos hacer?</p>
+<ol type="a">
+<li>Solicitar otro PSA</li>
+<li><strong>Hacer RMN y proponer biopsia de próstata</strong></li>
+<li>Hacer TAC abdominal y gammagrafía ósea</li>
+<li>Todas son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> PSA elevado + velocidad &gt; 0,75/año = sospecha → <em>RMN multiparamétrica</em> (mp-MRI; PI-RADS) y biopsia dirigida si PI-RADS ≥ 3. TC/gammagrafía solo si Gleason alto o PSA &gt; 20.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U15 =============== -->
+<section class="card" id="u15">
+<h2 class="section-title"><span class="num">U15</span>Patología del aparato genital masculino · criptorquidia</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Criptorquidia</strong>: testículo no descendido a la bolsa escrotal. La anomalía urogenital congénita más frecuente en RN varones.</li>
+<li><strong>Epidemiología:</strong> 3 % de RN a término, 30 % de prematuros. 80 % descienden espontáneamente en los primeros 3-6 meses.</li>
+<li><strong>Localizaciones:</strong>
+  <ul>
+    <li>Abdominal (10 %): no palpable. Riesgo oncológico máximo.</li>
+    <li>Inguinal (más frecuente).</li>
+    <li>Ectópico (femoral, perineal, peneano).</li>
+  </ul>
+</li>
+<li><strong>Riesgos no tratados:</strong>
+  <ul>
+    <li><em>Infertilidad</em> (sobre todo bilateral): por daño térmico del epitelio germinal.</li>
+    <li><em>Cáncer testicular × 5-10</em> (riesgo en el contralateral también ↑).</li>
+    <li><em>Torsión testicular</em>.</li>
+    <li>Hernia inguinal asociada.</li>
+    <li>Trauma psicológico.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Esperar hasta los 6 meses</em> por si desciende solo.</li>
+    <li><strong>Orquidopexia quirúrgica entre 6 y 18 meses</strong> (antes de 1-2 años; cuanto antes, mejor preservación de la fertilidad).</li>
+    <li>Si no se palpa ni se ve en eco → <em>laparoscopia exploradora</em>. Si se encuentra: orquidopexia (1 o 2 tiempos, técnica de Fowler-Stephens si vasos cortos). Si testículo atrófico: extirpación.</li>
+    <li>Hormonoterapia con HCG: eficacia limitada.</li>
+    <li>Adulto con criptorquidia tardíamente descubierta y testículo atrófico → <em>orquiectomía profiláctica</em> (no fertilidad recuperable y alto riesgo oncológico).</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>15.1 Escroto agudo — diagnóstico diferencial</h3>
+<p>Síntoma frecuente en el adolescente y varón joven. <em>Toda urgencia escrotal es torsión testicular hasta demostrar lo contrario</em>.</p>
+
+<div class="table-wrap"><table>
+<thead><tr><th>Entidad</th><th>Edad</th><th>Inicio</th><th>Reflejo cremastérico</th><th>Doppler</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Torsión testicular</strong></td><td>Pico 12-18 a.</td><td>Súbito, intenso · náuseas/vómitos</td><td><strong>Ausente</strong></td><td>↓↓ o ausente flujo · testículo elevado/horizontalizado</td><td><strong>Cirugía urgente &lt; 6 h</strong>: detorsión + orquidopexia bilateral. Si necrosis: orquiectomía</td></tr>
+<tr><td>Torsión de hidátide de Morgagni</td><td>7-12 a.</td><td>Subagudo</td><td>Conservado</td><td>Flujo normal. "Punto azul" visible en escroto</td><td>AINE + reposo (autolimitada)</td></tr>
+<tr><td>Orquiepididimitis</td><td>Cualquier edad</td><td>Subagudo (días) · fiebre · síntomas miccionales</td><td>Conservado</td><td><strong>Flujo aumentado</strong></td><td>ATB: doxiciclina (Chlamydia, &lt; 35 a.) · cipro/levo (E. coli, &gt; 35 a.)</td></tr>
+<tr><td>Hernia inguinal incarcerada</td><td>Cualquier</td><td>Variable</td><td>Conservado</td><td>Flujo normal · masa palpable que se extiende a inguinal</td><td>Reducción manual · cirugía urgente si necrosis intestinal</td></tr>
+<tr><td>Trauma escrotal</td><td>Cualquier</td><td>Tras impacto</td><td>Variable</td><td>Eco: hematocele, hematoma, fractura testicular</td><td>Conservador o quirúrgico (rotura albugínea, hematocele grande)</td></tr>
+</tbody></table></div>
+
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🚨</span>Torsión testicular — emergencia</div>
+<ul style="margin:6px 0">
+<li>Tasa de salvación testicular: &lt; 6 h ≈ 100 %, 6-12 h ≈ 70 %, 12-24 h ≈ 20 %, &gt; 24 h ≈ 0 %.</li>
+<li>El Doppler tiene <em>falsos negativos</em> en fases tempranas — si la sospecha clínica es alta, llevar a quirófano sin pruebas adicionales.</li>
+<li>Durante la cirugía: detorsión + envolver el testículo en gasas calientes; si recupera color → orquidopexia bilateral (riesgo de torsión contralateral por anomalía anatómica del gubernaculum tipo "badajo de campana"). Si negro/necrótico → orquiectomía + orquidopexia contralateral.</li>
+</ul>
+</div>
+
+<h3>15.2 Varicocele</h3>
+<ul>
+<li>Dilatación del plexo pampiniforme. Más frecuente patología del adulto joven (15-20 %).</li>
+<li><strong>90 % IZQUIERDO</strong> (la vena espermática izquierda desemboca perpendicularmente en la vena renal izquierda — drenaje peor; la derecha drena oblicuamente en cava).</li>
+<li><strong>Clasificación de Dubin (grados):</strong>
+  <ul>
+    <li>0: subclínico (solo Doppler).</li>
+    <li>I: solo palpable con Valsalva.</li>
+    <li>II: palpable en reposo.</li>
+    <li>III: visible en bipedestación (sin Valsalva).</li>
+    <li>(Algunos clasifican IV cuando es visible en reposo).</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> molestia escrotal sorda, "bolsa de gusanos", infertilidad masculina (alteración de la espermatogénesis por aumento de temperatura), atrofia testicular ipsilateral.</li>
+<li><strong>Indicaciones de tratamiento:</strong> infertilidad masculina con varicocele clínico + espermiograma alterado, dolor refractario, atrofia testicular en adolescente.</li>
+<li><strong>Tratamiento:</strong> ligadura de la vena espermática (Palomo, Ivanissevich, laparoscópica) o embolización percutánea.</li>
+<li><strong>¡Atención! Varicocele DERECHO de novo en adulto</strong> = sospechar <em>masa retroperitoneal</em> que comprime la vena cava (CCR, linfoma) → <em>TAC TAP obligatorio</em>.</li>
+</ul>
+
+<h3>15.3 Hidrocele</h3>
+<ul>
+<li>Acumulación de líquido entre las capas vaginales del testículo.</li>
+<li>Transiluminación positiva (a diferencia del hematocele).</li>
+<li>Primario (idiopático) o secundario (infección, traumatismo, tumor).</li>
+<li>Tratamiento: observación si pequeño/asintomático; cirugía (técnica de Jaboulay o Lord) si grande/molesto.</li>
+<li>En niños: hidrocele congénito por persistencia del conducto peritoneo-vaginal. Suele resolverse antes de los 2 a.</li>
+</ul>
+
+<h3>15.4 Espermatocele</h3>
+<p>Quiste paratesticular en cabeza del epidídimo, indoloro, transiluminación (+). Conservador.</p>
+
+<h3>15.5 Fimosis y parafimosis</h3>
+<ul>
+<li><strong>Fimosis:</strong> imposibilidad de retraer el prepucio sobre el glande. Fisiológica hasta los 3 a. Si persiste: corticoides tópicos o circuncisión.</li>
+<li><strong>Parafimosis:</strong> retracción prolongada del prepucio retrocoronal con edema → urgencia. Reducción manual o incisión dorsal si fracasa.</li>
+</ul>
+
+<h3>15.6 Balanopostitis</h3>
+<p>Infección/inflamación del glande y prepucio. Frecuente en niños con fimosis y diabéticos (Candida). Tratamiento: higiene, antibióticos/antifúngicos tópicos, circuncisión si recurrente.</p>
+
+<h3>15.7 Enfermedad de Peyronie (induratio penis plastica)</h3>
+<ul>
+<li>Placa fibrosa en la túnica albugínea de los cuerpos cavernosos → curvatura peneana durante la erección, dolor, disfunción eréctil.</li>
+<li>Diagnóstico clínico + ecografía Doppler.</li>
+<li>Tratamiento: fase aguda (dolor) — sintomático; fase crónica (placa estable) — colagenasa intralesional (Xiapex), cirugía (plicaturas de Nesbit, parches de injerto).</li>
+</ul>
+
+<h3>15.8 Priapismo</h3>
+<ul>
+<li>Erección dolorosa &gt; 4 h no relacionada con estímulo sexual.</li>
+<li><strong>Isquémico (de bajo flujo):</strong> dolor, rigidez, sangre venosa oscura en aspiración. Drepanocitosis, leucemia, inyecciones intracavernosas, fármacos (trazodona, antipsicóticos). <em>Emergencia urológica</em>: aspiración + irrigación con suero salino + inyección de fenilefrina; shunt quirúrgico si refractario.</li>
+<li><strong>No isquémico (de alto flujo):</strong> traumatismo perineal con fístula arteriocavernosa. Indoloro. Conservador o embolización.</li>
+</ul>
+
+<h3>15.9 Preguntas — U15</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Escroto agudo en adolescente — torsión testicular</summary>
+<div class="qa-body">
+<p>Paciente de 18 años con dolor testicular derecho de 3 h + náuseas. EF: testículo poco móvil. Doppler: ↓ flujo testicular derecho. ¿Orientación y tratamiento?</p>
+<ol type="a">
+<li>Orquitis – Tratamiento antibiótico</li>
+<li><strong>Torsión testicular – Tratamiento quirúrgico</strong></li>
+<li>Hernia inguinal incarcerada – Tratamiento quirúrgico</li>
+<li>Torsión de hidátide de Morgagni – AINE</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Adolescente + dolor brusco + ↓ flujo Doppler = torsión testicular. <strong>EMERGENCIA quirúrgica &lt; 6 h</strong>: orquidopexia bilateral (también del contralateral por riesgo). Tasa de salvación: &lt; 6 h ≈ 100 %; &gt; 24 h ≈ 0 %.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Varicocele derecho voluminoso en adulto</summary>
+<div class="qa-body">
+<p>Hombre de 53 a. con aumento del hemiescroto derecho de 5 días, "bolsa de gusanos" en bipedestación. ¿Sospecha y prueba?</p>
+<ol type="a">
+<li><strong>Varicocele derecho grado 3 – TAC abdomino-pélvico</strong></li>
+<li>Varicocele derecho grado 1 – Eco escrotal</li>
+<li>Varicocele derecho grado 2 – RNM pélvica</li>
+<li>Varicocele derecho grado 4 – Eco abdominal</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Varicocele derecho de novo en adulto → descartar tumor retroperitoneal que comprima la vena cava (CCR, linfoma). <em>TAC TAP obligado</em>. Visible en bipedestación = grado III (grado IV sería visible también en decúbito).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Criptorquidia en lactante de 16 meses sin testículo palpable</summary>
+<div class="qa-body">
+<p>Lactante de 16 meses derivado por ausencia de testículo izquierdo en bolsa. EF y eco negativas. ¿Actitud?</p>
+<ol type="a">
+<li>Esperar hasta los 2 años descenso espontáneo</li>
+<li>Iniciar HCG durante 6 meses</li>
+<li><strong>Laparoscopia exploradora y, si se encuentra, orquidopexia</strong></li>
+<li>Cirugía inguinal y exéresis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tras los 6 meses ya no hay descenso espontáneo. Si no se palpa ni se ve en eco → laparoscopia diagnóstica/terapéutica. Si se encuentra → orquidopexia (1 o 2 tiempos, Fowler-Stephens si vasos cortos). HCG sin demostrada eficacia.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Adulto de 26 a. con criptorquidia descubierta</summary>
+<div class="qa-body">
+<p>Paciente de 26 a. con criptorquidia derecha en canal inguinal (12 mm, atrofiado). Testículo izquierdo único y normal. ¿Tratamiento y motivo?</p>
+<ol type="a">
+<li>Orquidopexia derecha para desarrollo testicular</li>
+<li>Orquidopexia derecha para mantener fertilidad</li>
+<li><strong>Orquiectomía derecha para evitar riesgo de malignización</strong></li>
+<li>Orquidopexia derecha para función hormonal</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> En el adulto con criptorquidia tardía y testículo atrófico, la fertilidad y función hormonal son irrecuperables. El riesgo de cáncer (especialmente seminoma) se mantiene ↑↑ → orquiectomía profiláctica.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U16 =============== -->
+<section class="card" id="u16">
+<h2 class="section-title"><span class="num">U16</span>Patología de uretra y pene · cáncer de pene</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Cáncer de pene</strong>: raro en países desarrollados (1-2/100.000), incidencia alta en África, Asia, Sudamérica. Edad media 60 años.</li>
+<li><strong>Factores de riesgo:</strong>
+  <ul>
+    <li><em>Infección por HPV 16 y 18</em> (40-50 % de los casos).</li>
+    <li>Fimosis (×10).</li>
+    <li>Mala higiene local (smegma irritante).</li>
+    <li>Tabaquismo.</li>
+    <li>PUVA terapia (psoriasis).</li>
+    <li>Lesiones premalignas (ver más abajo).</li>
+    <li>Liquen escleroso atrófico (balanitis xerótica obliterante).</li>
+    <li>Inmunodepresión (VIH, trasplante).</li>
+  </ul>
+</li>
+<li><strong>HPV de alto riesgo</strong> (16, 18, 31, 33) → cáncer.</li>
+<li><strong>HPV de bajo riesgo</strong> (6, 11) → condilomas acuminados / verrugas / carcinoma verrucoso (forma menos agresiva).</li>
+<li><strong>Circuncisión neonatal</strong>: factor protector mayor.</li>
+</ul>
+</div>
+
+<h3>16.1 Lesiones premalignas</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Lesión</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td><strong>Balanitis xerótica obliterante (BXO)</strong></td><td>Variante de liquen escleroso atrófico en glande/prepucio. Placas blanquecinas, fimosis adquirida, esclerosis del meato. Riesgo de carcinoma 4-9 %</td></tr>
+<tr><td>Leucoplasia</td><td>Placa blanquecina del glande</td></tr>
+<tr><td><strong>Eritroplasia de Queyrat</strong></td><td>Carcinoma in situ del <em>glande</em> (placa eritematosa, brillante, bien delimitada)</td></tr>
+<tr><td><strong>Enfermedad de Bowen</strong></td><td>Carcinoma in situ del cuerpo del pene o piel adyacente</td></tr>
+<tr><td><strong>Papulosis bowenoide</strong></td><td>Pápulas verrucosas multifocales en varones jóvenes con HPV. Riesgo bajo de progresión</td></tr>
+<tr><td>Cuerno cutáneo</td><td>Proliferación hiperqueratósica que puede albergar carcinoma en la base</td></tr>
+<tr><td>Condilomas acuminados gigantes (Buschke-Löwenstein)</td><td>Asociados a HPV 6/11 → forma agresiva localmente: carcinoma verrucoso</td></tr>
+</tbody></table></div>
+
+<h3>16.2 Histología del cáncer de pene</h3>
+<ul>
+<li><strong>Carcinoma epidermoide / escamoso</strong> = 95 %.</li>
+<li>Variantes:
+  <ul>
+    <li><em>Convencional / queratinizante</em> (50 %).</li>
+    <li><em>Verrucoso</em> (carcinoma de Buschke-Löwenstein, asociado a HPV 6/11): bien diferenciado, agresivo localmente pero rara vez metastatiza.</li>
+    <li><em>Papilar</em>, <em>basaloide</em>, <em>sarcomatoide</em> (peor pronóstico).</li>
+  </ul>
+</li>
+<li>Otros: melanoma de pene, sarcoma de Kaposi (VIH), enfermedad de Paget extramamaria, metástasis.</li>
+</ul>
+
+<h3>16.3 Clínica</h3>
+<ul>
+<li>Lesión en glande o prepucio: nódulo, úlcera, vegetación, placa eritematosa, secreción fétida bajo fimosis.</li>
+<li>Sangrado tras coito o roce.</li>
+<li>Adenopatías inguinales palpables (50 % al diagnóstico — la mitad son inflamatorias y la mitad metastásicas).</li>
+<li>Cualquier lesión persistente del pene &gt; 4 semanas → biopsia.</li>
+</ul>
+
+<h3>16.4 Diagnóstico</h3>
+<ul>
+<li><strong>Biopsia</strong> de la lesión (incisional o por punch).</li>
+<li><strong>Exploración inguinal bilateral</strong>: tamaño, número, fijación, ulceración.</li>
+<li>Estadiaje: RMN de pene (extensión local), TC TAP (adenopatías y metástasis), PET-TAC si avanzado.</li>
+<li>Biopsia selectiva del ganglio centinela en cN0 con tumor pT1G2 o superior.</li>
+</ul>
+
+<h3>16.5 Estadificación TNM (resumida)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>T</th><th>Significado</th></tr></thead>
+<tbody>
+<tr><td>Tis</td><td>Carcinoma in situ</td></tr>
+<tr><td>Ta</td><td>Carcinoma verrucoso no invasivo</td></tr>
+<tr><td>T1</td><td>Invade subepitelio (T1a sin invasión vasculolinfática, T1b con invasión o grado &gt; 2)</td></tr>
+<tr><td>T2</td><td>Invade cuerpo esponjoso</td></tr>
+<tr><td>T3</td><td>Invade cuerpo cavernoso o uretra</td></tr>
+<tr><td>T4</td><td>Invade estructuras adyacentes (escroto, próstata, pubis)</td></tr>
+</tbody></table></div>
+<p><strong>N:</strong> N1 = 1 ganglio inguinal · N2 = múltiples o bilaterales · N3 = ganglio pélvico o extranodal.</p>
+
+<h3>16.6 Tratamiento</h3>
+
+<h4>Lesión primaria</h4>
+<ul>
+<li><strong>Tis / Ta:</strong> 5-fluorouracilo o imiquimod tópicos, láser CO₂, glandectomía superficial.</li>
+<li><strong>T1a:</strong> cirugía conservadora (escisión local amplia, glandectomía parcial, técnica de Mohs, láser, radioterapia, braquiterapia).</li>
+<li><strong>T1b-T2:</strong> glandectomía total o amputación parcial (penectomía parcial) preservando ≥ 2 cm de pene proximal.</li>
+<li><strong>T3-T4:</strong> amputación total con uretrostomía perineal ± exenteración pélvica si T4.</li>
+</ul>
+
+<h4>Adenopatías</h4>
+<ul>
+<li><strong>cN0:</strong> en T1b o superior: biopsia del ganglio centinela. Si (+) → linfadenectomía inguinal ipsilateral.</li>
+<li><strong>cN1-N2:</strong> linfadenectomía inguinal radical bilateral (incluso si solo unilateral palpable).</li>
+<li><strong>cN3:</strong> linfadenectomía pélvica + QT/RT.</li>
+</ul>
+
+<h4>Quimio/radioterapia</h4>
+<ul>
+<li>QT neoadyuvante (cisplatino + 5-FU + paclitaxel) en N2/N3.</li>
+<li>QT/RT adyuvante en ganglios + o márgenes positivos.</li>
+<li>Enfermedad metastásica: cisplatino + 5-FU + paclitaxel; inmunoterapia en ensayos.</li>
+</ul>
+
+<h3>16.7 Patología de la uretra</h3>
+<ul>
+<li><strong>Estenosis uretral</strong> (ver U2).</li>
+<li><strong>Divertículo uretral</strong> (en mujer): masa periuretral con disuria, dispareunia, goteo postmiccional, ITU recurrente. Diagnóstico por RM. Tratamiento: diverticulectomía.</li>
+<li><strong>Carunculo uretral</strong>: lesión benigna del meato uretral femenino postmenopáusica. Estrógenos tópicos o resección.</li>
+<li><strong>Carcinoma de uretra</strong>: raro. Más en mujer. Asociado a uretritis crónica, divertículo, HPV. Histología: epidermoide, urotelial, adenocarcinoma. Tratamiento: cirugía + RT.</li>
+</ul>
+
+<h3>16.8 Preguntas — U16</h3>
+
+<details class="qa"><summary>1. (Ord 2025) HPV 6 y 11 — lesión asociada</summary>
+<div class="qa-body">
+<p>La lesión de pene relacionada con HPV cepas 6 y 11 corresponde a:</p>
+<ol type="a">
+<li>Carcinoma epidermoide</li>
+<li>Enfermedad de Bowen</li>
+<li><strong>Carcinoma verrucoso</strong></li>
+<li>Sarcoma de Kaposi</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (banco UGR).</strong> HPV 6 y 11 son los de "bajo riesgo" responsables de los condilomas acuminados y del <em>carcinoma verrucoso</em> (tumor de Buschke-Löwenstein). HPV 16/18 son de "alto riesgo" → carcinoma epidermoide convencional.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) NO es lesión premaligna del cáncer de pene</summary>
+<div class="qa-body">
+<p>En relación con el cáncer de pene, ¿cuál NO se considera lesión premaligna?</p>
+<ol type="a">
+<li>Balanitis xerótica obliterante</li>
+<li><strong>Leucoplasia</strong></li>
+<li>Eritroplasia de Queyrat</li>
+<li>Papulosis bowenoide</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (banco; respuesta controvertida).</strong> En realidad la leucoplasia SÍ se considera lesión premaligna clásica. El banco UGR marca b en esta versión, pero la respuesta más fisiopatológica sería ambigua. Las demás opciones son claramente premalignas.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Cáncer de pene — FALSA</summary>
+<div class="qa-body">
+<p>En relación con el cáncer de pene, señale la FALSA:</p>
+<ol type="a">
+<li>HPV 16 y 18 tienen un papel etiológico en el 40-50 % de los cánceres de vulva, pene y bucofaringe</li>
+<li>La balanitis xerótica obliterante es una lesión premaligna</li>
+<li><strong>Paciente con afectación del cuerpo cavernoso derecho + 1 ganglio inguinal derecho + 1 ganglio ilíaco externo derecho = pT2N2</strong></li>
+<li>La enfermedad de Bowen es una neoplasia intraepitelial de pene</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (FALSA).</strong> Cuerpo cavernoso = pT2. Adenopatías inguinales + pélvicas (ilíaca externa) = N3 (no N2). N2 sería ganglios inguinales múltiples sin pélvicos.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Lesión premaligna del pene</summary>
+<div class="qa-body">
+<p>En relación con el cáncer de pene, ¿cuál de las siguientes patologías se considera lesión premaligna?</p>
+<ol type="a">
+<li>Balanitis xerótica obliterante</li>
+<li>Leucoplasia</li>
+<li>Papulosis bowenoide</li>
+<li><strong>Todas las respuestas son correctas</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Todas son lesiones premalignas reconocidas del cáncer de pene.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U17 =============== -->
+<section class="card" id="u17">
+<h2 class="section-title"><span class="num">U17</span>Cáncer de testículo</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Cáncer sólido más frecuente en el varón joven</strong> (15-35 a.). Incidencia 7-10/100.000. Tasa de curación global &gt; 95 % gracias a la sensibilidad a quimioterapia con cisplatino.</li>
+<li><strong>Factores de riesgo:</strong>
+  <ul>
+    <li><em>Criptorquidia</em> (× 5-10; aumenta también el riesgo en el testículo contralateral, descendido).</li>
+    <li>Antecedente familiar de cáncer testicular.</li>
+    <li>Atrofia testicular, infertilidad, microlitiasis testicular.</li>
+    <li>Síndrome de Klinefelter (47,XXY) — tumores extragonadales, sobre todo mediastínicos.</li>
+    <li>VIH, raza blanca.</li>
+  </ul>
+</li>
+<li><strong>Origen embrionario:</strong>
+  <ul>
+    <li><em>Tumores de células germinales (TCG, 95 %)</em>: seminoma (50 %) y no seminomatosos (carcinoma embrionario, coriocarcinoma, tumor del saco vitelino, teratoma).</li>
+    <li><em>Tumores del estroma/cordones sexuales (5 %)</em>: Leydig (productores de testosterona — pubertad precoz, ginecomastia), Sertoli (Peutz-Jeghers, síndrome de feminización), gonadoblastoma.</li>
+    <li>Otros: linfomas testiculares (en &gt; 50 a.), metástasis.</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Bulto intratesticular indoloro, duro, sensación de pesadez (consultar siempre).</li>
+    <li>Dolor escrotal en 10-20 %.</li>
+    <li>Ginecomastia (β-HCG productores).</li>
+    <li>Metástasis: adenopatías retroperitoneales palpables (paraaórticas L1-L3), supraclaviculares (Virchow), pulmonares, óseas.</li>
+    <li>Hemoptisis, disnea (metástasis pulmonares), neurológico (metástasis cerebrales — coriocarcinoma).</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>17.1 Marcadores tumorales</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Marcador</th><th>Origen</th><th>Vida media</th><th>Significado</th></tr></thead>
+<tbody>
+<tr><td><strong>α-fetoproteína (AFP)</strong></td><td>Tumor del saco vitelino, carcinoma embrionario, teratoma inmaduro</td><td>5-7 días</td><td><em>NUNCA</em> está elevada en seminoma puro · si AFP↑, no es seminoma</td></tr>
+<tr><td><strong>β-HCG</strong></td><td>Coriocarcinoma (↑↑↑), carcinoma embrionario, 15 % seminomas</td><td>24-36 h</td><td>Puede dar ginecomastia · niveles muy altos → coriocarcinoma</td></tr>
+<tr><td><strong>LDH</strong></td><td>Inespecífica, refleja masa tumoral</td><td>24 h</td><td>Pronóstico (IGCCCG)</td></tr>
+</tbody></table></div>
+
+<h3>17.2 Clasificación histológica y marcadores</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tumor</th><th>β-HCG</th><th>AFP</th><th>Edad típica</th><th>Características</th></tr></thead>
+<tbody>
+<tr><td><strong>Seminoma clásico puro</strong></td><td>± (15 % ↑)</td><td><strong>NORMAL</strong> (nunca eleva AFP)</td><td>30-40 a.</td><td><em>Radiosensible</em> y muy quimiosensible · pronóstico excelente</td></tr>
+<tr><td>Seminoma espermatocítico</td><td>−</td><td>−</td><td>&gt; 50 a.</td><td>Raro, baja malignidad</td></tr>
+<tr><td><strong>Carcinoma embrionario</strong></td><td>+</td><td>+</td><td>20-30 a.</td><td>Agresivo, suele formar parte de tumor mixto</td></tr>
+<tr><td><strong>Coriocarcinoma</strong></td><td><strong>↑↑↑</strong></td><td>−</td><td>20-30 a.</td><td>Muy agresivo, <em>metástasis hematógenas precoces</em> (pulmón, SNC). Riesgo de hemorragia</td></tr>
+<tr><td>Tumor del saco vitelino (yolk sac)</td><td>−</td><td><strong>↑↑↑</strong></td><td>Niño &lt; 3 a.</td><td>El más frecuente en niños</td></tr>
+<tr><td>Teratoma</td><td>−</td><td>± leve</td><td>Cualquier edad</td><td>Quimiorresistente y radiorresistente · resección quirúrgica</td></tr>
+<tr><td><strong>Tumor mixto</strong></td><td>Variable</td><td>Variable</td><td>20-30 a.</td><td>Pronóstico según componente más agresivo</td></tr>
+</tbody></table></div>
+
+<div class="box box-mnemo">
+<div class="box-title"><span class="icon">🧠</span>Reglas mnemotécnicas</div>
+<ul style="margin:6px 0">
+<li><strong>SEMINOMA PURO ≠ AFP elevada.</strong> Si AFP ↑ → tratar como no seminomatoso.</li>
+<li><strong>Carcinoma embrionario → β-HCG + AFP ambos elevados.</strong></li>
+<li><strong>Coriocarcinoma → β-HCG ↑↑↑.</strong></li>
+<li><strong>Saco vitelino → AFP ↑↑↑ (en niños).</strong></li>
+<li><strong>Teratoma → marcadores normales o ligeramente elevados.</strong></li>
+</ul>
+</div>
+
+<h3>17.3 Diagnóstico y estadificación</h3>
+<ol>
+<li><strong>Exploración + ecografía escrotal:</strong> nódulo hipoecogénico, heterogéneo, hipervascularizado.</li>
+<li><strong>Marcadores tumorales</strong> (β-HCG, AFP, LDH) antes de la cirugía.</li>
+<li><strong>Orquiectomía radical inguinal</strong>: incisión inguinal con ligadura alta del cordón espermático ANTES de movilizar el testículo (evita diseminación linfática). <em>JAMÁS abordaje escrotal</em> (riesgo de cambio del patrón de drenaje linfático al inguinal).</li>
+<li><strong>Estudio histológico</strong> de la pieza.</li>
+<li><strong>Estudio de extensión:</strong> TC TAP, RM cerebral si síntomas. Marcadores tras orquiectomía (deben caer según vida media).</li>
+<li><strong>Estadios TNMS</strong> (incorpora marcadores):
+  <ul>
+    <li>Estadio I: limitado al testículo, sin metástasis.</li>
+    <li>Estadio II: adenopatías retroperitoneales (IIA &lt; 2 cm, IIB 2-5, IIC &gt; 5).</li>
+    <li>Estadio III: metástasis a distancia (pulmón, hígado, hueso, SNC).</li>
+  </ul>
+</li>
+</ol>
+
+<h3>17.4 Drenaje linfático</h3>
+<p><strong>Testículo derecho:</strong> ganglios <em>interaortocava</em> y precava. <strong>Testículo izquierdo:</strong> ganglios <em>paraaórticos</em> y preaórticos. El drenaje cruzado de derecho a izquierdo es posible. <em>Nunca son ganglios inguinales</em> (salvo invasión escrotal o cirugía previa, ej. orquidopexia o hernia).</p>
+
+<h3>17.5 Pronóstico (clasificación IGCCCG)</h3>
+<p>Para tumor metastásico, según marcadores post-orquiectomía y localización de metástasis:</p>
+<ul>
+<li><strong>Buen pronóstico:</strong> seminoma con cualquier localización de metástasis excepto no pulmonar visceral; no seminomatoso testicular o retroperitoneal con metástasis solo pulmonares y marcadores bajos.</li>
+<li><strong>Pronóstico intermedio.</strong></li>
+<li><strong>Mal pronóstico:</strong> no seminomatoso con metástasis viscerales no pulmonares (hígado, SNC, hueso) o marcadores muy elevados; primario mediastínico.</li>
+</ul>
+
+<h3>17.6 Tratamiento (post-orquiectomía)</h3>
+
+<h4>Seminoma</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Estadio</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>Estadio I bajo riesgo (tumor &lt; 4 cm, sin invasión de rete testis)</td><td><strong>Vigilancia activa</strong></td></tr>
+<tr><td>Estadio I alto riesgo (tumor &gt; 4 cm o invasión de rete testis)</td><td>Vigilancia / <em>carboplatino 1 ciclo</em> / RT retroperitoneal (las 3 opciones aceptables)</td></tr>
+<tr><td>IIA-B (adenopatías retroperitoneales pequeñas-medianas)</td><td>RT retroperitoneal "dog-leg" o QT (BEP × 3 o EP × 4)</td></tr>
+<tr><td>IIC-III (avanzado)</td><td>QT BEP × 3-4 ciclos</td></tr>
+</tbody></table></div>
+
+<h4>No seminomatoso</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Estadio</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>Estadio I bajo riesgo</td><td>Vigilancia activa (preferido)</td></tr>
+<tr><td>Estadio I alto riesgo (invasión vasculolinfática, carcinoma embrionario predominante)</td><td>Vigilancia / BEP × 1 / LRP (linfadenectomía retroperitoneal preservadora de fibras nerviosas)</td></tr>
+<tr><td>II + III</td><td>BEP × 3-4 ± linfadenectomía retroperitoneal post-QT si masa residual</td></tr>
+</tbody></table></div>
+
+<h4>Manejo de masa residual post-QT</h4>
+<ul>
+<li><strong>Seminoma:</strong> si masa &lt; 3 cm → seguimiento. Si &gt; 3 cm → <em>PET-TAC</em>: si captante → linfadenectomía o QT de rescate; si no captante → seguimiento.</li>
+<li><strong>No seminomatoso:</strong> si masa &gt; 1 cm con marcadores normales → <em>linfadenectomía retroperitoneal de rescate</em> (puede contener teratoma puro o tumor viable resistente).</li>
+</ul>
+
+<h4>Esquema BEP</h4>
+<ul>
+<li><em>Bleomicina + Etopósido + Cisplatino</em>, ciclos de 3 semanas.</li>
+<li>Efectos adversos: nefro/oto/neurotoxicidad (cisplatino), neumonitis (bleomicina — limitar dosis, vigilar DLCO), mielosupresión (etopósido), náuseas, infertilidad.</li>
+<li>Crioconservación de semen ANTES de iniciar QT.</li>
+</ul>
+
+<h3>17.7 Tumores no germinales del testículo</h3>
+<ul>
+<li><strong>Tumor de Leydig:</strong> produce testosterona y/o estrógenos. Pubertad precoz, ginecomastia, infertilidad. Orquiectomía.</li>
+<li><strong>Tumor de Sertoli:</strong> raro. Asociado a síndrome de Peutz-Jeghers y síndrome de Carney.</li>
+<li><strong>Linfoma testicular:</strong> el tumor testicular más frecuente en &gt; 50 a. Linfoma B difuso de células grandes. Tratamiento: orquiectomía + QT (R-CHOP) + profilaxis SNC.</li>
+<li>Metástasis testiculares: próstata, riñón, pulmón.</li>
+</ul>
+
+<h3>17.8 Seguimiento</h3>
+<p>Marcadores + TC + Rx tórax cada 3 m primer año, espaciado progresivamente hasta los 5-10 años. Riesgo de segundo tumor testicular contralateral en 5 %.</p>
+
+<h3>17.9 Preguntas — U17</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Joven con nódulo testicular 22 mm + marcadores normales</summary>
+<div class="qa-body">
+<p>Paciente de 32 años con bulto indoloro, nódulo intratesticular de 22 mm. β-HCG y AFP normales. ¿Sospecha?</p>
+<ol type="a">
+<li>Carcinoma embrionario</li>
+<li><strong>Seminoma clásico</strong></li>
+<li>Coriocarcinoma</li>
+<li>Tumor mixto seminoma con coriocarcinoma</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Joven adulto con marcadores normales y tumor testicular → seminoma puro (que típicamente no eleva AFP y solo eleva β-HCG en 15 %). Carcinoma embrionario suele elevar ambos.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Carcinoma embrionario con metástasis tras QT BEP — masa de 22 mm</summary>
+<div class="qa-body">
+<p>Paciente de 22 a. con orquiectomía por carcinoma embrionario + metástasis retroperitoneales. Tras BEP, TAC: adenopatía interaortocava de 22 mm. ¿Tratamiento?</p>
+<ol type="a">
+<li><strong>Cirugía de rescate para exéresis de la adenopatía</strong></li>
+<li>RT SBRT</li>
+<li>QT de rescate sistémica</li>
+<li>Seguimiento al ser inferior a 3 cm</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> En no seminomatosos, masa residual &gt; 1 cm tras QT con marcadores normales → <em>linfadenectomía retroperitoneal de rescate</em> (puede contener teratoma o tumor viable resistente).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Seminoma estadio I post-orquiectomía</summary>
+<div class="qa-body">
+<p>Paciente de 34 a. con orquiectomía por seminoma clásico puro. Estudio de extensión negativo. Tumor 25 mm sin infiltración de rete testis. ¿Tratamiento adyuvante?</p>
+<ol type="a">
+<li>RT retroperitoneal</li>
+<li>6 ciclos de QT con carboplatino</li>
+<li>6 ciclos de QT con cisplatino</li>
+<li><strong>Observación y seguimiento</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Seminoma estadio I de bajo riesgo (tumor &lt; 4 cm + sin invasión de rete testis) → <em>vigilancia activa</em> (recidiva ~ 15 %, curables al rescate). Si fuera de alto riesgo: carboplatino 1 dosis (no 6 ciclos).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Tumor que eleva β-HCG y AFP</summary>
+<div class="qa-body">
+<p>¿Cuál de los siguientes tumores testiculares puede elevar tanto β-HCG como AFP?</p>
+<ol type="a">
+<li>Coriocarcinoma</li>
+<li>Seminoma</li>
+<li><strong>Carcinoma embrionario</strong></li>
+<li>Tumor del saco vitelino</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Carcinoma embrionario eleva ambos. Coriocarcinoma solo β-HCG (↑↑↑). Saco vitelino solo AFP. Seminoma puro nunca AFP.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U18 =============== -->
+<section class="card" id="u18">
+<h2 class="section-title"><span class="num">U18</span>Disfunción eréctil · infertilidad masculina</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Disfunción eréctil (DE)</strong>: incapacidad persistente (≥ 3 meses) para conseguir y/o mantener una erección suficiente para una relación sexual satisfactoria.</li>
+<li><strong>Prevalencia:</strong> ↑ con edad. 5-20 % a los 40 a., &gt; 50 % a los 70 a.</li>
+<li><strong>DE = marcador precoz de enfermedad cardiovascular</strong>: los vasos peneanos (arterias helicinas) son los más pequeños y se obstruyen primero; suele preceder en 3-5 años a un evento coronario. <em>"Lo que es bueno para el corazón es bueno para el pene"</em>.</li>
+</ul>
+</div>
+
+<h3>18.1 Fisiología de la erección</h3>
+<ul>
+<li>Estímulo sexual (somático y/o psicógeno) → activación parasimpática (S2-S4, nervio cavernoso) → liberación de <em>óxido nítrico (NO)</em> en endotelio y nervios cavernosos.</li>
+<li>NO activa <em>guanilato ciclasa</em> → ↑ <em>GMPc</em> intracelular en el músculo liso cavernoso.</li>
+<li>GMPc activa proteína cinasa G → ↓ Ca²⁺ intracelular → <em>relajación del músculo liso</em> → vasodilatación arteriolar + relajación trabecular → atrapamiento sanguíneo en sinusoides → compresión venosa pasiva (oclusión veno-oclusiva) → erección.</li>
+<li>La <strong>fosfodiesterasa 5 (PDE-5)</strong> degrada el GMPc → relajación termina → flacidez.</li>
+<li>La <em>prostaglandina E1 (alprostadil)</em>, vía VIP, activa <em>cAMP</em> (vía alternativa, base de las inyecciones intracavernosas).</li>
+<li>El <em>simpático</em> (α1) inhibe la erección y produce eyaculación.</li>
+</ul>
+
+<h3>18.2 Etiología</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Causas</th></tr></thead>
+<tbody>
+<tr><td><strong>Vascular (la más frecuente)</strong></td><td>Aterosclerosis (FRCV: HTA, DM, dislipemia, tabaco, obesidad), insuficiencia venosa cavernosa</td></tr>
+<tr><td>Neurogénica</td><td>Lesión medular, EM, ACV, Parkinson, cirugía pélvica radical (prostatectomía, cistectomía, cirugía de recto), diabetes con neuropatía, alcoholismo</td></tr>
+<tr><td>Endocrina</td><td>Hipogonadismo (T total &lt; 300 ng/dL), hiperprolactinemia (prolactinoma), hipo/hipertiroidismo, síndrome de Cushing, hiperestrogenismo, DM</td></tr>
+<tr><td>Psicógena</td><td>Ansiedad de ejecución, depresión, problemas de pareja, trauma sexual. Característica: erección matinal/nocturna conservada</td></tr>
+<tr><td>Farmacológica</td><td>Antihipertensivos (β-bloqueantes, tiazidas, espironolactona), antidepresivos (ISRS, tricíclicos), antipsicóticos (risperidona), antiandrógenos, opioides, alcohol crónico, finasterida</td></tr>
+<tr><td>Local / mecánica</td><td>Enfermedad de Peyronie, fibrosis post-priapismo, traumatismo perineal</td></tr>
+<tr><td>Mixta</td><td>Combinación (frecuente)</td></tr>
+</tbody></table></div>
+
+<h3>18.3 Evaluación</h3>
+<ul>
+<li><strong>Anamnesis sexual</strong> + cuestionario <em>IIEF-5</em> (International Index of Erectile Function, 5-25; ≤ 21 = DE).</li>
+<li><strong>Distinguir psicógena de orgánica:</strong> presencia de erecciones nocturnas/matinales sugiere psicógena.</li>
+<li><strong>Analítica:</strong> glucemia, perfil lipídico, testosterona total (matinal), prolactina si baja, TSH.</li>
+<li><strong>Eco Doppler peneano</strong> (con prostaglandina E1 intracavernosa): valora flujo arterial cavernoso (&gt; 30 cm/s normal) y veno-oclusión.</li>
+<li>Cavernosografía, arteriografía pélvica: casos seleccionados (jóvenes con traumatismo).</li>
+</ul>
+
+<h3>18.4 Tratamiento escalonado</h3>
+
+<h4>1ª línea: estilo de vida + inhibidores PDE-5</h4>
+<ul>
+<li><strong>Cambios de estilo de vida</strong> (eficacia comparable a fármacos): pérdida de peso, ejercicio, dejar de fumar, control de DM/HTA/dislipemia.</li>
+<li><strong>Inhibidores de PDE-5 (iPDE-5)</strong>:
+  <ul>
+    <li>Sildenafilo (50-100 mg, inicio 30-60 min, duración 4 h).</li>
+    <li>Tadalafilo (10-20 mg a demanda o 5 mg diario, duración 36 h — "weekend pill").</li>
+    <li>Vardenafilo (10-20 mg).</li>
+    <li>Avanafilo (100-200 mg, rápido inicio).</li>
+  </ul>
+</li>
+<li><strong>CONTRAINDICACIONES:</strong>
+  <ul>
+    <li><span class="tag danger">NITRATOS / NITRITOS</span> (orales, sublinguales, parches, pomadas) → hipotensión severa. Esperar 24 h tras sildenafilo y 48 h tras tadalafilo.</li>
+    <li>Anginas inestables, IAM reciente, ICC NYHA III-IV.</li>
+    <li>Retinitis pigmentaria, NOIA no arterítica previa.</li>
+    <li>Cuidado con α-bloqueantes (riesgo de hipotensión ortostática).</li>
+  </ul>
+</li>
+<li><em>Tratamiento de la pareja</em>: terapia sexual, comunicación.</li>
+</ul>
+
+<h4>2ª línea: tras fracaso de iPDE-5</h4>
+<ul>
+<li><strong>Inyecciones intracavernosas</strong> de prostaglandina E1 (alprostadil 5-40 µg). Tasa de respuesta 70-90 %. Efecto adverso: priapismo (4 %), fibrosis cavernosa.</li>
+<li>Alprostadil intrauretral (MUSE).</li>
+<li><strong>Bombas de vacío</strong> (mecánica): aspiran sangre al pene → constricción con anillo. Funciona pero compromete la cualidad emocional.</li>
+<li>Terapia con ondas de choque de baja intensidad (LiESWT): regeneración endotelial. Evidencia en aumento.</li>
+</ul>
+
+<h4>3ª línea</h4>
+<ul>
+<li><strong>Prótesis peneanas</strong>: maleable (cilíndrica), inflable de 2 o 3 piezas. Para DE refractaria. Tasa de satisfacción alta.</li>
+<li>Cirugía vascular en jóvenes con causa traumática.</li>
+</ul>
+
+<h3>18.5 Trastornos de la eyaculación</h3>
+<ul>
+<li><strong>Eyaculación precoz:</strong> &lt; 1 min tras penetración. Tratamiento: ISRS (dapoxetina, paroxetina, fluoxetina), técnicas conductuales, anestésicos locales.</li>
+<li><strong>Eyaculación retardada/anhedónica:</strong> antidepresivos, daño neurológico.</li>
+<li><strong>Eyaculación retrógrada:</strong> esperma al vacío vesical. <em>Causa: post-RTU-P (65 %)</em>, α-bloqueantes (tamsulosina), DM, cirugía retroperitoneal. Diagnóstico: orina post-eyaculación con espermatozoides. Tratamiento: pseudoefedrina (cerrar cuello vesical) si fertilidad deseada.</li>
+<li><strong>Aneyaculación:</strong> ausencia. Lesión medular, fármacos. Estímulo vibratorio o electroeyaculación.</li>
+</ul>
+
+<h3>18.6 Hipogonadismo masculino</h3>
+<ul>
+<li>Testosterona total &lt; 300 ng/dL (matinal, en ayunas, repetir 2 muestras).</li>
+<li><strong>Hipogonadismo primario:</strong> testicular (Klinefelter, criptorquidia, orquitis, traumatismo, QT). FSH y LH altas.</li>
+<li><strong>Hipogonadismo secundario:</strong> hipotálamo-hipofisario (tumor, hiperprolactinemia, hemocromatosis, opioides, edad). FSH y LH bajas.</li>
+<li>Clínica: ↓ libido, DE, fatiga, depresión, sarcopenia, osteoporosis, anemia, ginecomastia.</li>
+<li>Tratamiento: testosterona (geles, IM) si síntomas + niveles bajos confirmados. Contraindicado en cáncer de próstata.</li>
+</ul>
+
+<h3>18.7 Infertilidad masculina</h3>
+<ul>
+<li>Causa de 40-50 % de las infertilidades de pareja.</li>
+<li>Definición: no concepción tras 12 m de relaciones sin protección.</li>
+<li><strong>Etiología:</strong>
+  <ul>
+    <li>Pretesticular (endocrina): hipogonadismo hipogonadotrópico.</li>
+    <li><em>Testicular</em> (la más frecuente): varicocele (causa más frecuente y corregible), Klinefelter, criptorquidia, orquitis (urliana, post-parotiditis), QT/RT, tóxicos.</li>
+    <li>Postesticular: obstrucción (vasectomía, ausencia congénita de conductos deferentes en fibrosis quística), disfunción eyaculatoria.</li>
+  </ul>
+</li>
+<li><strong>Evaluación:</strong>
+  <ul>
+    <li>Espermiograma (dos muestras): volumen, concentración, movilidad, morfología, vitalidad. <em>Criterios OMS 2021</em>: concentración ≥ 16 mill/mL, movilidad progresiva ≥ 30 %, morfología ≥ 4 %.</li>
+    <li>Hormonas: FSH, LH, testosterona total, prolactina.</li>
+    <li>Eco escrotal Doppler (varicocele).</li>
+    <li>Cariotipo + microdeleciones del cromosoma Y si oligozoospermia severa o azoospermia.</li>
+    <li>Biopsia testicular si azoospermia.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Etiológico cuando posible (varicocelectomía si varicocele clínico + espermiograma alterado).</li>
+    <li>Hormonal: clomifeno, gonadotropinas en hipogonadismo secundario.</li>
+    <li>Técnicas de reproducción asistida: IIU, FIV/ICSI (recuperación con TESE/MicroTESE en azoospermia).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>18.8 Preguntas — U18</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Disfunción eréctil — FALSA</summary>
+<div class="qa-body">
+<p>En relación con la DE en el varón, señale la FALSA:</p>
+<ol type="a">
+<li>El principal neurotransmisor de la erección es el óxido nítrico (NO)</li>
+<li>Las fosfodiesterasas inhiben la degradación del GMPc</li>
+<li><strong>La prostaglandina E es un neurotransmisor y activa el cAMP</strong></li>
+<li>El GMPc relaja el músculo liso del cuerpo cavernoso</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> Las fosfodiesterasas <em>DEGRADAN</em> el GMPc (no lo inhiben). Los <em>inhibidores de PDE-5</em> (sildenafilo) bloquean esa degradación y prolongan la erección. La prostaglandina E sí activa la vía cAMP (opción c es cierta).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Inhibidores PDE-5 — FALSA</summary>
+<div class="qa-body">
+<p>En relación con los inhibidores de la PDE-5, señale la FALSA:</p>
+<ol type="a">
+<li>Evitan la degradación del GMPc</li>
+<li><strong>Son de elección en pacientes en tratamiento con nitritos</strong></li>
+<li>Están contraindicados en la retinitis pigmentaria</li>
+<li>Constituyen la primera línea de tratamiento farmacológico en caso de DE</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> Los iPDE-5 están <em>CONTRAINDICADOS con nitritos</em> (sublinguales, parches, IV) — riesgo de hipotensión severa. Hay que separarlos al menos 24 h del sildenafilo / 48 h del tadalafilo.</div>
+</div></details>
+
+</section>
+
+<!-- =============== U19 =============== -->
+<section class="card" id="u19">
+<h2 class="section-title"><span class="num">U19</span>Patología del retroperitoneo y glándulas suprarrenales</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>El retroperitoneo</strong> contiene riñones, suprarrenales, uréteres, aorta y cava abdominal, plexos nerviosos, ganglios linfáticos, parte del duodeno, páncreas, colon ascendente y descendente.</li>
+<li><strong>Masas retroperitoneales primarias</strong> (no de órganos): suponen el 0,2 % de los tumores. 70-80 % malignas.</li>
+<li><strong>Clasificación etiológica:</strong>
+  <ul>
+    <li>Tumores mesenquimales: sarcomas (liposarcoma, leiomiosarcoma, fibrosarcoma, sarcoma indiferenciado).</li>
+    <li>Tumores neurogénicos: neuroblastoma, ganglioneuroma, paraganglioma, schwannoma, neurofibroma.</li>
+    <li>Tumores linfoides: linfomas.</li>
+    <li>Tumores germinales extragonadales.</li>
+    <li>Enfermedades inflamatorias: fibrosis retroperitoneal, enfermedad de Castleman, enfermedad relacionada con IgG4.</li>
+    <li>Lesiones quísticas: linfangioma, mucocele apendicular.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>19.1 Sarcomas retroperitoneales</h3>
+<ul>
+<li>El tumor mesenquimal retroperitoneal más frecuente.</li>
+<li><strong>Liposarcoma</strong> (el más frecuente, 50 %): bien diferenciado, mixoide, desdiferenciado, pleomórfico, células redondas.</li>
+<li><strong>Leiomiosarcoma</strong> (25 %): origen muscular liso, frecuentemente paraaórtico o paracava.</li>
+<li>Otros: fibrosarcoma, sarcoma sinovial, rabdomiosarcoma.</li>
+<li>Diagnóstico: TC/RM, biopsia percutánea preoperatoria.</li>
+<li>Tratamiento: <strong>resección quirúrgica radical en bloque</strong>, con resecciones multiviscerales. RT preoperatoria en sarcomas operables. QT en histologías sensibles (ifosfamida + doxorrubicina).</li>
+<li>Pronóstico: recurrencia local frecuente, supervivencia 5 a. 50-70 % según histología y márgenes.</li>
+</ul>
+
+<h3>19.2 Tumores neurogénicos retroperitoneales</h3>
+
+<h4>Neuroblastoma</h4>
+<ul>
+<li>Tumor sólido extracraneal <em>más frecuente en niños</em>, pico 1-4 años.</li>
+<li>Origen en cresta neural simpática (médula suprarrenal o ganglios simpáticos paraaórticos).</li>
+<li>Clínica: masa abdominal, fiebre, dolor, opsoclonus-mioclonus (paraneoplásico).</li>
+<li>Marcadores: catecolaminas urinarias (VMA, HVA), ferritina, NSE, LDH.</li>
+<li>Metástasis: hueso (cráneo), médula ósea, hígado, piel — vía hematógena y linfática.</li>
+<li>Tratamiento: cirugía + QT + autotrasplante de MO + ácido retinoico + anti-GD2 (dinutuximab) según riesgo. Pronóstico variable según etapa y biología (MYCN amplificado = mal pronóstico).</li>
+</ul>
+
+<h4>Ganglioneuroma</h4>
+<p>Tumor benigno bien diferenciado. Asintomático generalmente. Resección si grande/sintomático.</p>
+
+<h4>Paraganglioma extraadrenal</h4>
+<ul>
+<li>Origen en ganglios paraaórticos (órgano de Zuckerkandl), pared vesical, mediastino, cuello (yugulo-timpánicos).</li>
+<li>10 % funcionantes (productores de catecolaminas).</li>
+<li>Asociaciones genéticas: SDHB/SDHD (mutaciones), VHL, NF1, MEN 2.</li>
+<li>Diagnóstico: metanefrinas y catecolaminas en orina de 24 h, RM (T2 hiperintenso "luz brillante"), MIBG-gammagrafía, ⁶⁸Ga-DOTATATE PET.</li>
+<li>Tratamiento: cirugía con <em>preparación con α-bloqueantes</em> (igual que feocromocitoma).</li>
+</ul>
+
+<h4>Schwannoma y neurofibroma</h4>
+<p>Tumores benignos de células de Schwann. Asociados a <em>NF1 (neurofibromatosis tipo 1)</em>. Manchas café con leche, neurofibromas cutáneos, nódulos de Lisch. Resección si sintomáticos. Cuidado con malignización (MPNST — tumor maligno de la vaina nerviosa periférica).</p>
+
+<h3>19.3 Linfomas retroperitoneales</h3>
+<ul>
+<li>Linfomas no Hodgkin (LNH) más frecuentemente. También linfoma de Hodgkin.</li>
+<li>Clínica: masa, fiebre, sudores nocturnos, pérdida de peso (síntomas B), adenopatías periféricas.</li>
+<li>Diagnóstico: biopsia incisional o excisional (NO con aguja fina — necesita arquitectura), estudio inmunohistoquímico y citogenético.</li>
+<li>Tratamiento: QT (R-CHOP en LNH B difuso de células grandes) + RT consolidación.</li>
+</ul>
+
+<h3>19.4 Patología de la glándula suprarrenal</h3>
+
+<h4>Anatomía recordatoria</h4>
+<p>Corteza (zona glomerular: aldosterona; fascicular: cortisol; reticular: andrógenos) + médula (catecolaminas).</p>
+
+<h4>Feocromocitoma</h4>
+<ul>
+<li>Tumor neuroendocrino de la médula suprarrenal productor de catecolaminas (adrenalina, noradrenalina, dopamina).</li>
+<li><em>"Regla del 10":</em> 10 % bilateral, 10 % extraadrenal (paraganglioma), 10 % maligno, 10 % familiar, 10 % en niños, 10 % silente.</li>
+<li><strong>Síndromes hereditarios:</strong> MEN 2A y 2B (RET), VHL, NF1, SDH-mutaciones.</li>
+<li><strong>Clínica:</strong> tríada clásica → <em>cefalea + sudoración + palpitaciones</em> + HTA (sostenida o paroxística), ansiedad, palidez, taquicardia, dolor torácico/abdominal, miocardiopatía.</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li><em>Metanefrinas en plasma libre</em> o <em>metanefrinas fraccionadas en orina de 24 h</em> = prueba de elección (alta sensibilidad y especificidad).</li>
+    <li>Localización: TC/RM abdominal con contraste; MIBG-I123 o ⁶⁸Ga-DOTATATE PET-TC en sospecha de paraganglioma/multifocalidad.</li>
+    <li>Test genético en jóvenes, bilaterales, multifocales, AF +.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ol>
+    <li><strong>Preparación preoperatoria 10-14 días con α-bloqueante</strong> (fenoxibenzamina o doxazosina) hasta normalizar TA y conseguir hipotensión ortostática leve. <em>Esto es OBLIGATORIO antes de la cirugía</em> para prevenir crisis hipertensiva intraoperatoria al manipular el tumor.</li>
+    <li>Tras 4-7 días de α-bloqueo, añadir β-bloqueante si taquicardia. <em>NUNCA β-bloqueante sin α-bloqueo previo</em> (riesgo de crisis hipertensiva por vasoconstricción α sin oposición).</li>
+    <li>Expansión de volumen con dieta rica en sal.</li>
+    <li><strong>Adrenalectomía laparoscópica</strong> (preferida si &lt; 6-8 cm). Manejo anestésico cuidadoso.</li>
+    <li>Seguimiento de por vida (recidiva, contralateral, malignización).</li>
+  </ol>
+</li>
+</ul>
+
+<h4>Hiperaldosteronismo primario (síndrome de Conn)</h4>
+<ul>
+<li>HTA + hipopotasemia + alcalosis metabólica + niveles bajos de renina y altos de aldosterona.</li>
+<li>Causas: adenoma productor de aldosterona (Conn clásico), hiperplasia bilateral.</li>
+<li>Diagnóstico: ratio aldosterona/renina elevado + test de supresión (sobrecarga salina) + TC/RM + cateterismo selectivo de venas suprarrenales.</li>
+<li>Tratamiento: adrenalectomía unilateral si adenoma; espironolactona si hiperplasia.</li>
+</ul>
+
+<h4>Síndrome de Cushing</h4>
+<ul>
+<li>Hipercortisolismo. Causas: enfermedad de Cushing (adenoma hipofisario ACTH+, 70 %), adenoma o carcinoma suprarrenal, ACTH ectópico (cáncer de pulmón microcítico).</li>
+<li>Clínica: cara de luna llena, joroba de búfalo, estrías rojas, obesidad central, debilidad proximal, DM, HTA, osteoporosis, hirsutismo, depresión.</li>
+<li>Diagnóstico: cortisol libre urinario, supresión con dexametasona, ACTH plasmática, RM hipofisaria/TC suprarrenal.</li>
+<li>Tratamiento: cirugía (transesfenoidal hipofisaria o adrenalectomía).</li>
+</ul>
+
+<h4>Carcinoma suprarrenal (ACC)</h4>
+<ul>
+<li>Tumor raro, agresivo. Hormonalmente activo en 60 % (Cushing, virilización).</li>
+<li>Característica TC: tamaño &gt; 4-6 cm, contornos irregulares, necrosis central, captación heterogénea.</li>
+<li>Tratamiento: adrenalectomía abierta radical + mitotane + QT/RT en avanzados.</li>
+</ul>
+
+<h4>Incidentaloma suprarrenal</h4>
+<p>Hallazgo casual ≥ 1 cm en TC/RM. Algoritmo: estudio hormonal (cortisol post-dexametasona, metanefrinas, aldosterona/renina, sulfato de DHEA) + características radiológicas (densidad en TC, "wash-out" del contraste). Cirugía si funcionante, &gt; 4-6 cm o sospechoso de malignidad.</p>
+
+<h3>19.5 Fibrosis retroperitoneal (enfermedad de Ormond)</h3>
+<ul>
+<li>Placa fibrosa periaórtica que engloba estructuras retroperitoneales (uréteres → hidronefrosis bilateral por englobamiento medial).</li>
+<li><strong>Causas:</strong>
+  <ul>
+    <li>Idiopática (la más frecuente).</li>
+    <li>Enfermedad relacionada con <em>IgG4</em>.</li>
+    <li>Fármacos: ergotamina, metisergida, β-bloqueantes, hidralacina.</li>
+    <li>Neoplasias (linfoma, sarcoma), infecciones, RT, aneurisma aórtico.</li>
+  </ul>
+</li>
+<li>Clínica: dolor lumbar/abdominal sordo, HTA, IR por obstrucción ureteral, varicocele, claudicación.</li>
+<li>Diagnóstico: TC/RM (placa periaórtica, atrapamiento ureteral con desviación medial), IgG4 plasmática, biopsia.</li>
+<li><strong>Tratamiento:</strong> <em>corticoides ± inmunosupresores (MMF, tamoxifeno)</em>, derivación urinaria (doble J o NPC) si obstrucción, ureterólisis quirúrgica con desplazamiento intraperitoneal.</li>
+</ul>
+
+<h3>19.6 Enfermedad de Castleman</h3>
+<ul>
+<li>Trastorno linfoproliferativo (hiperplasia linfoide angiofolicular).</li>
+<li><em>Unicéntrica</em> (un solo grupo ganglionar, mediastino, retroperitoneo): variante hialino-vascular o plasmocelular. Resección curativa.</li>
+<li><em>Multicéntrica</em>: asociada a HHV-8 (especialmente en VIH+); IgG4 puede estar elevada; cursa con síntomas constitucionales, citopenias, hipoalbuminemia. Tratamiento: anti-IL-6 (siltuximab, tocilizumab), rituximab.</li>
+</ul>
+
+<h3>19.7 Preguntas — U19</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Masa retroperitoneal + pretratamiento con doxazosina</summary>
+<div class="qa-body">
+<p>Paciente de 32 a. con masa retroperitoneal junto a riñón izquierdo. Tratamiento previo a cirugía con <em>doxazosina</em> durante 10 días. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Enfermedad de Castleman</li>
+<li>Histiocitoma maligno</li>
+<li><strong>Paraganglioma</strong></li>
+<li>Schwannoma</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Pretratamiento con α-bloqueante (doxazosina) durante 10-14 días = paraganglioma / feocromocitoma productor de catecolaminas. Sin bloqueo α habría crisis hipertensiva intraoperatoria al manipular el tumor.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Tumores retroperitoneales — FALSA</summary>
+<div class="qa-body">
+<p>En relación con los tumores retroperitoneales, señale la FALSA:</p>
+<ol type="a">
+<li>El neuroblastoma suele metastatizar por vía linfática y sanguínea</li>
+<li>Los paragangliomas pueden localizarse en el órgano de Zuckerkandl</li>
+<li>El neurofibroma contiene elementos fibrosos junto a células de Schwann</li>
+<li><strong>En la enfermedad de Castleman puede estar elevada la IgG4</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta del banco: d.</strong> Atención: en realidad la enfermedad de Castleman <em>SÍ</em> puede asociarse a IgG4 elevada (especialmente la multicéntrica relacionada con HHV-8). La pregunta del banco puede ser interpretable; las demás opciones son ciertas.</div>
+</div></details>
+
+</section>
+
+<!-- ============================================================ -->
+<!-- BLOQUE B · NEFROLOGÍA -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-b">
+  <h2>🫘 BLOQUE B · NEFROLOGÍA</h2>
+  <div class="b-sub">12 temas · 25 preguntas en el examen</div>
+</div>
+
+<!-- =============== N1 =============== -->
+<section class="card" id="n1">
+<h2 class="section-title"><span class="num">N1</span>Conceptos generales de función renal · semiología · pruebas diagnósticas</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Funciones del riñón:</strong>
+  <ul>
+    <li>Filtración glomerular y depuración de productos del metabolismo (urea, creatinina, ácido úrico).</li>
+    <li>Regulación del agua y electrolitos (Na, K, Cl, Mg, Ca, P).</li>
+    <li>Regulación del equilibrio ácido-base.</li>
+    <li>Regulación de la presión arterial (SRAA).</li>
+    <li>Función endocrina: <em>eritropoyetina (EPO)</em>, <em>calcitriol (1,25-(OH)₂-D3)</em>, renina, prostaglandinas, kalicreína.</li>
+    <li>Metabolismo: gluconeogénesis (ayuno prolongado), degradación de hormonas (insulina, glucagón, PTH).</li>
+  </ul>
+</li>
+<li><strong>Aclaramiento de creatinina (CrCl) y FG estimado (FGe):</strong>
+  <ul>
+    <li>FGe estimado mediante <em>CKD-EPI 2021</em> (sin raza, recomendada actualmente) o MDRD a partir de creatinina sérica + edad + sexo.</li>
+    <li><em>Cistatina C</em>: marcador alternativo útil en sarcopenia, ancianos, obesidad. Combinada con creatinina mejora la precisión (CKD-EPI Cr-CysC).</li>
+    <li>FG normal: 90-120 mL/min/1,73 m².</li>
+    <li>La creatinina sérica solo aumenta cuando se ha perdido &gt; 50 % de la función renal (poco sensible para deterioro precoz).</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>1.1 Anatomía y fisiología renal básica</h3>
+<ul>
+<li>Cada riñón contiene ≈ 1 millón de <em>nefronas</em>: glomérulo + túbulo (proximal + asa de Henle + distal + colector).</li>
+<li>El <em>glomérulo</em> filtra 180 L/d de filtrado a partir del plasma. El túbulo reabsorbe el 99 % del agua y solutos.</li>
+<li>El <em>aparato yuxtaglomerular</em> (mácula densa + células granulares + arteriolas aferente/eferente) regula el feedback tubuloglomerular y la liberación de renina.</li>
+<li>La <em>autorregulación renal</em> mantiene un FG constante entre TAM 80-180 mmHg mediante la regulación de la arteriola aferente (mecanismo miogénico + feedback de la mácula densa).</li>
+</ul>
+
+<h3>1.2 Semiología nefrológica</h3>
+
+<h4>Síntomas y signos</h4>
+<ul>
+<li><strong>Edemas:</strong>
+  <ul>
+    <li>Origen renal: blandos, con fóvea, simétricos, predominio facial-palpebral (en cara con síndrome nefrótico, en MMII en IC y cirrosis).</li>
+    <li>Mañanas (postdecúbito) → cara; tardes (bipedestación) → MMII.</li>
+  </ul>
+</li>
+<li><strong>Cambios en la orina:</strong> oliguria (&lt; 400 mL/d), anuria (&lt; 100 mL/d), poliuria (&gt; 3 L/d), polaquiuria, nicturia, urgencia, espumosa (proteinuria), coloración (hematuria, mioglobinuria, hemoglobinuria, bilirrubinuria).</li>
+<li><strong>Hipertensión arterial:</strong> de novo en joven → sospechar nefropatía. HTA + proteinuria/hematuria/IR es de origen renal hasta demostrar lo contrario.</li>
+<li><strong>Síntomas urémicos:</strong> astenia, anorexia, náuseas, prurito, neuropatía, encefalopatía, pericarditis, alteraciones del sueño.</li>
+<li><strong>Dolor:</strong>
+  <ul>
+    <li>Cólico nefrítico (litiasis): irradiación a fosa iliaca-genitales.</li>
+    <li>Lumbar sordo: PNA, hidronefrosis, infarto renal.</li>
+    <li>Hipogástrico: vesical.</li>
+  </ul>
+</li>
+</ul>
+
+<h4>Exploración</h4>
+<ul>
+<li>TA + FC + edemas (presacro, MMII).</li>
+<li>Puñopercusión renal (Murphy renal): dolor en PNA, pielonefritis.</li>
+<li>Auscultación de soplo abdominal (HTA renovascular).</li>
+<li>Globo vesical palpable.</li>
+<li>Tacto rectal (próstata).</li>
+</ul>
+
+<h3>1.3 Pruebas analíticas</h3>
+
+<h4>Sangre</h4>
+<ul>
+<li><strong>Función renal:</strong> creatinina, urea, FGe (CKD-EPI), cistatina C.</li>
+<li><strong>Iones:</strong> Na, K, Cl, Ca, P, Mg.</li>
+<li><strong>Equilibrio ácido-base:</strong> pH, HCO₃, anion gap.</li>
+<li><strong>Otros:</strong> ácido úrico, glucosa, PTH, vitamina D, lípidos, albúmina, hemograma.</li>
+<li><strong>Inmunología</strong> (sospecha de GN/vasculitis): ANA, anti-DNAn, complemento (C3, C4), ANCA, anti-MBG, crioglobulinas, anti-PLA2R, electroforesis sérica, cadenas ligeras libres, IgG/IgM/IgA, FR, serologías VHB/VHC/VIH/sífilis.</li>
+</ul>
+
+<h4>Orina</h4>
+<ul>
+<li><strong>Tira reactiva:</strong> pH, densidad, proteínas, glucosa, sangre, leucocitos, nitritos, cuerpos cetónicos, bilirrubina.</li>
+<li><strong>Sedimento urinario</strong> (microscopía):
+  <ul>
+    <li><em>Hematíes dismórficos / cilindros hemáticos</em> → origen glomerular.</li>
+    <li><em>Leucocituria + cilindros leucocitarios</em> → pielonefritis, NIA, glomerulonefritis.</li>
+    <li><em>Cilindros granulosos pigmentados (céreos)</em> → necrosis tubular aguda.</li>
+    <li><em>Cilindros céreos anchos</em> → ERC avanzada.</li>
+    <li><em>Cristales</em> (oxalato cálcico, ácido úrico, fosfato amónico-magnésico, cistina) → litiasis.</li>
+    <li><em>Eosinofiluria</em> → nefritis intersticial aguda / ateroembolia.</li>
+  </ul>
+</li>
+<li><strong>Cuantificación de proteinuria:</strong>
+  <ul>
+    <li><em>Orina de 24 h</em> (gold standard pero engorroso).</li>
+    <li><em>Cociente proteína/creatinina (Pr/Cr)</em> o <em>albúmina/creatinina (UACR)</em> en muestra aislada (válido y reproducible).</li>
+    <li>Normal: &lt; 150 mg/d o UACR &lt; 30 mg/g.</li>
+    <li>Microalbuminuria (A2): UACR 30-300 mg/g (importante en DM y HTA).</li>
+    <li>Macroalbuminuria (A3): UACR &gt; 300 mg/g.</li>
+    <li>Rango nefrótico: &gt; 3,5 g/d (UACR &gt; 2.000 mg/g).</li>
+  </ul>
+</li>
+<li><strong>Iones en orina:</strong> Na urinario, K urinario, urea, osmolaridad, FENa, FEUrea.</li>
+<li><strong>Urocultivo + antibiograma:</strong> bacteriuria significativa ≥ 10⁵ UFC/mL.</li>
+</ul>
+
+<h3>1.4 Pruebas de imagen</h3>
+<ul>
+<li><strong>Ecografía renal:</strong> primera prueba. Tamaño, ecogenicidad, simetría, dilatación pielocalicial, quistes, masas, vejiga, residuo postmiccional. Doppler para flujos.</li>
+<li><strong>TAC sin contraste de baja dosis</strong>: cólico renal (litiasis).</li>
+<li><strong>UroTC con contraste</strong>: anatomía, tumores, traumatismos.</li>
+<li><strong>RMN:</strong> alergias a contraste yodado, lesiones complejas, MR-angiografía renal.</li>
+<li><strong>Renograma con MAG-3 ± furosemida:</strong> función renal diferencial, patrón obstructivo.</li>
+<li><strong>Gammagrafía con DMSA:</strong> cicatrices renales, función parenquimatosa.</li>
+<li><strong>Arteriografía renal:</strong> sospecha de HTA renovascular o sangrado.</li>
+<li><strong>CUMS:</strong> RVU, anomalías vesicouretrales.</li>
+</ul>
+
+<h3>1.5 Biopsia renal</h3>
+<ul>
+<li><strong>Indicaciones:</strong>
+  <ul>
+    <li>Síndrome nefrótico del adulto sin causa clara.</li>
+    <li>GN aguda con deterioro de la función renal.</li>
+    <li>IRA de causa no aclarada (sospecha de NIA, GN, vasculitis).</li>
+    <li>ERC progresiva sin causa filiada.</li>
+    <li>Hematuria glomerular persistente con proteinuria.</li>
+    <li>Estudio en pacientes con LES, vasculitis o paraproteinemia.</li>
+    <li>Biopsia del injerto renal (rechazo, recurrencia).</li>
+  </ul>
+</li>
+<li><strong>Contraindicaciones:</strong> riñón único anatómico (relativa), coagulopatía no corregida, HTA no controlada, ITU activa, hidronefrosis bilateral, neoplasia renal sospechosa.</li>
+<li><strong>Técnica:</strong> biopsia percutánea ecoguiada con aguja tru-cut. Material para microscopía óptica, inmunofluorescencia y microscopía electrónica.</li>
+<li><strong>Complicaciones:</strong> hematuria (más frecuente), hematoma perirrenal, fístula AV, lesión de órganos vecinos.</li>
+</ul>
+
+<h3>1.6 Síndromes clínicos nefrológicos (anticipación a N4)</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Síndrome nefrótico</span><span class="v">Proteinuria &gt; 3,5 g/d + hipoalbuminemia + edemas + hiperlipidemia. ± hipercoagulabilidad</span></div>
+<div class="kv"><span class="k">Síndrome nefrítico</span><span class="v">Hematuria glomerular + HTA + edemas + IR + proteinuria moderada</span></div>
+<div class="kv"><span class="k">Hematuria</span><span class="v">Macro o microscópica. Glomerular (dismórfica + cilindros) vs no glomerular</span></div>
+<div class="kv"><span class="k">Proteinuria</span><span class="v">Glomerular (albuminuria), tubular (β2-microglobulina), por sobrecarga (paraproteínas)</span></div>
+<div class="kv"><span class="k">IRA</span><span class="v">↑ Cr aguda. Prerrenal vs renal vs posrenal</span></div>
+<div class="kv"><span class="k">ERC</span><span class="v">Alteración estructural/funcional &gt; 3 m con FGe &lt; 60 o albuminuria/sedimento alterado</span></div>
+</div>
+</section>
+
+<!-- =============== N2 =============== -->
+<section class="card" id="n2">
+<h2 class="section-title"><span class="num">N2</span>Trastornos hidroelectrolíticos · uso de diuréticos</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>HIPONATREMIA (&lt; 135 mEq/L):</strong> evaluar siempre <em>osmolaridad plasmática</em> y <em>volemia</em>.
+  <ul>
+    <li><em>Hiponatremia hipoosmolar</em>:
+      <ul>
+        <li>Hipovolémica: pérdidas (digestivas, renales, sudor) → reposición salina.</li>
+        <li>Euvolémica: <strong>SIADH</strong> (orina concentrada con Na &gt; 30 mEq/L y osmU &gt; osmP). Hipotiroidismo, déficit corticoide. Tratamiento: restricción hídrica, tolvaptán si severa.</li>
+        <li>Hipervolémica: insuficiencia cardíaca, cirrosis, sd. nefrótico, IR. Tratamiento: restricción de agua y sodio + diuréticos.</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>HIPERPOTASEMIA:</strong> ECG con <em>ondas T altas y picudas</em>, PR alargado, QRS ancho, FV/asistolia. Causas: IR, IECA/ARA2/espironolactona/AINE, lisis tumoral, rabdomiolisis. <strong>Tratamiento</strong>:
+  <ul>
+    <li>Gluconato cálcico iv (protege miocardio).</li>
+    <li><em>Insulina + glucosa</em> (introduce K en célula).</li>
+    <li>β2-agonistas (salbutamol nebulizado).</li>
+    <li>Bicarbonato si acidosis.</li>
+    <li>Resinas de intercambio (poliestireno) + furosemida iv.</li>
+    <li>Diálisis si refractaria o IR avanzada.</li>
+  </ul>
+</li>
+<li><strong>Diuréticos:</strong>
+  <ul>
+    <li>Tiazidas (TCD): hipoNa, hipoK, hipoMg, <em>hiperCa</em>, hiperuricemia, hiperglucemia.</li>
+    <li>Asa (TAL): furosemida, torasemida. HipoNa, hipoK, hipoMg, hipoCa.</li>
+    <li>Ahorradores de potasio: espironolactona, eplerenona (anti-aldosterona), amilorida (canal ENaC). <em>HIPERkalemia</em>.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>2.1 Preguntas — N2</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Mujer en IECA + espironolactona con debilidad MMII</summary>
+<div class="qa-body">
+<p>Mujer de 68 años con IC e HTA tratada con enalapril. Hace 15 días le añaden espironolactona. Acude por debilidad de MMII. EF normal, TA 150/85. Una afirmación es INCORRECTA:</p>
+<ol type="a">
+<li>Es muy probable que las ondas T del ECG sean altas y picudas</li>
+<li>La infusión de glucosa e insulina probablemente sea útil</li>
+<li>Sin tratamiento, es probable que desarrolle una arritmia fatal</li>
+<li><strong>Muy probablemente la excreción de potasio en orina esté muy elevada</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d (INCORRECTA).</strong> Combinación IECA + espironolactona = hiperpotasemia muy frecuente. La excreción urinaria de K estará <em>DISMINUIDA</em> (espironolactona inhibe la secreción tubular distal). ECG: ondas T picudas. Tratamiento: insulina + glucosa, gluconato cálcico, β2-agonistas, resinas.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Varón con neoplasia pulmonar + bradipsiquia + hiponatremia</summary>
+<div class="qa-body">
+<p>Varón de 45 a., fumador, en estudio por imagen pulmonar sospechosa. Consulta por bradipsiquia. TA normal, no edemas. Osmolaridad plasmática 255, glucemia normal, urea 20. Orina: Na 35, osmolaridad 250. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li>Hiponatremia hipoosmolar hipervolémica</li>
+<li>Hipernatremia por diabetes insípida central</li>
+<li><strong>Hiponatremia por SIADH</strong></li>
+<li>Polidipsia psicógena</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Hiponatremia hipoosmolar + EUVOLEMIA (sin edemas, TA normal) + orina inadecuadamente concentrada (osmU &gt; 100) + Na urinario &gt; 30 = SIADH. Causa: cáncer pulmonar (microcítico clásico, paraneoplásico). Tratamiento: restricción hídrica.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Cirrótico con ascitis e hiponatremia — FALSA</summary>
+<div class="qa-body">
+<p>Hombre de 60 años con insuficiencia hepática grave, ascitis y edemas. TA 90/50. Na sérico 126, osmolalidad 250, glucemia normal. Orina: Na 10, osmolalidad 300. ¿Cuál es FALSA?</p>
+<ol type="a">
+<li>Presenta hiponatremia hipoosmolar por hipervolemia</li>
+<li>La hipoosmolalidad es por retención de agua libre</li>
+<li><strong>La causa de la hiponatremia es pérdida gastrointestinal de sodio</strong></li>
+<li>El tratamiento consiste en forzar eliminación de agua libre</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (FALSA).</strong> En la cirrosis con ascitis hay <em>aumento del volumen extracelular total</em> pero ↓ volumen circulante efectivo → activación SRAA → retención de Na y agua, con <em>retención de agua libre &gt; retención de Na</em> → dilución. Na urinario bajo (&lt; 20) refleja la retención renal. NO hay pérdida GI. Tratamiento: restricción de líquidos + diuréticos + ¿tolvaptán?</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Hiperpotasemia ERC4 — NO indicado</summary>
+<div class="qa-body">
+<p>¿Cuál medida NO está indicada en hiperpotasemia grave en ERC estadio 4?</p>
+<ol type="a">
+<li>Bicarbonato sódico iv en presencia de acidosis</li>
+<li><strong>Diurético tiazídico vía oral</strong></li>
+<li>Furosemida iv</li>
+<li>Glucosa con insulina iv</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Las tiazidas son ineficaces con FG &lt; 30 mL/min y NO se usan para hiperpotasemia. Furosemida iv sí (diurético de asa, kaliurético).</div>
+</div></details>
+
+</section>
+
+<!-- =============== N3 =============== -->
+<section class="card" id="n3">
+<h2 class="section-title"><span class="num">N3</span>Equilibrio ácido-base · metabolismo calcio-fósforo</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Acidosis metabólica:</strong> ↓ HCO₃⁻ + ↓ pH.
+  <ul>
+    <li><strong>Anion gap (AG) elevado</strong> (= Na − Cl − HCO₃; normal 8-12): cetoacidosis, acidosis láctica, intoxicaciones (metanol, etilenglicol, salicilatos), IRC avanzada. <em>"MUDPILES"</em>.</li>
+    <li><strong>AG normal / hiperclorémica</strong>: pérdida de HCO₃⁻ (<em>diarrea</em>, ureterosigmoidostomía) o ATR. Acidosis tubular renal:
+      <ul>
+        <li>Tipo I (distal): incapacidad para acidificar la orina → pH urinario &gt; 5,5, <em>hipopotasemia</em>, nefrocalcinosis.</li>
+        <li>Tipo II (proximal): ↓ reabsorción de HCO₃⁻, hipopotasemia. Síndrome de Fanconi.</li>
+        <li>Tipo IV (hipoaldosteronismo hiporreninémico): <em>HIPERPOTASEMIA</em> + AG normal. DM, AINE, IECA.</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>Alcalosis metabólica:</strong> ↑ HCO₃⁻. Causas: vómitos, diuréticos, hiperaldosteronismo. Compensación respiratoria con ↑ PaCO₂.</li>
+<li><strong>Compensación:</strong> regla rápida — por cada 1 mEq/L ↓ HCO₃⁻, ↓ PaCO₂ 1,2 mmHg.</li>
+</ul>
+</div>
+
+<h3>3.1 Preguntas — N3</h3>
+
+<details class="qa"><summary>1. (Ord 2025) ATR tipo IV — características</summary>
+<div class="qa-body">
+<p>¿Qué tipo de acidosis metabólica se observa en la ATR tipo IV?</p>
+<ol type="a">
+<li>Acidosis metabólica con AG elevado</li>
+<li><strong>Acidosis metabólica con AG normal e hiperpotasemia</strong></li>
+<li>Acidosis metabólica con AG normal, hipopotasemia y orina alcalina</li>
+<li>Acidosis metabólica con hiponatremia</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ATR tipo IV (hipoaldosteronismo hiporreninémico) = AG normal + HIPERkalemia. Causas: nefropatía diabética, IECA/ARA2/espironolactona, AINE. Las ATR I y II cursan con hipopotasemia.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Gasometría con HCO₃ bajo + Cl normal — causa</summary>
+<div class="qa-body">
+<p>Paciente con pH 7,23, HCO₃ 17, pCO₂ 32, Na 140, Cl 100. ¿Cuál sería compatible con estos valores?</p>
+<ol type="a">
+<li>Acidosis tubular renal proximal</li>
+<li>Síndrome diarreico</li>
+<li><strong>Intoxicación por salicilatos</strong></li>
+<li>Ureterosigmoidostomía</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Calculamos AG = 140 − 100 − 17 = 23 (elevado). Acidosis con AG elevado → cetoacidosis, lactica, intoxicaciones. Las ATR y diarrea darían AG normal. Salicilatos = AG elevado + alcalosis respiratoria asociada (trastorno mixto, pCO₂ baja como aquí).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Acidosis hiperclorémica — EXCEPTO</summary>
+<div class="qa-body">
+<p>La acidosis hiperclorémica se ve en todo lo siguiente, MENOS:</p>
+<ol type="a">
+<li>ATR tipo I</li>
+<li>Diarrea</li>
+<li>ATR tipo IV</li>
+<li><strong>Acidosis láctica</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> La acidosis láctica cursa con AG <em>ELEVADO</em> (no hiperclorémica). ATR I, II, IV y diarrea son típicas con AG normal e hipercloremia.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N4 =============== -->
+<section class="card" id="n4">
+<h2 class="section-title"><span class="num">N4</span>Síndromes clínicos en nefrología: hematuria, proteinuria, nefrótico, nefrítico</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Cinco grandes síndromes clínicos en nefrología: <strong>nefrótico</strong>, <strong>nefrítico</strong>, <strong>hematuria aislada</strong>, <strong>proteinuria aislada</strong>, <strong>IRA / ERC</strong>.</li>
+<li>Los dos primeros se diferencian por la presencia o no de los "5 grandes" (HTA, IR, hematuria, edemas, proteinuria) en distinta intensidad.</li>
+</ul>
+</div>
+
+<h3>4.1 Síndrome nefrótico</h3>
+<ul>
+<li><strong>Criterios diagnósticos:</strong>
+  <ul>
+    <li><strong>Proteinuria &gt; 3,5 g/24 h</strong> en adultos (&gt; 40 mg/m²/h en niños).</li>
+    <li><strong>Hipoalbuminemia</strong> (&lt; 3 g/dL).</li>
+    <li><strong>Edemas</strong> (blando, fóvea, simétricos, facial-palpebral y MMII).</li>
+    <li><strong>Hiperlipidemia</strong> (↑ colesterol total, LDL, lipoproteínas — ↑ síntesis hepática compensatoria + ↓ catabolismo).</li>
+  </ul>
+</li>
+<li><strong>Fisiopatología:</strong> daño podocitario / membrana basal → pérdida masiva de albúmina y otras proteínas → activación de SRAA + retención de Na y agua → edemas.</li>
+<li><strong>Causas en adultos:</strong>
+  <ul>
+    <li><em>Primarias (GN idiopáticas):</em> cambios mínimos, GFS, membranosa, membranoproliferativa.</li>
+    <li><em>Secundarias:</em>
+      <ul>
+        <li><strong>Nefropatía diabética</strong> (la causa más frecuente en países desarrollados).</li>
+        <li>LES (sobre todo clase V membranosa).</li>
+        <li>Amiloidosis (AL — mieloma; AA — inflamación crónica).</li>
+        <li>Mieloma múltiple / paraproteinemias.</li>
+        <li>VIH (HIVAN — GFS colapsante).</li>
+        <li>VHB, VHC, sífilis (membranosa).</li>
+        <li>Fármacos: AINE, oro, penicilamina, captopril.</li>
+        <li>Neoplasias (membranosa paraneoplásica).</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>Causas en niños:</strong> 80 % <em>cambios mínimos</em> (corticosensible).</li>
+<li><strong>Complicaciones</strong> (importantísimas):
+  <ul>
+    <li><strong>Tromboembolismo</strong> (5-50 %): por pérdida urinaria de antitrombina III, hipercoagulabilidad. <em>Trombosis de la vena renal</em> es clásica de la GN membranosa. TVP y TEP frecuentes. <em>Hipoalbuminemia severa &lt; 2 g/dL = factor de riesgo principal</em>. Anticoagulación profiláctica si albúmina &lt; 2-2,5 + factores de riesgo.</li>
+    <li><strong>Infecciones:</strong> pérdida de IgG y complemento → infecciones por encapsulados (S. pneumoniae, peritonitis primaria en niños). Vacunación.</li>
+    <li><strong>IRA</strong>: prerrenal por hipovolemia efectiva, NTA por sobrediuresis, trombosis renal.</li>
+    <li><strong>Hiperlipidemia → aterosclerosis</strong> acelerada.</li>
+    <li><strong>Hipocalcemia</strong> (pérdida de vit D unida a globulina) → osteomalacia.</li>
+    <li><strong>Hipotiroidismo subclínico</strong> (pérdida de tiroglobulina).</li>
+    <li>Desnutrición proteica, anemia por pérdida de transferrina.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento sintomático general:</strong>
+  <ul>
+    <li>Restricción de sodio + diuréticos de asa.</li>
+    <li>IECA/ARA-II (reducción de proteinuria por ↓ presión intraglomerular).</li>
+    <li>Estatinas para dislipidemia.</li>
+    <li>Profilaxis tromboembólica con HBPM si albúmina &lt; 2-2,5.</li>
+    <li>Vacunación (neumococo, gripe).</li>
+    <li>Tratamiento etiológico según causa (corticoides en GN primarias, inmunosupresores).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>4.2 Síndrome nefrítico</h3>
+<ul>
+<li><strong>Tríada clásica:</strong>
+  <ul>
+    <li><strong>Hematuria GLOMERULAR</strong> (dismórfica + cilindros hemáticos + acantocitos).</li>
+    <li><strong>HTA</strong>.</li>
+    <li><strong>Edemas</strong> (no tan masivos como en nefrótico).</li>
+  </ul>
+</li>
+<li>Puede haber: oliguria, ↑ creatinina (IR), proteinuria leve-moderada (&lt; 3,5 g/d).</li>
+<li><strong>Fisiopatología:</strong> inflamación glomerular → ↓ FG (oliguria, ↑ Cr) + ruptura capilar (hematuria) + retención de Na/agua (HTA, edemas).</li>
+<li><strong>Causas:</strong>
+  <ul>
+    <li><em>GN aguda post-infecciosa (post-estreptocócica)</em>: niños 5-15 a., 1-3 sem tras faringitis o impétigo por <em>S. pyogenes</em> nefritogénico. ↓ C3 transitorio. Pronóstico bueno (sobre todo en niños).</li>
+    <li><em>GN IgA (Berger)</em>: adultos jóvenes, hematuria sin/poco proteinuria, "sinfaringítica" (concomitante a infección respiratoria, no tras como la post-streptocócica). IgA elevada. Adultos.</li>
+    <li><em>Vasculitis ANCA</em> (GPA, PAM, GEPA) — semilunas en biopsia.</li>
+    <li><em>Anti-MBG (Goodpasture)</em>: + hemorragia alveolar.</li>
+    <li><em>LES clase III/IV</em>: proliferativa focal/difusa con asas de alambre.</li>
+    <li><em>Crioglobulinemia mixta</em> (VHC): GNMP.</li>
+    <li><em>Endocarditis bacteriana / shunt</em>.</li>
+    <li><em>Schönlein-Henoch / IgA</em>: niños con púrpura + nefritis.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>4.3 GN rápidamente progresiva (GNRP) / extracapilar / crescéntica</h3>
+<ul>
+<li>Variante grave: pérdida de la función renal en días-semanas (hasta meses) con <em>semilunas glomerulares</em> en biopsia.</li>
+<li><strong>Clasificación según inmunofluorescencia:</strong>
+  <ul>
+    <li><em>Tipo I (5 %)</em>: <strong>anti-MBG (Goodpasture)</strong>. IF lineal continua para IgG. ± hemorragia alveolar.</li>
+    <li><em>Tipo II (45 %)</em>: <strong>por inmunocomplejos</strong>. IF granular. LES, IgA, post-infecciosa, crioglobulinemia.</li>
+    <li><em>Tipo III (50 %)</em>: <strong>pauciinmune (ANCA-asociada)</strong>. IF negativa o débil. Vasculitis ANCA (GPA, PAM, GEPA).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento (urgencia):</strong> corticoides en pulsos iv (metilprednisolona 500 mg-1 g × 3 días) + ciclofosfamida o rituximab ± plasmaféresis (Goodpasture grave, ANCA con creatinina muy elevada).</li>
+</ul>
+
+<h3>4.4 Hematuria — algoritmo diagnóstico</h3>
+<ul>
+<li><strong>Macroscópica</strong> = visible. <strong>Microscópica</strong> = solo en sedimento.</li>
+<li>Es siempre patológica salvo: menstruación, ejercicio físico extremo (atletas), tras cateterismo.</li>
+<li><strong>Distinguir glomerular vs no glomerular:</strong></li>
+</ul>
+<div class="table-wrap"><table>
+<thead><tr><th>Característica</th><th>Glomerular</th><th>No glomerular (urológica)</th></tr></thead>
+<tbody>
+<tr><td>Color</td><td>"Coca-cola", marrón</td><td>Rojo brillante</td></tr>
+<tr><td>Coágulos</td><td>Raros</td><td>Frecuentes</td></tr>
+<tr><td>Cilindros hemáticos</td><td><strong>Sí (patognomónico)</strong></td><td>No</td></tr>
+<tr><td>Hematíes dismórficos / acantocitos</td><td><strong>Sí (&gt; 80 %)</strong></td><td>No</td></tr>
+<tr><td>Proteinuria asociada</td><td>Sí (&gt; 500 mg/d)</td><td>Mínima (acompaña al sangrado)</td></tr>
+<tr><td>HTA, edemas, ↑ Cr</td><td>Posibles</td><td>No</td></tr>
+<tr><td>Coexistencia con dolor</td><td>No (excepto IgA con dolor lumbar)</td><td>Sí (cólico, ITU)</td></tr>
+</tbody></table></div>
+
+<p><strong>Causas no glomerulares:</strong> litiasis, tumor (renal, vesical, prostático), ITU, hiperplasia/cáncer próstata, traumatismo, anomalías anatómicas, fármacos (ciclofosfamida, anticoagulantes), schistosomiasis, TBC.</p>
+
+<h3>4.5 Proteinuria — tipos</h3>
+<ul>
+<li><strong>Glomerular (la más relevante):</strong> alteración de la barrera glomerular → pérdida de albúmina y proteínas de alto peso molecular. UACR ↑.</li>
+<li><strong>Tubular:</strong> alteración de la reabsorción de proteínas filtradas (β2-microglobulina, α1-microglobulina, retinol-binding protein). Causas: NTA, NIA, ATR, síndrome de Fanconi, tóxicos.</li>
+<li><strong>Por sobrecarga:</strong> producción excesiva de proteínas que rebasan la capacidad tubular. Cadenas ligeras (mieloma — proteína de Bence Jones), hemoglobinuria, mioglobinuria.</li>
+<li><strong>Ortostática</strong> (en adolescentes): solo en bipedestación; benigna.</li>
+<li><strong>Transitoria</strong>: fiebre, ejercicio, deshidratación. Benigna.</li>
+</ul>
+
+<h3>4.6 Preguntas — N4</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Complicaciones del síndrome nefrótico</summary>
+<div class="qa-body">
+<p>Un paciente adulto con síndrome nefrótico presenta alto riesgo de complicaciones tromboembólicas. ¿Qué factor aumenta significativamente este riesgo?</p>
+<ol type="a">
+<li>Hiperlipidemia</li>
+<li>Hematuria microscópica</li>
+<li><strong>Hipoalbuminemia severa</strong></li>
+<li>Hipertensión arterial</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Hipoalbuminemia &lt; 2 g/dL = pérdida urinaria de antitrombina III + estado hipercoagulable. Riesgo de TVP, TEP, <em>trombosis de la vena renal</em> (clásica en GN membranosa). Profilaxis con HBPM en albúmina &lt; 2-2,5.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Complicación NO frecuente del síndrome nefrótico</summary>
+<div class="qa-body">
+<p>¿Cuál NO es complicación frecuente del síndrome nefrótico?</p>
+<ol type="a">
+<li>Trombosis venosa profunda</li>
+<li>Hiperlipidemia</li>
+<li><strong>Hiperglucemia</strong></li>
+<li>Infecciones</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> La hiperglucemia NO es complicación. Complicaciones típicas: trombosis, hiperlipidemia (↑ síntesis hepática de lipoproteínas), infecciones por pérdida de Ig, déficit de vit D, hipotiroidismo subclínico.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N5 =============== -->
+<section class="card" id="n5">
+<h2 class="section-title"><span class="num">N5</span>Glomerulonefritis primarias</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Clasificación según síndrome clínico predominante:</strong>
+  <ul>
+    <li>Síndrome <em>nefrótico</em>: cambios mínimos, GFS, membranosa.</li>
+    <li>Síndrome <em>nefrítico</em>: IgA, post-infecciosa, MPGN.</li>
+    <li>GN <em>rápidamente progresiva</em>: anti-MBG, ANCA, inmunocomplejos.</li>
+  </ul>
+</li>
+<li><strong>Clasificación según patrón histológico:</strong> proliferativa (mesangial, endocapilar, extracapilar), no proliferativa (membranosa, cambios mínimos, GFS).</li>
+<li><strong>Estudio de la biopsia renal:</strong> microscopía óptica (MO), inmunofluorescencia (IF) y microscopía electrónica (ME).</li>
+</ul>
+</div>
+
+<h3>5.1 Nefropatía por cambios mínimos (NCM)</h3>
+<ul>
+<li><strong>Causa más frecuente de SN en niños</strong> (80-90 %). En adultos representa ~10 % del SN.</li>
+<li><strong>Patogenia:</strong> daño podocitario reversible. Mediadores circulantes (¿linfocitos T? ¿anti-nefrina?). Asociaciones: AINE (causa frecuente en adultos), atopia, linfoma de Hodgkin.</li>
+<li><strong>Clínica:</strong> síndrome nefrótico <em>puro</em> (sin hematuria glomerular significativa, sin HTA, función renal preservada).</li>
+<li><strong>Biopsia:</strong>
+  <ul>
+    <li>MO: glomérulos NORMALES.</li>
+    <li>IF: negativa.</li>
+    <li>ME: <em>borramiento difuso de pedicelos podocitarios</em> (única alteración).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Corticoides</em> (prednisona 1 mg/kg/d en adultos, 60 mg/m²/d en niños) — respuesta espectacular en &gt; 90 % de niños y 70-80 % de adultos.</li>
+    <li>Recidivas frecuentes (50 %): ciclofosfamida, ciclosporina, rituximab.</li>
+  </ul>
+</li>
+<li><strong>Pronóstico:</strong> excelente. NO progresa a ERC (en la NCM "auténtica").</li>
+</ul>
+
+<h3>5.2 Glomeruloesclerosis focal y segmentaria (GFS / FSGS)</h3>
+<ul>
+<li><strong>Causa frecuente de SN en adultos</strong> (sobre todo afroamericanos, hispanos).</li>
+<li><strong>Patogenia:</strong> daño podocitario. <em>Primaria</em>: mediadores circulantes. <em>Secundaria</em>:
+  <ul>
+    <li><em>Adaptativa</em>: hiperfiltración (obesidad, RVU, masa renal reducida).</li>
+    <li><em>HIVAN</em>: GFS colapsante por daño directo del VIH a podocitos.</li>
+    <li>Fármacos: heroína, pamidronato, bisfosfonatos, interferón.</li>
+    <li>Genética: mutaciones podocitarias (NPHS1 nefrina, NPHS2 podocina, ACTN4).</li>
+    <li>Anemia falciforme, parvovirus B19, COVID.</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> SN (rango variable), HTA, hematuria microscópica, IR progresiva.</li>
+<li><strong>Biopsia:</strong>
+  <ul>
+    <li>MO: esclerosis segmentaria en algunos glomérulos (focal). Variantes: colapsante (peor), perihiliar, celular, tip lesion, NOS.</li>
+    <li>IF: IgM y C3 segmentarios.</li>
+    <li>ME: borramiento difuso de pedicelos (primaria) o segmentario (secundaria).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Primaria: <em>corticoides</em> 4-6 m + IECA/ARA-II. Si refractaria: ciclosporina, tacrolimús, MMF, rituximab.</li>
+    <li>Secundaria: <em>tratar la causa</em> + IECA/ARA-II. No corticoides.</li>
+  </ul>
+</li>
+<li>Pronóstico: 30-50 % progresan a ERC. Recurre en el trasplante (30 %).</li>
+</ul>
+
+<h3>5.3 Glomerulonefritis membranosa</h3>
+<ul>
+<li><strong>Causa más frecuente de SN primario en adultos &gt; 40 a.</strong> (sobre todo caucásicos).</li>
+<li><strong>Patogenia:</strong>
+  <ul>
+    <li><em>Primaria (80 %)</em>: autoanticuerpos contra antígenos podocitarios — <em>anti-PLA2R</em> (70-80 %) y anti-THSD7A (5 %). Depósitos inmunes subepiteliales.</li>
+    <li><em>Secundaria (20 %)</em>:
+      <ul>
+        <li>Neoplasias (sobre todo &gt; 65 a.): cáncer de pulmón, colon, próstata, mama.</li>
+        <li>Infecciones: VHB, VHC, sífilis.</li>
+        <li>LES (clase V).</li>
+        <li>Fármacos: AINE, sales de oro, penicilamina, captopril.</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> SN insidioso + hematuria microscópica + HTA leve. <em>Alto riesgo de tromboembolismo</em> (TVP, TEP, trombosis de la vena renal — clásica).</li>
+<li><strong>Biopsia:</strong>
+  <ul>
+    <li>MO: engrosamiento difuso de la MBG. <em>"Spikes" (púas)</em> visibles con tinción de plata (PAS).</li>
+    <li>IF: depósitos GRANULARES de IgG (sobre todo IgG4) y C3 a lo largo de la MBG.</li>
+    <li>ME: <em>depósitos subepiteliales electrodensos</em>.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento (regla del 1/3):</strong> 1/3 remite espontáneamente, 1/3 estable, 1/3 progresa.
+  <ul>
+    <li>SN persistente o ↑ Cr: tratamiento inmunosupresor.</li>
+    <li><em>Rituximab</em> (preferido actualmente, mejor perfil de seguridad).</li>
+    <li><em>Régimen Ponticelli</em>: alternancia mensual de corticoide iv + ciclofosfamida oral × 6 meses.</li>
+    <li>Inhibidores de calcineurina (tacrolimús) como alternativa.</li>
+    <li>Siempre asociar IECA/ARA-II, estatinas, diuréticos, anticoagulación si alb &lt; 2.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>5.4 Nefropatía IgA (enfermedad de Berger)</h3>
+<ul>
+<li><strong>GN primaria más frecuente del adulto mundialmente</strong>. Asia &gt; Europa &gt; África.</li>
+<li><strong>Patogenia:</strong> alteración de la galactosilación de IgA1 → depósitos mesangiales de IgA1.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li><em>Hematuria macroscópica recurrente sinfaringítica</em> (concomitante a infección respiratoria — a diferencia de la post-estreptocócica que es tras): clásica en adolescentes/jóvenes.</li>
+    <li>Hematuria microscópica persistente con proteinuria variable.</li>
+    <li>Puede evolucionar a SN o GNRP en algunos.</li>
+    <li>IgA sérica elevada en 50 %.</li>
+  </ul>
+</li>
+<li><strong>Biopsia:</strong>
+  <ul>
+    <li>MO: proliferación mesangial focal.</li>
+    <li>IF: <em>depósitos mesangiales de IgA</em> (diagnóstico).</li>
+    <li>ME: depósitos electrodensos mesangiales.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Conservador: IECA/ARA-II + control de TA + restricción de sal.</li>
+    <li>Si proteinuria persistente &gt; 1 g/d a pesar de IECA: corticoides 6 meses (régimen STOP-IgAN/TESTING).</li>
+    <li>Budesónida de liberación entérica (Nefecon) en estudio.</li>
+    <li>Iptacopán (inhibidor C3) — opción reciente.</li>
+  </ul>
+</li>
+<li>Variante: <em>vasculitis IgA (Schönlein-Henoch)</em> — niños con púrpura + artritis + dolor abdominal + nefritis IgA. Tratamiento similar.</li>
+</ul>
+
+<h3>5.5 GN membranoproliferativa (GNMP) / mesangiocapilar</h3>
+<ul>
+<li><strong>Clasificación moderna (basada en patogenia):</strong>
+  <ul>
+    <li><em>Por inmunocomplejos</em> (IF con IgG y C3):
+      <ul>
+        <li>Infecciones crónicas: VHC + crioglobulinemia mixta tipo II (la más frecuente), VHB, endocarditis, shunt.</li>
+        <li>Autoinmunes: LES, Sjögren, AR.</li>
+        <li>Paraproteinemias: gammapatía monoclonal, mieloma.</li>
+      </ul>
+    </li>
+    <li><em>Mediada por complemento (C3 glomerulopatía)</em>: depósitos solo de C3 por desregulación de la vía alternativa. C3 nefritic factor, mutaciones factor H/I/MCP. <em>Subdividida en enfermedad por depósitos densos (DDD)</em> y <em>GN C3</em>.</li>
+    <li><em>Pauci-inmune / asociada a ANCA</em> (raro).</li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong> patrón mixto nefrítico-nefrótico. Hematuria + proteinuria + HTA + ↓ FG + <em>hipocomplementemia</em> (C3 bajo persistente).</li>
+<li><strong>Biopsia:</strong>
+  <ul>
+    <li>MO: <em>doble contorno</em> de la MBG ("rieles de tren"), proliferación mesangial.</li>
+    <li>IF: depósitos C3 ± IgG según etiología.</li>
+    <li>ME: depósitos subendoteliales (inmunocomplejos) o intramembranosos (DDD).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Etiológico cuando posible (AAD para VHC, corticoides en LES).</li>
+    <li>Inmunosupresores en C3 glomerulopatía: corticoides, MMF.</li>
+    <li>Eculizumab / inhibidores de complemento en formas mediadas por complemento.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>5.6 GN aguda post-infecciosa (post-estreptocócica)</h3>
+<ul>
+<li>Niños 5-15 años. 1-3 semanas tras faringoamigdalitis o impétigo por <em>S. pyogenes nefritogénico</em> (cepas con proteína M específica).</li>
+<li>Clínica: <em>síndrome nefrítico clásico</em> = hematuria macroscópica color "Coca-cola", HTA, edemas, oliguria, proteinuria leve.</li>
+<li>Laboratorio: ↓ C3 (transitorio, recupera en 6-8 sem), ↑ ASLO o anti-DNasa B, hematuria con cilindros hemáticos.</li>
+<li>Biopsia: <em>proliferación endocapilar difusa</em>, "humps" subepiteliales en IF granular y ME.</li>
+<li>Tratamiento: sintomático (control TA, edemas, diuréticos). Resolución espontánea en niños (&gt; 90 %), peor pronóstico en adultos.</li>
+</ul>
+
+<h3>5.7 GN rápidamente progresiva (extracapilar / con semilunas)</h3>
+<p>Ver también N4. Resumen:</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>IF</th><th>Etiología</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td>I (anti-MBG)</td><td>Lineal</td><td>Goodpasture (± hemorragia alveolar)</td><td>Plasmaféresis + corticoides + ciclofosfamida</td></tr>
+<tr><td>II (inmunocomplejos)</td><td>Granular</td><td>LES, IgA, post-infecciosa, crioglobulinemia</td><td>Corticoides + inmunosupresor según causa</td></tr>
+<tr><td>III (pauci-inmune, ANCA)</td><td>Negativa</td><td>GPA, PAM, GEPA</td><td>Pulsos de metilprednisolona + rituximab o ciclofosfamida ± plasmaféresis</td></tr>
+</tbody></table></div>
+
+<h3>5.8 Preguntas — N5</h3>
+
+<details class="qa"><summary>1. (Ord 2025) GN membranosa con proteinuria persistente — siguiente paso</summary>
+<div class="qa-body">
+<p>Paciente con GN membranosa con proteinuria nefrótica persistente a pesar de tratamiento sintomático 6 meses. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Continuar tratamiento sintomático indefinidamente</li>
+<li>Diuréticos a dosis altas</li>
+<li><strong>Iniciar tratamiento inmunosupresor</strong></li>
+<li>Biopsia renal de control</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Tras 6 m de tratamiento conservador con IECA/ARA2 sin remisión → iniciar inmunosupresor (rituximab de elección actual, o régimen Ponticelli con ciclofosfamida + corticoides alternantes mensuales).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) GN con "spikes" en MO</summary>
+<div class="qa-body">
+<p>¿Qué tipo de GN se caracteriza por "spikes" o "púas" en MO?</p>
+<ol type="a">
+<li>Cambios mínimos</li>
+<li><strong>Glomerulonefritis membranosa</strong></li>
+<li>GFS</li>
+<li>GN mesangial IgA</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Las "espigas" o spikes (proyecciones de MBG entre depósitos subepiteliales con tinción argéntica) son característicos de GN membranosa.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) GFS primaria — tratamiento inicial</summary>
+<div class="qa-body">
+<p>Adulto con SN. Biopsia: glomeruloesclerosis focal y segmentaria. Sin enfermedad sistémica. ¿Tratamiento inicial?</p>
+<ol type="a">
+<li>Observación sin tratamiento específico</li>
+<li>IECA/ARA-II únicamente</li>
+<li><strong>Tratamiento inmunosupresor</strong></li>
+<li>Plasmaféresis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> GFS primaria con SN → corticoides (prednisona 1 mg/kg/d, 4-6 meses). Si refractaria/recidivante → ciclosporina, MMF, rituximab.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) GNMP con C3 — patogenia</summary>
+<div class="qa-body">
+<p>Paciente joven con GNMP. IF: depósitos predominantes de C3. ¿Alteración subyacente?</p>
+<ol type="a">
+<li><strong>Desregulación de la vía alternativa del complemento</strong></li>
+<li>Inmunocomplejos por enf. autoinmunes</li>
+<li>Infección crónica por VHC</li>
+<li>Artritis reumatoide</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Cuando solo hay C3 (sin Ig) en IF = <em>"C3 glomerulopathy"</em> por desregulación de la vía alternativa (factor H, factor I, C3 nefrítico). VHC/LES/AR darían depósitos de inmunoglobulinas.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N6 =============== -->
+<section class="card" id="n6">
+<h2 class="section-title"><span class="num">N6</span>Glomerulonefritis secundarias</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las nefropatías glomerulares secundarias son las complicaciones renales de enfermedades sistémicas, infecciones o paraproteinemias.</li>
+<li>Las más importantes: <em>nefropatía diabética</em> (la causa más frecuente de ERC terminal mundialmente), nefropatía lúpica, vasculitis ANCA, anti-MBG, paraproteinemias, HIVAN, VHC.</li>
+</ul>
+</div>
+
+<h3>6.1 Nefropatía diabética (ND)</h3>
+<ul>
+<li><strong>Causa más frecuente de ERC terminal</strong> en países desarrollados (40 % de pacientes en diálisis).</li>
+<li><strong>Patogenia:</strong> hiperglucemia crónica → glicación de proteínas (productos finales de glicosilación avanzada, AGEs) + activación del SRAA → daño podocitario + hipertrofia mesangial + engrosamiento de la MBG + glomerulosclerosis nodular.</li>
+<li><strong>Estadios de Mogensen (DM tipo 1):</strong>
+  <ol>
+    <li>Hipertrofia/hiperfunción renal (DM reciente).</li>
+    <li>Lesiones estructurales sin clínica.</li>
+    <li><em>Microalbuminuria (UACR 30-300 mg/g)</em> — nefropatía incipiente.</li>
+    <li><em>Proteinuria establecida (UACR &gt; 300 mg/g)</em> — nefropatía clínica.</li>
+    <li>ERC terminal.</li>
+  </ol>
+</li>
+<li><strong>Histología:</strong>
+  <ul>
+    <li>Hipertrofia y expansión mesangial.</li>
+    <li>Engrosamiento de la MBG.</li>
+    <li><em>Nódulos de Kimmelstiel-Wilson</em> (glomerulosclerosis nodular, característicos pero no patognomónicos — también en amiloidosis y enfermedad por depósito de Ig).</li>
+    <li>Esclerosis arteriolar aferente y eferente.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento (pilar):</strong>
+  <ul>
+    <li><em>Control glucémico</em> intensivo: HbA1c &lt; 7 %.</li>
+    <li><em>Control de la TA</em>: objetivo &lt; 130/80.</li>
+    <li><em>IECA o ARA-II</em>: nefroprotección por reducción de la hipertensión glomerular (vasodilatación de la arteriola eferente).</li>
+    <li><strong>iSGLT2</strong> (dapagliflozina, empagliflozina, canagliflozina): demostrado beneficio renal y CV INDEPENDIENTE de la glucemia (DAPA-CKD, EMPA-Kidney, CREDENCE). Indicación en ND con FGe ≥ 20 y albuminuria. Iniciar con FGe &gt; 30 (preservar).</li>
+    <li><strong>Finerenona</strong>: antagonista no esteroideo del receptor mineralocorticoide. Reduce progresión renal y eventos CV en DM2 con albuminuria (FIDELIO-DKD, FIGARO-DKD).</li>
+    <li><strong>Agonistas GLP-1</strong>: semaglutida, liraglutida (efectos renales beneficiosos en estudios).</li>
+    <li><em>Estatinas</em> + control de FRCV.</li>
+    <li>Dejar de fumar, restricción proteica moderada.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>6.2 Nefropatía lúpica</h3>
+<ul>
+<li>Afectación renal en 30-50 % de los pacientes con LES, sobre todo en los primeros 5 años.</li>
+<li><strong>Patogenia:</strong> depósito de inmunocomplejos (anti-dsDNA + DNA) en glomérulos → activación del complemento → inflamación.</li>
+<li><strong>Marcadores serológicos de actividad:</strong> ↑ anti-dsDNA, ↓ C3 y C4, hematuria + proteinuria nueva.</li>
+<li><strong>Clasificación ISN/RPS 2003 (6 clases):</strong>
+  <ul>
+    <li><em>Clase I:</em> mesangial mínima (sólo IF/ME alterada). Asintomática.</li>
+    <li><em>Clase II:</em> proliferativa mesangial.</li>
+    <li><em>Clase III:</em> proliferativa <strong>focal</strong> (&lt; 50 % glomérulos). Síndrome nefrítico, hematuria, proteinuria, HTA. <strong>Subclase A activa, C crónica, A/C mixta</strong>.</li>
+    <li><em>Clase IV:</em> proliferativa <strong>difusa</strong> (≥ 50 % glomérulos). <strong>La más frecuente y grave</strong>. "Asas de alambre", semilunas. Cuerpos hematoxilínicos.</li>
+    <li><em>Clase V:</em> <strong>membranosa</strong>. <em>SN puro</em> a menudo. Puede coexistir con III o IV (V+III, V+IV).</li>
+    <li><em>Clase VI:</em> esclerosis avanzada (&gt; 90 % glomérulos). Insuficiencia renal terminal.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Clase I-II: HCQ + corticoides bajos.</li>
+    <li><strong>Clase III-IV (activa):</strong> inducción (6 m) + mantenimiento (3-5 años).
+      <ul>
+        <li>Inducción: pulsos de metilprednisolona iv + <em>MMF (preferido)</em> o ciclofosfamida iv (esquemas NIH o Eurolupus).</li>
+        <li>Añadir <em>belimumab</em> o <em>voclosporina</em> (KDIGO 2024).</li>
+        <li>Mantenimiento: MMF o AZA.</li>
+      </ul>
+    </li>
+    <li>Clase V: como GN membranosa primaria — corticoides + ciclofosfamida o MMF si proteinuria significativa.</li>
+    <li>HCQ siempre.</li>
+    <li>Profilaxis tromboembólica si albúmina baja, control de FRCV.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>6.3 Vasculitis ANCA-asociadas</h3>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>GPA (Wegener)</th><th>PAM</th><th>GEPA (Churg-Strauss)</th></tr></thead>
+<tbody>
+<tr><td>ANCA</td><td><em>c-ANCA / PR3</em> (75-90 %)</td><td><em>p-ANCA / MPO</em> (70 %)</td><td>p-ANCA / MPO (40 %)</td></tr>
+<tr><td>Granulomas</td><td>Sí</td><td>No</td><td>Sí (eosinofílicos)</td></tr>
+<tr><td>Asma + eosinofilia</td><td>No</td><td>No</td><td><strong>Sí (definitorio)</strong></td></tr>
+<tr><td>ORL</td><td><strong>Sí</strong> (sinusitis crónica, perforación septal, nariz en silla de montar, estenosis subglótica)</td><td>Raro</td><td>Rinitis, pólipos</td></tr>
+<tr><td>Pulmón</td><td>Nódulos cavitados, hemorragia alveolar</td><td>Hemorragia alveolar (capilaritis pulmonar)</td><td>Infiltrados migratorios</td></tr>
+<tr><td>Riñón</td><td>GN necrotizante pauciinmune con semilunas</td><td><strong>GN crescéntica (la más frecuente y grave)</strong></td><td>Menos frecuente</td></tr>
+<tr><td>Otros</td><td>Estenosis subglótica</td><td>Mejor pronóstico que GPA</td><td>Neuropatía, coronariopatía, miocarditis</td></tr>
+</tbody></table></div>
+<p><strong>Tratamiento AAV con afectación renal:</strong></p>
+<ul>
+<li><em>Inducción</em>: pulsos de metilprednisolona iv (500 mg-1 g × 3 d) + <strong>rituximab (de elección)</strong> o <strong>ciclofosfamida iv en pulsos</strong>. Añadir <em>avacopán</em> (inhibidor C5a) como ahorrador de corticoide.</li>
+<li><em>Plasmaféresis</em>: en formas con hemorragia alveolar grave, Cr &gt; 5,7 mg/dL, anti-MBG asociada (estudio PEXIVAS redujo indicaciones).</li>
+<li><em>Mantenimiento</em>: rituximab cada 6 m × 18-24 m (preferido); alternativa AZA/MTX/MMF.</li>
+<li>GEPA: <em>mepolizumab</em> (anti-IL-5) eficaz para componente asmático y eosinofílico.</li>
+</ul>
+
+<h3>6.4 Enfermedad por anti-MBG (Goodpasture)</h3>
+<ul>
+<li>Anticuerpos contra la cadena α3 del colágeno IV de la MBG (común a MBG renal y a la membrana basal alveolar).</li>
+<li>Asociaciones: HLA-DR15, tabaco, exposición a hidrocarburos, COVID, RT.</li>
+<li><strong>Clínica:</strong> <em>síndrome reno-pulmonar</em> = hemorragia alveolar (hemoptisis, anemia, infiltrados pulmonares) + GN rápidamente progresiva (semilunas).</li>
+<li><strong>Biopsia:</strong> GN crescéntica + <em>IF lineal continua para IgG</em> (patognomónica).</li>
+<li><strong>Tratamiento: emergencia.</strong>
+  <ul>
+    <li>Pulsos de metilprednisolona iv.</li>
+    <li>Ciclofosfamida iv (mantener &lt; 200 mg/m²).</li>
+    <li><em>Plasmaféresis diaria/altema</em> durante 2-3 sem (eliminar anticuerpos circulantes).</li>
+    <li>Pronóstico: si Cr &gt; 6 mg/dL o requerimiento de diálisis al inicio, mal pronóstico renal pero el tratamiento sí mejora supervivencia del paciente.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>6.5 Nefropatía por mieloma / paraproteinemias</h3>
+<ul>
+<li><strong>Nefropatía por cilindros de cadenas ligeras (cast nephropathy):</strong>
+  <ul>
+    <li>El mecanismo más frecuente. Cadenas ligeras (κ o λ) precipitan con la uromodulina (Tamm-Horsfall) en TCD → obstrucción tubular.</li>
+    <li>Clínica: IRA con proteinuria que NO es albúmina (la tira detecta solo albúmina, NO Bence Jones → falso negativo). Electroforesis de proteínas en orina + inmunofijación.</li>
+    <li>Biopsia: cilindros refringentes intratubulares con reacción inflamatoria.</li>
+    <li>Tratamiento: <em>QT dirigida al mieloma</em> (bortezomib + dexametasona) + <em>hemodiálisis con filtros de alto cut-off</em> (Theralite) para retirar cadenas ligeras.</li>
+  </ul>
+</li>
+<li><strong>Amiloidosis renal</strong> (ver también N6.6):
+  <ul>
+    <li>AL (cadenas ligeras): mieloma, gammapatía monoclonal de significado renal (MGRS).</li>
+    <li>AA (proteína sérica A reactante de fase aguda): inflamación crónica (AR, EII, infecciones).</li>
+    <li>Clínica: SN sumiso, organomegalia. Biopsia: tinción de rojo Congo con birrefringencia verde manzana bajo luz polarizada.</li>
+    <li>Tratamiento: QT en AL, tratar enfermedad inflamatoria en AA.</li>
+  </ul>
+</li>
+<li>Enfermedad por depósito de Ig (LCDD): depósitos no fibrilares de cadenas κ.</li>
+</ul>
+
+<h3>6.6 HIVAN (nefropatía asociada al VIH)</h3>
+<ul>
+<li>Manifestación renal clásica de pacientes con VIH no tratado, especialmente raza negra (asociación con APOL1).</li>
+<li>Histología: <em>glomeruloesclerosis focal y segmentaria forma colapsante</em>.</li>
+<li>Patogenia: <em>daño directo podocitario por proteínas virales</em> (Nef, gp120).</li>
+<li>Clínica: SN + IR de rápida progresión.</li>
+<li><strong>Tratamiento:</strong> <em>iniciar TAR</em> + IECA/ARA-II ± corticoides. Mejora con el control viral.</li>
+</ul>
+
+<h3>6.7 Nefropatía por VHB y VHC</h3>
+<ul>
+<li><strong>VHB:</strong> GN membranosa (la más típica) o membranoproliferativa. Niños y adultos. Tratamiento: antivirales (tenofovir, entecavir).</li>
+<li><strong>VHC:</strong> GN membranoproliferativa por <em>crioglobulinemia mixta tipo II</em> (IgM monoclonal con FR vs IgG policlonal). Clínica: SN/nefrítico + púrpura + artralgias + neuropatía. Tratamiento: <em>antivirales directos (sofosbuvir + velpatasvir, glecaprevir/pibrentasvir)</em> ± rituximab si grave.</li>
+</ul>
+
+<h3>6.8 Otras GN secundarias</h3>
+<ul>
+<li><strong>Sjögren:</strong> nefritis tubulointersticial (lo más frecuente), también GN membranosa.</li>
+<li><strong>Endocarditis infecciosa:</strong> GN proliferativa por inmunocomplejos.</li>
+<li><strong>Schönlein-Henoch (vasculitis IgA):</strong> niños con púrpura + artritis + dolor abdominal + GN IgA.</li>
+<li><strong>Drepanocitosis:</strong> nefropatía falciforme: hiperfiltración → microalbuminuria → GFS.</li>
+<li><strong>Fármacos:</strong> AINE (NIA, NCM, GFS), oro/penicilamina (membranosa), litio (NIC, ATR), tóxicos.</li>
+</ul>
+
+<h3>6.9 Preguntas — N6</h3>
+
+<details class="qa"><summary>1. (Ord 2025) LES con SN y hematuria — clase más probable</summary>
+<div class="qa-body">
+<p>Mujer de 40 años con LES desarrolla proteinuria nefrótica y hematuria. ¿Qué clase ISN/RPS se asocia más frecuentemente con SN?</p>
+<ol type="a">
+<li>Clase I: mesangial mínima</li>
+<li>Clase III: focal</li>
+<li>Clase IV: proliferativa difusa</li>
+<li><strong>Clase V: membranosa</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Clase V (membranosa) es la que más se asocia a <em>síndrome nefrótico puro</em>. Clase IV es la más frecuente y grave, pero típicamente con sd. nefrítico (HTA, IR).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) DM2 + ERC + albuminuria — beneficio renal</summary>
+<div class="qa-body">
+<p>Paciente de 62 a. con DM2 de larga data, HTA y albuminuria. FGe 40 mL/min. Además de metformina y control de TA, ¿qué opción ha demostrado reducir progresión renal?</p>
+<ol type="a">
+<li>Aumentar metformina</li>
+<li>Iniciar inhibidor DPP-4</li>
+<li><strong>Iniciar iSGLT2</strong></li>
+<li>Suplementos de vitamina D</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> iSGLT2 (dapagliflozina, empagliflozina, canagliflozina) tienen beneficio renal independiente de la glucemia → recomendado en ERC diabética y no diabética con albuminuria. Reducen hipertensión glomerular.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) IRA + hemorragia alveolar + IF lineal anti-IgG</summary>
+<div class="qa-body">
+<p>Paciente con IR rápidamente progresiva y hemorragia pulmonar. Biopsia renal: GN necrosante con semilunas. IF: tinción lineal para IgG a lo largo de la MBG. ¿Diagnóstico?</p>
+<ol type="a">
+<li>PAM</li>
+<li><strong>Enfermedad por anti-MBG (Goodpasture)</strong></li>
+<li>GPA</li>
+<li>Vasculitis IgA</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> IF lineal continua para IgG a lo largo de la MBG = patognomónica de anti-MBG (síndrome de Goodpasture si hay hemorragia alveolar). Las vasculitis ANCA dan IF pauciinmune (sin depósitos). Tratamiento: pulsos de metilprednisolona + ciclofosfamida + <em>plasmaféresis</em> urgente.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Ord 2025) Mieloma + IRA + cast nephropathy</summary>
+<div class="qa-body">
+<p>Paciente con gammapatía monoclonal e IRA. MO: 15 % células plasmáticas. Biopsia renal: nefropatía por cilindros de cadenas ligeras. ¿Tratamiento inicial más adecuado?</p>
+<ol type="a">
+<li>Plasmaféresis</li>
+<li>Corticoides a altas dosis</li>
+<li>Inmunoglobulinas iv</li>
+<li><strong>Quimioterapia dirigida a mieloma y hemodiálisis con filtros de alto cut-off</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Tratamiento de la cast nephropathy = QT del mieloma (bortezomib + dexametasona) + hemodiálisis con filtros de alto cut-off para retirar cadenas ligeras. La plasmaféresis ha sido controvertida pero hoy se usa menos.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Ord 2025) HIVAN — factor patogénico principal</summary>
+<div class="qa-body">
+<p>Paciente de 35 a. con VIH desarrolla proteinuria e IR. Biopsia: GFS colapsante. ¿Factor patogénico más importante?</p>
+<ol type="a">
+<li>Depósito de inmunocomplejos</li>
+<li>Infiltración por células inflamatorias</li>
+<li><strong>Daño directo podocitario</strong></li>
+<li>Activación del complemento</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> HIVAN = GFS colapsante con daño directo del VIH (gp120, Nef) sobre podocitos y células tubulares. Patrón con podocitopatía severa. Tratamiento: TAR efectivo + IECA/ARA2.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) LES con GN difusa — anticuerpo asociado a actividad</summary>
+<div class="qa-body">
+<p>Mujer con LES desarrolla HTA y deterioro renal. Biopsia: GN proliferativa difusa. ¿Anticuerpo más asociado a actividad?</p>
+<ol type="a">
+<li>Anti-Ro/SSA</li>
+<li>Anti-La/SSB</li>
+<li><strong>Anti-dsDNA</strong></li>
+<li>Anti-Sm</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Anti-dsDNA correlaciona con <em>actividad y nefritis lúpica</em>, especialmente clases III/IV. Su descenso es marcador de respuesta. Anti-Sm es específico pero no de actividad.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Extra 2025) Mujer con asma + ANCA — vasculitis</summary>
+<div class="qa-body">
+<p>Mujer de 50 a. con asma y rinitis alérgica desarrolla vasculitis. Labo: eosinofilia + ANCA (+). ¿Cuál?</p>
+<ol type="a">
+<li>PAM</li>
+<li>GPA</li>
+<li><strong>GEPA (Churg-Strauss)</strong></li>
+<li>Vasculitis IgA</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Asma + eosinofilia + p-ANCA = GEPA. Mepolizumab (anti-IL5) eficaz. PAM y GPA no cursan con asma/eosinofilia.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Extra 2025) Metformina e IR — efecto secundario</summary>
+<div class="qa-body">
+<p>Diabético de 70 a. con ERC y FGe 40. ¿Qué antidiabético puede provocar acidosis láctica sin ajuste de dosis?</p>
+<ol type="a">
+<li><strong>Metformina</strong></li>
+<li>iSGLT2</li>
+<li>Agonistas GLP-1</li>
+<li>Linagliptina</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Metformina no debe usarse con FGe &lt; 30; entre 30-45 usar dosis reducida (1000 mg/d máx). Riesgo de acidosis láctica grave por acumulación en IR.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N7 =============== -->
+<section class="card" id="n7">
+<h2 class="section-title"><span class="num">N7</span>Nefropatía tubulointersticial · tubulopatías</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>El intersticio renal contiene capilares, células fibroblásticas, túbulos. Las nefropatías tubulointersticiales (NTI) afectan a túbulos e intersticio sin afectación glomerular primaria.</li>
+<li><strong>NIA</strong> = nefritis intersticial aguda; <strong>NIC</strong> = nefritis intersticial crónica. <em>Tubulopatías</em> = trastornos hereditarios o adquiridos de la función tubular.</li>
+</ul>
+</div>
+
+<h3>7.1 Nefritis intersticial aguda (NIA)</h3>
+<ul>
+<li><strong>Etiología:</strong>
+  <ul>
+    <li><em>Farmacológica</em> (75 %, la más frecuente):
+      <ul>
+        <li>Antibióticos: β-lactámicos (penicilina, cefalosporinas, ampicilina), sulfamidas, quinolonas, vancomicina, rifampicina.</li>
+        <li>AINE.</li>
+        <li>Inhibidores de la bomba de protones (omeprazol, pantoprazol) — causa creciente, NIA insidiosa.</li>
+        <li>Diuréticos, alopurinol, antineoplásicos (cisplatino, ifosfamida), inhibidores de checkpoint (nivolumab, pembrolizumab — nefritis inmunomediada).</li>
+      </ul>
+    </li>
+    <li><em>Infecciosa:</em> pielonefritis, leptospirosis, hantavirus, legionella, BK virus, CMV.</li>
+    <li><em>Autoinmune:</em> Sjögren (asociación clásica), LES, sarcoidosis, IgG4-RD, síndrome TINU (uveítis + NIA).</li>
+    <li><em>Idiopática.</em></li>
+  </ul>
+</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>IRA en días-semanas tras inicio del fármaco.</li>
+    <li>Tríada clásica (pero solo presente en &lt; 30 % de casos):
+      <ul>
+        <li><em>Fiebre</em>.</li>
+        <li><em>Exantema maculopapular</em>.</li>
+        <li><em>Eosinofilia</em> periférica.</li>
+      </ul>
+    </li>
+    <li>Dolor lumbar, artralgias.</li>
+    <li>Orina: <em>leucocituria estéril + eosinofiluria</em> (tinción de Hansel — sensibilidad limitada), proteinuria escasa (excepto en NIA por AINE, que puede dar SN).</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> clínico + sedimento + analítica + relación temporal con fármaco. <em>Biopsia renal</em> es definitiva (infiltrado intersticial linfo-eosinofílico + edema + tubulitis).</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Retirar el fármaco causal</em> (fundamental).</li>
+    <li>Si no mejoría en 7-10 días o IR significativa: <em>corticoides</em> (prednisona 1 mg/kg × 4 sem, descenso lento).</li>
+    <li>Soporte renal (diálisis si necesario).</li>
+    <li>Pronóstico: 60 % recuperación completa; 20 % progresan a ERC.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>7.2 Nefritis intersticial crónica (NIC)</h3>
+<ul>
+<li><strong>Causas:</strong>
+  <ul>
+    <li>Analgésicos crónicos (fenacetina, AINE — "nefropatía por analgésicos" con necrosis papilar).</li>
+    <li>Litio (NIC + diabetes insípida nefrogénica).</li>
+    <li>Hierba aristolóquica (China, Balcanes — carcinoma urotelial).</li>
+    <li>Reflujo vesicoureteral crónico (nefropatía por reflujo).</li>
+    <li>Metales pesados (plomo, cadmio).</li>
+    <li>Hiperuricemia / nefropatía gotosa.</li>
+    <li>Hipercalcemia / hiperoxaluria.</li>
+    <li>Hereditarias: NIAD (ADTKD), enfermedad medular quística.</li>
+  </ul>
+</li>
+<li>Clínica: progresión insidiosa a ERC, poliuria, polidipsia (defecto de concentración), proteinuria escasa, anemia precoz (déficit EPO).</li>
+<li>Tratamiento: retirar tóxicos + nefroprotección.</li>
+</ul>
+
+<h3>7.3 Tubulopatías hereditarias</h3>
+
+<h4>Acidosis tubular renal (ATR)</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Mecanismo</th><th>K plasmático</th><th>pH urinario</th><th>Causas</th></tr></thead>
+<tbody>
+<tr><td><strong>I (distal, clásica)</strong></td><td>Incapacidad para acidificar la orina (defecto en α-IC del TCD)</td><td>↓ (hipoK)</td><td>&gt; 5,5 (no puede bajar)</td><td>Hereditaria, Sjögren, AR, LES, drepanocitosis, anfotericina B, litio · <em>cálculos de fosfato cálcico, nefrocalcinosis</em></td></tr>
+<tr><td><strong>II (proximal)</strong></td><td>↓ reabsorción de HCO₃ en TCP</td><td>↓ (hipoK)</td><td>Variable (5,5 inicial, baja después)</td><td><em>Síndrome de Fanconi</em>, mieloma, paraproteinemias, metales pesados, ifosfamida</td></tr>
+<tr><td><strong>IV (hipoaldosteronismo hiporreninémico)</strong></td><td>Resistencia a la aldosterona</td><td><strong>↑ (HIPERK)</strong></td><td>&lt; 5,5</td><td><em>DM</em>, IECA/ARA-II, espironolactona, AINE, nefropatía por reflujo</td></tr>
+</tbody></table></div>
+<p><strong>Todas dan acidosis metabólica con AG normal (hiperclorémica).</strong> Tratamiento: bicarbonato + suplementos (K en I y II, restricción de K en IV).</p>
+
+<h4>Síndrome de Fanconi</h4>
+<p>Disfunción global del TCP → aminoaciduria, glucosuria, fosfaturia (→ raquitismo/osteomalacia hipofosfatémica), bicarbonaturia (ATR II), uricosuria, proteinuria de bajo peso. Causas: cistinosis, mieloma, fármacos (tenofovir, cisplatino, ifosfamida), metales pesados.</p>
+
+<h4>Síndromes de Bartter y Gitelman</h4>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>Bartter</th><th>Gitelman</th></tr></thead>
+<tbody>
+<tr><td>Segmento afectado</td><td><strong>Asa de Henle gruesa ascendente</strong></td><td><strong>Túbulo contorneado distal</strong></td></tr>
+<tr><td>"Como tomar"</td><td>Furosemida crónica</td><td>Tiazida crónica</td></tr>
+<tr><td>Inicio</td><td>Infancia (neonatal o juvenil)</td><td>Adolescencia/adulto joven</td></tr>
+<tr><td>Calciuria</td><td><strong>Hipercalciuria</strong> (nefrocalcinosis)</td><td><strong>HipoCalciuria</strong></td></tr>
+<tr><td>Magnesio</td><td>Normal o leve ↓</td><td><strong>HipoMg</strong></td></tr>
+<tr><td>Renina/aldosterona</td><td>↑↑</td><td>↑</td></tr>
+<tr><td>K</td><td>↓ severa</td><td>↓ moderada</td></tr>
+<tr><td>Acidosis/alcalosis</td><td>Alcalosis metabólica</td><td>Alcalosis metabólica</td></tr>
+<tr><td>HTA</td><td>No (normo/hipotenso)</td><td>No</td></tr>
+<tr><td>Tratamiento</td><td>Suplementos de K, AINE (indometacina), espironolactona/amilorida</td><td>Suplementos K + Mg, espironolactona, eplerenona</td></tr>
+</tbody></table></div>
+
+<h4>Síndrome de Liddle</h4>
+<p>Ganancia de función del canal ENaC en el tubo colector. <strong>HTA</strong> + hipopotasemia + alcalosis metabólica + renina baja + aldosterona baja. Tratamiento: <em>amilorida o triamtereno</em> (bloquean ENaC). La espironolactona NO funciona (no es aldosterona el problema).</p>
+
+<h4>Diabetes insípida nefrogénica</h4>
+<p>Resistencia del túbulo colector a la ADH. Poliuria + polidipsia + orina diluida. Causas: hereditaria (mutación AVPR2/AQP2), litio, hipercalcemia, hipopotasemia. Tratamiento: ingesta de agua adecuada, restricción de Na, tiazidas (paradójicamente reducen el volumen urinario), AINE.</p>
+
+<h3>7.4 Preguntas — N7</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Síndrome de Bartter — segmento afectado</summary>
+<div class="qa-body">
+<p>¿Qué segmento de la nefrona es el principalmente afectado en el síndrome de Bartter?</p>
+<ol type="a">
+<li>TCP</li>
+<li><strong>Asa de Henle</strong></li>
+<li>TCD</li>
+<li>Túbulo colector</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Bartter = defecto del cotransportador Na-K-2Cl (NKCC2) en la rama gruesa ascendente del asa de Henle. Equivale farmacológicamente a tomar furosemida crónica.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) NIA por cefalosporina</summary>
+<div class="qa-body">
+<p>Hombre de 48 a. con fiebre, exantema y dolor lumbar, 8 días tras iniciar cefalosporina por infección respiratoria. Cr 4 mg/dL, eosinofilia. Orina: leucocituria, hematuria, proteinuria leve. ¿Diagnóstico y manejo?</p>
+<ol type="a">
+<li>GN aguda; corticoides</li>
+<li><strong>Nefritis intersticial aguda; suspender antibiótico y considerar corticoides si no mejora</strong></li>
+<li>Pielonefritis aguda; continuar ATB e hidratar</li>
+<li>NTA; fluidos iv y monitorizar</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Tríada de NIA: fiebre + exantema + eosinofilia + IRA + sedimento con leucocitos/eosinófilos. Causa: cefalosporina. Tratamiento: <em>retirar fármaco</em>. Si tras 5-7 días no hay recuperación → corticoides 4-6 semanas en pauta descendente.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Bartter — analítica característica</summary>
+<div class="qa-body">
+<p>Mujer de 30 a. con síndrome de Bartter. ¿Qué hallazgo es característico?</p>
+<ol type="a">
+<li>Acidosis metabólica hiperclorémica</li>
+<li>HTA y retención de sodio</li>
+<li><strong>Alcalosis metabólica, hipopotasemia e hipercalciuria</strong></li>
+<li>Hipocalcemia por aumento de reabsorción renal de calcio</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Bartter = hipopotasemia + alcalosis metabólica + <em>hipercalciuria</em> + normotensión (no HTA). Equivalente a furosemida crónica. Gitelman tendría <em>hipocalciuria</em> e hipomagnesemia.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) NIA por alopurinol</summary>
+<div class="qa-body">
+<p>Hombre de 58 a. en alopurinol desde hace 1 mes. Acude por malestar, febrícula, erupción cutánea. Cr 5 mg/dL, eosinofilia, ↑ enzimas hepáticas. Orina: leucocituria y hematuria. ¿Diagnóstico y manejo?</p>
+<ol type="a">
+<li>GNRP; plasmaféresis</li>
+<li>PNA complicada; ATB amplio espectro</li>
+<li>Vasculitis sistémica; ciclofosfamida</li>
+<li><strong>NIA por fármacos; suspender alopurinol y considerar corticoides</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Síndrome DRESS-like por alopurinol (NIA + hepatitis + exantema + eosinofilia). Suspender + corticoides. El alopurinol es de los fármacos más frecuentes en NIA + síndrome DRESS.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N8 =============== -->
+<section class="card" id="n8">
+<h2 class="section-title"><span class="num">N8</span>Enfermedad renal hereditaria · quísticas</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Enfermedades renales hereditarias clasificadas en:</strong>
+  <ul>
+    <li>Quísticas: PQRAD, PQRAR, enfermedad medular quística, nefronoptisis, riñón en esponja medular.</li>
+    <li>Glomerulares: Alport, enfermedad de la MBG fina.</li>
+    <li>De depósito: Fabry, cistinosis, Gaucher, oxalosis primaria.</li>
+    <li>Tubulares: ATR, Bartter, Gitelman, Liddle, diabetes insípida nefrogénica, cistinuria.</li>
+    <li>Tubulointersticiales: NIAD (ADTKD).</li>
+    <li>Asociadas a esclerosis tuberosa, VHL, Birt-Hogg-Dubé.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>8.1 Poliquistosis renal autosómica dominante (PQRAD)</h3>
+<ul>
+<li><strong>La enfermedad renal hereditaria más frecuente</strong> (1:400-1.000). Responsable de 5-10 % de los pacientes en diálisis.</li>
+<li><strong>Genética:</strong>
+  <ul>
+    <li><em>PKD1</em> (16p13.3, codifica policistina-1) — 85 % de casos, progresión más rápida (ERC terminal a 50-55 a.).</li>
+    <li><em>PKD2</em> (4q21, policistina-2) — 15 %, progresión más lenta (ERC terminal a 70-75 a.).</li>
+  </ul>
+</li>
+<li><strong>Síndrome de genes contiguos (16p13.3):</strong> PKD1 + TSC2 → PQRAD + esclerosis tuberosa.</li>
+<li><strong>Clínica renal:</strong> quistes renales bilaterales múltiples que aparecen y crecen con la edad. Inicio sintomático 30-50 a.:
+  <ul>
+    <li>HTA (a menudo es la primera manifestación).</li>
+    <li>Dolor lumbar (sangrado o infección de quiste).</li>
+    <li>Hematuria macroscópica.</li>
+    <li>Litiasis (en 25 %).</li>
+    <li>ITU recurrentes / infección de quiste (E. coli) — difícil de tratar (penetración del ATB).</li>
+    <li>Insuficiencia renal progresiva.</li>
+  </ul>
+</li>
+<li><strong>Manifestaciones extrarrenales:</strong>
+  <ul>
+    <li>Quistes hepáticos (75 % a los 60 a.) — más frecuentes en mujeres.</li>
+    <li>Quistes pancreáticos, ováricos, esplénicos.</li>
+    <li><em>Aneurismas cerebrales</em> (5-10 %; cribado si AF de hemorragia o aneurisma).</li>
+    <li>Valvulopatía mitral (prolapso) y aórtica.</li>
+    <li>Hernias inguinales, diverticulosis colónica.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> ecografía + AF familiar. Criterios de Ravine-Pei según edad:
+  <ul>
+    <li>15-39 a.: ≥ 3 quistes (uni o bilaterales).</li>
+    <li>40-59 a.: ≥ 2 quistes por riñón.</li>
+    <li>≥ 60 a.: ≥ 4 quistes por riñón.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Control de TA &lt; 130/80 con IECA/ARA-II.</li>
+    <li>Hidratación abundante (suprime ADH y vasopresina).</li>
+    <li><em>Tolvaptán</em> (antagonista V2): aprobado en PQRAD con progresión rápida. Reduce el crecimiento de quistes y enlentece la pérdida de FG. Vigilar hepatotoxicidad y poliuria.</li>
+    <li>Manejo de complicaciones: dolor, infección de quiste (quinolonas penetran mejor), litiasis, sangrado.</li>
+    <li>Diálisis o trasplante en ERC terminal (puede requerir nefrectomía pre-trasplante si riñones muy grandes).</li>
+    <li>Cribado de aneurisma cerebral (angio-RM) si AF de aneurisma o hemorragia subaracnoidea.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.2 Poliquistosis renal autosómica recesiva (PQRAR)</h3>
+<ul>
+<li>Rara (1:20.000). Gen <em>PKHD1</em> (6p21).</li>
+<li><strong>Presentación:</strong>
+  <ul>
+    <li>Perinatal/neonatal: <em>oligohidramnios intraútero → hipoplasia pulmonar + facies de Potter (orejas bajas, pliegues epicantos, nariz aplanada, micrognatia, extremidades arqueadas) + distrés respiratorio + riñones muy aumentados con microquistes corticomedulares</em>. Alta mortalidad neonatal.</li>
+    <li>Niños supervivientes: <em>fibrosis hepática congénita</em> con hipertensión portal, varices esofágicas, esplenomegalia.</li>
+  </ul>
+</li>
+<li>Tratamiento: soporte, diálisis y trasplante renal-hepático combinado en casos graves.</li>
+</ul>
+
+<h3>8.3 Otras enfermedades quísticas</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Nefronoptisis</span><span class="v">AR. Niños/adolescentes. Quistes en unión corticomedular. Asociaciones extrarrenales (Joubert, Senior-Løken con retinitis pigmentaria). Progresión rápida a ERC en la 2ª década</span></div>
+<div class="kv"><span class="k">Enfermedad medular quística</span><span class="v">AD. Quistes medulares. Adulto. Progresión a ERC</span></div>
+<div class="kv"><span class="k">Riñón en esponja medular (Cacchi-Ricci)</span><span class="v">Dilatación de los conductos colectores. Litiasis recurrente, hematuria. Función renal preservada en general</span></div>
+<div class="kv"><span class="k">Esclerosis tuberosa (PKD1/TSC2)</span><span class="v">Angiomiolipomas múltiples bilaterales, quistes, CCR. Tratamiento con everolimus reduce AML</span></div>
+<div class="kv"><span class="k">VHL</span><span class="v">CCR células claras múltiples bilaterales, feocromocitoma, hemangioblastoma cerebeloso, quistes pancreáticos</span></div>
+<div class="kv"><span class="k">Birt-Hogg-Dubé</span><span class="v">CCR cromófobo, fibrofoliculomas cutáneos, quistes pulmonares y neumotórax</span></div>
+</div>
+
+<h3>8.4 Enfermedad de Alport</h3>
+<ul>
+<li>Nefropatía hereditaria por <em>defecto del colágeno IV</em> (cadenas α3, α4, α5) — componente de la MBG renal y de las membranas basales coclear y ocular.</li>
+<li><strong>Genética:</strong>
+  <ul>
+    <li><em>Forma ligada al X (85 %)</em>: mutación <strong>COL4A5</strong>. Varones gravemente afectados (IR en 20-30 a.). Mujeres portadoras con manifestaciones leves (hematuria, raramente IR).</li>
+    <li>Forma AR: mutación COL4A3/4. Afecta ambos sexos igualmente.</li>
+    <li>Forma AD (rara): mutación COL4A3/4 heterozigota.</li>
+  </ul>
+</li>
+<li><strong>Clínica clásica (tríada):</strong>
+  <ul>
+    <li><em>Nefropatía hematúrica</em>: hematuria persistente desde infancia → proteinuria → IR progresiva.</li>
+    <li><em>Sordera neurosensorial</em> bilateral progresiva (frecuencias altas).</li>
+    <li><em>Anomalías oculares</em>: lenticono anterior (patognomónico), distrofia macular, retinopatía moteada.</li>
+  </ul>
+</li>
+<li>Biopsia: <em>MBG con engrosamiento, adelgazamiento y desestructuración en "cesto de mimbre"</em> en ME. IF negativa para α3, α4, α5 (ausencia).</li>
+<li>Tratamiento: IECA/ARA-II (enlentece progresión), trasplante renal. Riesgo de glomerulonefritis anti-MBG post-trasplante (raro).</li>
+</ul>
+
+<h3>8.5 Enfermedad de la MBG fina (hematuria benigna familiar)</h3>
+<p>AD. Mutaciones heterocigóticas COL4A3/4. <em>Hematuria microscópica persistente desde infancia</em>, sin proteinuria ni IR. Pronóstico excelente. Distinguir de Alport.</p>
+
+<h3>8.6 Enfermedad de Fabry</h3>
+<ul>
+<li>Ligada al X recesiva. <em>Déficit de α-galactosidasa A</em> → acumulación intralisosomal de globotriaosilceramida (Gb3) en endotelio, podocitos, miocardio, SNC.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li><em>Acroparestesias</em> (dolor neuropático en manos y pies en niños).</li>
+    <li><em>Angioqueratomas</em> (lesiones papulares violáceas en abdomen y nalgas — "bañador").</li>
+    <li><em>Córnea verticilada</em> (opacidad corneal radial visible en lámpara de hendidura).</li>
+    <li>Hipoacusia, sudoración disminuida (hipohidrosis), intolerancia al calor.</li>
+    <li>Renal: proteinuria, ERC progresiva en 3ª-4ª década.</li>
+    <li>Cardíaco: <em>miocardiopatía hipertrófica</em>, arritmias.</li>
+    <li>SNC: ACV isquémicos precoces.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> actividad de α-galactosidasa A en leucocitos (varones, baja) o test genético (mujeres heterocigotas). Gb3 elevada.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Terapia enzimática sustitutiva: <em>agalsidasa α o β iv cada 2 semanas</em>.</li>
+    <li>Chaperonas (migalastat oral) en mutaciones aptas.</li>
+    <li>IECA/ARA-II para proteinuria.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.7 Cistinuria</h3>
+<ul>
+<li>AR. Defecto del transporte tubular y intestinal de aminoácidos dibásicos (cistina, ornitina, lisina, arginina) — gen SLC3A1, SLC7A9.</li>
+<li>Litiasis de cistina recurrente desde infancia/adolescencia. Cristales hexagonales en orina (patognomónicos). Tinción con nitroprusiato positiva (Brand).</li>
+<li>Tratamiento: hidratación masiva (&gt; 3 L/d), alcalinización (citrato), restricción de Na y metionina, tiopronina/D-penicilamina si refractaria.</li>
+</ul>
+
+<h3>8.8 NIAD / ADTKD (Autosomal Dominant Tubulointerstitial Kidney Disease)</h3>
+<ul>
+<li>Antiguamente "enfermedad medular quística tipo 2". Mutaciones MUC1, UMOD, REN, HNF1B.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Progresión <em>LENTA</em> a ERC (de 30 a 70 a. según familia).</li>
+    <li>Sedimento urinario <em>normal o leve microhematuria</em>.</li>
+    <li>Proteinuria escasa (&lt; 1 g/d). <em>NUNCA en rango nefrótico</em>.</li>
+    <li>Anemia precoz desproporcionada al grado de IR.</li>
+    <li>Hiperuricemia con gota juvenil precoz (UMOD).</li>
+  </ul>
+</li>
+<li>Diagnóstico: test genético.</li>
+</ul>
+
+<h3>8.9 Cromosoma 16 — síndromes contiguos importantes</h3>
+<div class="box box-mnemo">
+<div class="box-title"><span class="icon">🧠</span>Recuerda</div>
+<p style="margin:0"><strong>Cromosoma 16 (16p13.3):</strong> contiene PKD1 + TSC2. Deleciones grandes producen <em>poliquistosis renal AD + esclerosis tuberosa</em> simultáneamente (síndrome de genes contiguos).</p>
+</div>
+
+<h3>8.10 Preguntas — N8</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Cromosoma 16 — síndrome de genes contiguos</summary>
+<div class="qa-body">
+<p>¿Qué dos enfermedades renales hereditarias se producen por mutaciones en el cromosoma 16 (síndrome de genes contiguos)?</p>
+<ol type="a">
+<li>Alport y nefropatía del colágeno IV</li>
+<li>PQRAD y PQRAR</li>
+<li><strong>Esclerosis tuberosa y PQRAD</strong></li>
+<li>Fabry y Gaucher</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los genes PKD1 (16p13.3) y TSC2 (16p13.3) son contiguos. Una gran deleción afecta a ambos → fenotipo combinado de PQRAD + esclerosis tuberosa. PQRAR es del cromosoma 6 (PKHD1). Alport del cromosoma X (COL4A5).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Alport ligado al X — sugerente</summary>
+<div class="qa-body">
+<p>Hombre de 20 a. con microhematuria desde la infancia + AF de Alport. ¿Qué es más sugestivo de la forma ligada al X?</p>
+<ol type="a">
+<li>Igual afectación en hombres y mujeres</li>
+<li><strong>Presencia de lenticono anterior</strong></li>
+<li>Inicio de IR en edad adulta tardía</li>
+<li>Herencia autosómica recesiva</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Lenticono anterior (deformidad de la cápsula del cristalino) es patognomónico de Alport ligado al X (es muy específico, presente en 15-20 %). En ligado al X, los varones están <em>gravemente</em> afectados (no igual que mujeres). IR aparece en 20-30 a., no tarde.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Recién nacido con riñones aumentados + facies de Potter</summary>
+<div class="qa-body">
+<p>Niño recién nacido con distrés respiratorio, facies de Potter. ECO: riñones aumentados con muchos quistes &lt; 2 cm. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Enfermedad renal poliquística autosómica recesiva tipo III de Potter</li>
+<li>Pluriquistosis renal</li>
+<li><strong>Enfermedad renal poliquística autosómica recesiva</strong></li>
+<li>Enfermedad renal poliquística tipo II de Potter</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> PQRAR (PKHD1) en neonato con facies de Potter (rasgos faciales aplanados por oligohidramnios + hipoplasia pulmonar) + riñones grandes con microquistes corticomedulares.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Varón joven con SN + cardiopatía + angioqueratomas + opacidad corneal</summary>
+<div class="qa-body">
+<p>Hermano del paciente trasplantado por ERC. SN + IR progresiva, cardiopatía isquémica, opacidad corneal, angioqueratomas. ¿Prueba diagnóstica indicada?</p>
+<ol type="a">
+<li><strong>Determinación de actividad de α-galactosidasa A</strong></li>
+<li>Estudio genético PKD1</li>
+<li>Determinación de glucógeno</li>
+<li>Estudio genético colágeno tipo IV</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Tetrada clásica de Fabry: angioqueratomas + acroparestesias + córnea verticilada + cardiopatía/ictus precoz + ERC. Déficit de α-galactosidasa A. Tratamiento: terapia enzimática sustitutiva.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) NIAD — NO típico</summary>
+<div class="qa-body">
+<p>¿Qué característica NO es típica en la evolución de la NIAD?</p>
+<ol type="a">
+<li>Progresión lenta a ERC</li>
+<li><strong>Proteinuria en rango nefrótico</strong></li>
+<li>Sedimento normal o microhematuria</li>
+<li>Anemia precoz</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> La NIAD nunca cursa con proteinuria nefrótica. La proteinuria es escasa (&lt; 1 g/d). Características: hiperuricemia, gota juvenil, anemia precoz desproporcionada, sedimento limpio.</div>
+</div></details>
+
+</section>
+
+<!-- =============== N9 =============== -->
+<section class="card" id="n9">
+<h2 class="section-title"><span class="num">N9</span>Nefropatía de origen vascular · MAT</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Las nefropatías vasculares</strong> incluyen: HTA renovascular, nefroangioesclerosis, nefropatía isquémica, enfermedad ateroembólica, microangiopatías trombóticas (MAT), infarto renal, trombosis de vena renal, vasculitis.</li>
+</ul>
+</div>
+
+<h3>9.1 HTA renovascular</h3>
+<ul>
+<li>HTA secundaria a estenosis de la arteria renal → ↓ presión de perfusión → activación del SRAA → HTA.</li>
+<li><strong>Etiología:</strong>
+  <ul>
+    <li><em>Aterosclerosis</em> (90 %): varones &gt; 60 a. con FRCV. Estenosis ostial o proximal.</li>
+    <li><em>Displasia fibromuscular</em> (10 %): mujeres jóvenes 15-50 a. Aspecto en <em>"collar de cuentas"</em> en arteriografía (medial, predilección por el tercio distal).</li>
+    <li>Otras: arteritis de Takayasu (mujer joven asiática), trauma, disección.</li>
+  </ul>
+</li>
+<li><strong>Sospechar HTA renovascular si:</strong>
+  <ul>
+    <li>HTA &lt; 30 a. o &gt; 55-60 a. con inicio brusco.</li>
+    <li>HTA refractaria a 3 antihipertensivos (incluyendo diurético).</li>
+    <li>Empeoramiento agudo de la TA o de la función renal con IECA/ARA-II (clave: ↑ Cr &gt; 30 % indica estenosis bilateral o de riñón único).</li>
+    <li>Soplo abdominal o lumbar.</li>
+    <li>Asimetría renal en eco (&gt; 1,5 cm de diferencia).</li>
+    <li>Edema agudo pulmonar (EPA) "flash" recurrente sin causa cardíaca aparente.</li>
+    <li>Hipopotasemia espontánea + alcalosis (hiperaldosteronismo secundario).</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Doppler de arterias renales (cribado): velocidad sistólica pico &gt; 200 cm/s sugiere estenosis significativa.</li>
+    <li>Angio-TC o angio-RM con contraste.</li>
+    <li>Arteriografía renal selectiva (gold standard, terapéutica).</li>
+    <li>Renograma con captopril (clásico, en desuso).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Aterosclerótica</em>: control de FRCV + IECA/ARA-II + estatinas + antiagregantes. Revascularización (angioplastia ± stent) NO mejora el pronóstico vs tratamiento médico óptimo (estudio CORAL) salvo: HTA refractaria, EPA flash, IR rápidamente progresiva, estenosis bilateral.</li>
+    <li><em>Displasia fibromuscular</em>: angioplastia (sin stent) — generalmente curativa en mujeres jóvenes.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>9.2 Nefroangioesclerosis</h3>
+<ul>
+<li>Daño renal crónico por HTA esencial: arterioloesclerosis hialina y proliferativa → isquemia glomerular → glomerulosclerosis + atrofia tubular.</li>
+<li>Causa frecuente de ERC en adultos (especialmente raza negra — APOL1).</li>
+<li>Clínica: HTA + IR progresiva + proteinuria leve-moderada + sedimento limpio. Riñones de tamaño normal o pequeño simétricos.</li>
+<li>Tratamiento: control estricto de TA (objetivo &lt; 130/80) con IECA/ARA-II + tiazidas + otros antihipertensivos. Estatinas. Estilo de vida.</li>
+</ul>
+
+<h3>9.3 Nefropatía isquémica</h3>
+<p>Estenosis bilateral de arterias renales o sobre riñón único → ↓ FG progresivo. Manifestación clásica: <em>EPA flash recurrente</em> en anciano + IR progresiva.</p>
+
+<h3>9.4 Enfermedad ateroembólica (émbolos de colesterol)</h3>
+<ul>
+<li>Émbolos de colesterol desde placas aórticas tras <em>manipulación arterial</em> (cateterismo cardíaco, cirugía aórtica) o <em>anticoagulación</em> (heparina, AVK).</li>
+<li>Clínica: IR progresiva subaguda + síntomas isquémicos en piel (livedo reticularis, dedos azules), retina (placas de Hollenhorst), sistémicos (fiebre, mialgias).</li>
+<li>Laboratorio: <em>eosinofilia</em>, eosinofiluria, ↓ complemento (C3, C4), ↑ VSG.</li>
+<li>Biopsia: cristales de colesterol birrefringentes en arterias.</li>
+<li>Tratamiento: estatinas, control de FRCV. Suspender anticoagulación si posible. Mal pronóstico (50 % requieren diálisis).</li>
+</ul>
+
+<h3>9.5 Microangiopatías trombóticas (MAT)</h3>
+<p>Grupo de entidades caracterizadas por <em>anemia hemolítica microangiopática + trombocitopenia + lesión orgánica isquémica</em>.</p>
+<div class="table-wrap"><table>
+<thead><tr><th>Entidad</th><th>ADAMTS13</th><th>Etiología</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>SHU típico (post-diarrea, STEC-HUS)</strong></td><td>Normal</td><td>Niños, post-diarrea sanguinolenta por <em>E. coli O157:H7 productor de Shiga toxin</em></td><td>Soporte (fluidos, diálisis). NO ATB (puede empeorar liberando más toxina). Eculizumab si grave.</td></tr>
+<tr><td><strong>SHU atípico (aHUS)</strong></td><td>Normal</td><td>Desregulación de la vía alternativa del complemento (mutaciones factor H, I, MCP, C3, factor B; auto-Ac anti-factor H)</td><td><strong>Eculizumab</strong> (anti-C5) o ravulizumab. Trasplante con cobertura</td></tr>
+<tr><td><strong>PTT (Moschcowitz)</strong></td><td><strong>&lt; 10 % (déficit severo)</strong></td><td>Auto-anticuerpos contra ADAMTS13 (la mayoría) o congénita (Upshaw-Schulman)</td><td><strong>Plasmaféresis URGENTE</strong> + corticoides + caplacizumab (anti-vWF) + rituximab</td></tr>
+<tr><td>MAT secundarias</td><td>Variable</td><td>LES, SAF catastrófico, malignidad, fármacos (ciclosporina, tacrolimus, gemcitabina, mitomicina C, quinina, anti-VEGF), embarazo (HELLP), trasplante, infecciones (VIH, neumococo)</td><td>Tratar la causa; eculizumab en casos seleccionados</td></tr>
+</tbody></table></div>
+
+<h4>PTT — péntada clásica</h4>
+<ul>
+<li>Anemia hemolítica microangiopática (esquistocitos, LDH alta, BR indirecta alta, haptoglobina baja, Coombs negativo).</li>
+<li>Trombocitopenia.</li>
+<li>Fiebre.</li>
+<li>Alteraciones neurológicas (encefalopatía, focalidad, coma).</li>
+<li>Insuficiencia renal.</li>
+</ul>
+<p>(Solo el 40 % cumple los 5; basta con anemia microangiopática + trombopenia inexplicada para iniciar plasmaféresis empírica).</p>
+
+<h3>9.6 Infarto renal</h3>
+<ul>
+<li>Embolia (FA, endocarditis), trombosis arterial, disección renal, vasculitis.</li>
+<li>Clínica: dolor lumbar brusco + hematuria + ↑ LDH + ↑ FA.</li>
+<li>Diagnóstico: TC con contraste.</li>
+<li>Tratamiento: anticoagulación, fibrinolisis intraarterial en casos seleccionados.</li>
+</ul>
+
+<h3>9.7 Trombosis de vena renal</h3>
+<ul>
+<li>Causas: SN (sobre todo membranosa), tumor renal con trombo cava, deshidratación neonatal, hipercoagulabilidad.</li>
+<li>Clínica: dolor lumbar, hematuria, IR si bilateral.</li>
+<li>Diagnóstico: TC con contraste, RM.</li>
+<li>Tratamiento: anticoagulación.</li>
+</ul>
+
+<h3>9.8 Preguntas — N9</h3>
+
+<details class="qa"><summary>1. (Ord 2025) HTA reciente + diabético + IR + EPA flash + soplo abdominal</summary>
+<div class="qa-body">
+<p>Paciente de 65 a. con HTA reciente, DM. Cr 1,5, proteinuria 0,8 g. Ingresa por EPA. EF: soplo abdominal. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>Nefropatía isquémica</strong></li>
+<li>HTA esencial</li>
+<li>Nefroangioesclerosis</li>
+<li>Tromboembolismo arterial</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> EPA "flash" en anciano con HTA reciente y soplo abdominal = nefropatía isquémica por estenosis bilateral de arterias renales (o única funcionante). Confirmar con eco Doppler o angio-TC. Tratamiento: revascularización endovascular si funcional o conservador.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Mujer joven con IRA + MAT + ADAMTS13 normal</summary>
+<div class="qa-body">
+<p>Mujer de 20 a. con malestar, oliguria tras IRA respiratoria. TA 190/110. Hb 7,8, plaq 60.000, esquistocitos &gt; 2 %, Cr 6, LDH ↑, BR indirecta 4. Orina: proteinuria 0,2 g, 10 hematíes/c. ADAMTS13 normal. ¿Sospecha?</p>
+<ol type="a">
+<li>Púrpura trombótica trombocitopénica</li>
+<li>SHU típico</li>
+<li>CID</li>
+<li><strong>SHU atípico</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> MAT (anemia hemolítica microangiopática + trombopenia + IRA) con ADAMTS13 normal → SHU atípico (desregulación del complemento, factor H/I). Tratamiento: <em>eculizumab</em> (anti-C5). El típico requiere antecedente de diarrea sanguinolenta + Shiga toxin. PTT tendría ADAMTS13 &lt; 10 %.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) LES + MAT + ADAMTS13 normal</summary>
+<div class="qa-body">
+<p>Paciente de 45 a. con LES, IRA + anemia hemolítica microangiopática + trombopenia. ADAMTS13 normal. ¿Diagnóstico?</p>
+<ol type="a">
+<li>SHU típico</li>
+<li>Enfermedad ateroembólica</li>
+<li>PTT</li>
+<li><strong>SUH atípico secundario</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> MAT secundaria a LES (a veces con SAF asociado/catastrófico). ADAMTS13 normal descarta PTT. Tratamiento: corticoides + plasmaféresis + eculizumab en algunos casos.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Varón &gt; 60 a. con HTA renovascular</summary>
+<div class="qa-body">
+<p>Causa más frecuente de HTA renovascular en varones &gt; 60 a.:</p>
+<ol type="a">
+<li>Displasia fibromuscular</li>
+<li><strong>Estenosis de arteria renal aterosclerótica</strong></li>
+<li>Tromboembolismo arterial</li>
+<li>Enfermedad ateroembólica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En adultos &gt; 60 a. con FRCV, la causa es aterosclerótica. La displasia fibromuscular es típica de mujeres jóvenes 15-50 a. ("collar de cuentas").</div>
+</div></details>
+
+</section>
+
+<!-- =============== N10 =============== -->
+<section class="card" id="n10">
+<h2 class="section-title"><span class="num">N10</span>Insuficiencia renal aguda (IRA)</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Disminución brusca de la función renal en horas o días, reversible potencialmente. Mortalidad hospitalaria 10-50 % según gravedad.</li>
+<li><strong>Definición KDIGO 2012:</strong> cualquiera de los siguientes:
+  <ul>
+    <li>↑ Cr ≥ <em>0,3 mg/dL en 48 h</em>, o</li>
+    <li>↑ Cr ≥ 1,5 × basal en los últimos 7 días, o</li>
+    <li>Diuresis &lt; 0,5 mL/kg/h durante &gt; 6 h.</li>
+  </ul>
+</li>
+<li><strong>Clasificación KDIGO en estadios:</strong>
+  <ul>
+    <li>Estadio 1: ↑ Cr 1,5-1,9 × basal o ≥ 0,3.</li>
+    <li>Estadio 2: ↑ Cr 2-2,9 ×.</li>
+    <li>Estadio 3: ↑ Cr ≥ 3 × o ≥ 4 mg/dL o inicio de TRS.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>10.1 Etiología por tipos</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Causas</th><th>Mecanismo</th></tr></thead>
+<tbody>
+<tr><td><strong>Prerrenal (60-70 %)</strong></td><td>Hipovolemia (diarrea, vómitos, hemorragia, diuréticos), sepsis, IC, cirrosis (síndrome hepatorrenal), shock cardiogénico, AINE, IECA/ARA-II, ciclosporina/tacrolimús</td><td>↓ perfusión renal con parénquima intacto. Si se mantiene → NTA isquémica</td></tr>
+<tr><td><strong>Renal intrínseca</strong></td><td>
+<ul style="margin:0;padding-left:14px">
+<li><em>NTA</em> isquémica (continuación de prerrenal mantenida) o tóxica (aminoglucósidos, contrastes yodados, anfotericina B, cisplatino, vancomicina, foscarnet, mioglobinuria por rabdomiolisis, hemoglobinuria)</li>
+<li><em>GN aguda</em> (post-infecciosa, ANCA, anti-MBG, lúpica)</li>
+<li><em>NIA</em> (fármacos, infecciones, autoinmune)</li>
+<li><em>MAT</em> (PTT, SHU)</li>
+<li><em>Vasculitis</em></li>
+<li><em>Embolia ateromatosa</em> (post-cateterismo)</li>
+</ul>
+</td><td>Daño del parénquima</td></tr>
+<tr><td><strong>Posrrenal / obstructiva</strong></td><td>HBP (la más frecuente en ancianos varones), tumor pélvico, litiasis bilateral, fibrosis retroperitoneal, ligadura ureteral iatrogénica, vejiga neurógena</td><td>Obstrucción al flujo urinario. Bilateral o sobre riñón único</td></tr>
+</tbody></table></div>
+
+<h3>10.2 Patrón urinario para diferenciar prerrenal vs NTA</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Parámetro</th><th>Prerrenal</th><th>NTA</th></tr></thead>
+<tbody>
+<tr><td>Na urinario (mEq/L)</td><td><strong>&lt; 20</strong></td><td><strong>&gt; 40</strong></td></tr>
+<tr><td><strong>FENa</strong> (%)</td><td><strong>&lt; 1</strong></td><td><strong>&gt; 2</strong></td></tr>
+<tr><td>FEurea (%)</td><td>&lt; 35</td><td>&gt; 50</td></tr>
+<tr><td>Osmolaridad U (mOsm/kg)</td><td>&gt; 500</td><td>&lt; 350 (isostenuria)</td></tr>
+<tr><td>Urea / Cr</td><td>&gt; 20</td><td>10-15</td></tr>
+<tr><td>Densidad urinaria</td><td>&gt; 1.020</td><td>1.010</td></tr>
+<tr><td>Sedimento</td><td>Normal o cilindros hialinos</td><td>Cilindros granulosos pigmentados (céreos), células tubulares</td></tr>
+<tr><td>Respuesta a fluidos</td><td>Mejoría rápida</td><td>Sin mejoría</td></tr>
+</tbody></table></div>
+<p><em>FENa = (Na orina / Na plasma) / (Cr orina / Cr plasma) × 100</em></p>
+<p>Limitaciones: <em>FENa puede ser &lt; 1 % en NTA por contrastes, mioglobinuria, sepsis precoz, GN, ateroembolia</em>. Diuréticos invalidan FENa (usar FEurea, que no depende del diurético).</p>
+
+<h3>10.3 Diagnóstico</h3>
+<ol>
+<li><strong>Anamnesis</strong>: AP, fármacos (revisión completa), tóxicos, contrastes, intervenciones recientes, infecciones, traumatismos.</li>
+<li><strong>Exploración:</strong> volemia (TA, FC, signos de deshidratación, ingurgitación yugular), edemas, signos de obstrucción (globo vesical, próstata), signos cutáneos (livedo, púrpura, exantema).</li>
+<li><strong>Bioquímica sangre y orina simultáneas:</strong> Cr, urea, Na, K, osmolaridad. Calcular FENa, FEurea.</li>
+<li><strong>Sedimento urinario:</strong> cilindros, hematíes, leucocitos, eosinófilos.</li>
+<li><strong>Proteinuria</strong> (cuantificar).</li>
+<li><strong>Ecografía renal:</strong> descartar obstrucción (hidronefrosis), evaluar tamaño y simetría.</li>
+<li><strong>Inmunología</strong> (si sospecha de GN/vasculitis): ANA, anti-DNAn, ANCA, anti-MBG, complemento, crioglobulinas, electroforesis sérica y cadenas ligeras libres, serologías VHB/VHC/VIH.</li>
+<li><strong>Biopsia renal:</strong> en IRA de causa no clara, sospecha de GN o vasculitis, IRA persistente sin recuperación.</li>
+</ol>
+
+<h3>10.4 Tratamiento</h3>
+
+<h4>Prerrenal</h4>
+<ul>
+<li><em>Corregir la hipovolemia</em>: cristaloides (suero salino 0,9 % o Ringer lactato) hasta restablecer perfusión.</li>
+<li>Tratar shock séptico con fluidos + vasopresores (noradrenalina).</li>
+<li>Mejorar gasto cardíaco si IC.</li>
+<li>Retirar AINE, IECA/ARA-II si descompensan.</li>
+</ul>
+
+<h4>NTA</h4>
+<ul>
+<li>Soporte: fluidos balanceados, control hidroelectrolítico y ácido-base.</li>
+<li>Retirar nefrotóxicos.</li>
+<li>Ajustar dosis de fármacos según FG.</li>
+<li><em>NO furosemida</em> rutinariamente (no acelera recuperación, sí controla la sobrecarga).</li>
+<li><em>NO dopamina dosis renal</em> (no eficaz, riesgo de arritmias).</li>
+<li>Diálisis si necesidad.</li>
+</ul>
+
+<h4>Obstructiva</h4>
+<ul>
+<li>Sondaje vesical inmediato (obstrucción baja).</li>
+<li>Nefrostomía o doble J en obstrucción alta.</li>
+<li>Tratamiento etiológico (litiasis, tumor, HBP).</li>
+<li>Vigilar <em>poliuria postobstructiva</em>: reposición de líquidos para evitar deshidratación.</li>
+</ul>
+
+<h4>Indicaciones de diálisis (TRS) urgente en IRA</h4>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">⚠</span>Memorizar "AEIOU"</div>
+<ul style="margin:6px 0">
+<li><strong>A</strong>cidosis metabólica severa refractaria (pH &lt; 7,1).</li>
+<li><strong>E</strong>lectrolitos: hiperpotasemia &gt; 6,5 mEq/L refractaria.</li>
+<li><strong>I</strong>ntoxicaciones dializables (metanol, etilenglicol, salicilatos, litio, metformina).</li>
+<li><strong>O</strong>verload de volumen refractario (EAP).</li>
+<li><strong>U</strong>remia sintomática (encefalopatía, pericarditis, hemorragias).</li>
+</ul>
+</div>
+
+<h3>10.5 Síndrome hepatorrenal (SHR)</h3>
+<ul>
+<li>IRA prerrenal en paciente con cirrosis e hipertensión portal por vasoconstricción intrarrenal pese a hipovolemia efectiva.</li>
+<li>Diagnóstico de exclusión.</li>
+<li>Tipos:
+  <ul>
+    <li>SHR-AKI (antes tipo 1): IRA rápidamente progresiva.</li>
+    <li>SHR-CKD (antes tipo 2): progresión lenta.</li>
+  </ul>
+</li>
+<li>Tratamiento: <em>albúmina + terlipresina</em> (1ª línea) o noradrenalina si no terlipresina. TIPS, trasplante hepático.</li>
+</ul>
+
+<h3>10.6 Nefropatía por contrastes</h3>
+<p>↑ Cr 0,3 mg/dL o 25 % en 48-72 h tras contraste yodado. FR: ERC previa, DM, deshidratación, IC, edad, mieloma, dosis alta de contraste. Prevención: hidratación con SF/bicarbonato isotónico, suspender nefrotóxicos, evitar contraste si FGe &lt; 30. <em>N-acetilcisteína controvertida</em>.</p>
+
+<h3>10.7 Preguntas — N10</h3>
+
+<details class="qa"><summary>1. (Ord 2025) HTA + ↑ Cr brusco sin sedimento — siguiente paso</summary>
+<div class="qa-body">
+<p>Paciente de 60 a. con HTA sin tratamiento, ↓ volumen urinario y edemas. Cr 4 (normal hace 2 m), urea 100. Sedimento normal. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Biopsia renal</li>
+<li>Administrar diurético y bioquímica de orina</li>
+<li><strong>Bioquímica de sangre y orina simultáneas</strong></li>
+<li>Rx abdomen</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Para clasificar la IRA: bioquímica simultánea sangre + orina permite calcular FENa, urea/Cr, osmolaridad → distinguir prerrenal vs renal vs posrenal. Antes que biopsia o diuréticos.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Patrón urinario de IRA prerrenal</summary>
+<div class="qa-body">
+<p>El patrón urinario característico de la depleción de volumen arterial efectivo con fracaso renal agudo prerrenal consiste en:</p>
+<ol type="a">
+<li>Oliguria con orina isotónica y sodio bajo</li>
+<li>Diuresis conservada con osmolaridad alta</li>
+<li>Diuresis conservada con sodio bajo</li>
+<li><strong>Oliguria con osmolaridad alta y sodio bajo</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> IRA prerrenal: el riñón responde con oliguria + máxima concentración (osmU &gt; 500) + máximo ahorro de Na (NaU &lt; 20, FENa &lt; 1 %). Si se da diurético se "borra" este patrón.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Definición KDIGO de IRA</summary>
+<div class="qa-body">
+<p>¿Cuál de las siguientes condiciones define la presencia de IRA según KDIGO?</p>
+<ol type="a">
+<li><strong>Aumento de creatinina sérica ≥ 0,3 mg/dL en 48 horas</strong></li>
+<li>Urea sérica ≥ 30 mg/dL</li>
+<li>Volumen urinario &lt; 2 mL/kg/h durante 4 horas</li>
+<li>Ácido úrico &gt; 8 mg/dL</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> KDIGO: ↑ Cr ≥ 0,3 en 48 h, o ≥ 1,5 × basal en 7 días, o diuresis &lt; 0,5 mL/kg/h durante &gt; 6 h. La urea y úrico no son criterios.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Ord 2025) IRA con FENa &lt; 1 % — primera medida</summary>
+<div class="qa-body">
+<p>Paciente con vómitos, hipotensión, oliguria. Cr 3, Na urinario &lt; 10, FENa &lt; 1 %. ¿Primera medida?</p>
+<ol type="a">
+<li>Restricción proteica</li>
+<li>Forzar diuresis con furosemida</li>
+<li>Restringir líquidos</li>
+<li><strong>Corregir la hipovolemia</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Patrón prerrenal (FENa &lt; 1 %) → repleción de volumen con suero salino isotónico. NO restringir líquidos (empeora). NO forzar diuresis (depleta más).</div>
+</div></details>
+
+</section>
+
+<!-- =============== N11 =============== -->
+<section class="card" id="n11">
+<h2 class="section-title"><span class="num">N11</span>Enfermedad renal crónica (ERC)</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Definición KDIGO:</strong> alteración estructural o funcional renal durante &gt; 3 meses, manifestada por:
+  <ul>
+    <li>FGe &lt; 60 mL/min/1,73 m², O</li>
+    <li>Marcadores de daño renal (albuminuria ≥ 30 mg/g, alteración del sedimento, alteración estructural en imagen, alteración histológica, alteración electrolítica de origen tubular).</li>
+  </ul>
+</li>
+<li><strong>Epidemiología:</strong> 10-15 % de la población. ↑↑ con edad, DM, HTA, obesidad. 1ª causa de muerte: <em>enfermedad cardiovascular</em>.</li>
+<li><strong>Causas más frecuentes:</strong>
+  <ul>
+    <li>Nefropatía diabética (la 1ª).</li>
+    <li>Nefroangioesclerosis (HTA).</li>
+    <li>GN crónicas.</li>
+    <li>Hereditarias (PQRAD).</li>
+    <li>NIC.</li>
+    <li>Etiología desconocida.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>11.1 Clasificación KDIGO (G + A)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Estadio G</th><th>FGe (mL/min/1,73 m²)</th><th>Descripción</th></tr></thead>
+<tbody>
+<tr><td>G1</td><td>≥ 90</td><td>Normal o elevado, con daño renal</td></tr>
+<tr><td>G2</td><td>60-89</td><td>Leve ↓, con daño renal</td></tr>
+<tr><td>G3a</td><td>45-59</td><td>↓ Leve-moderada</td></tr>
+<tr><td>G3b</td><td>30-44</td><td>↓ Moderada-severa</td></tr>
+<tr><td>G4</td><td>15-29</td><td>↓ Severa · prediálisis</td></tr>
+<tr><td>G5</td><td>&lt; 15 o diálisis</td><td>Falla renal terminal</td></tr>
+</tbody></table></div>
+<div class="table-wrap"><table>
+<thead><tr><th>Albuminuria A</th><th>UACR (mg/g)</th><th>Descripción</th></tr></thead>
+<tbody>
+<tr><td>A1</td><td>&lt; 30</td><td>Normal o leve</td></tr>
+<tr><td>A2</td><td>30-300</td><td>Moderada (microalbuminuria)</td></tr>
+<tr><td>A3</td><td>&gt; 300</td><td>Severa (macroalbuminuria)</td></tr>
+</tbody></table></div>
+<p>La estadificación combinada permite estratificar el riesgo: <em>verde-amarillo-naranja-rojo</em>. Una combinación G3aA3 tiene más riesgo que G3aA1.</p>
+
+<h3>11.2 Mecanismos de progresión</h3>
+<p>Cuando se pierden nefronas, las restantes hipertrofian y se hiperfiltran → ↑ presión intraglomerular → glomerulosclerosis secundaria → mayor pérdida de nefronas → ciclo vicioso. Factores aceleradores: HTA, proteinuria, hiperglucemia, dislipemia, tabaco, obesidad, hiperuricemia, acidosis.</p>
+
+<h3>11.3 Complicaciones de la ERC</h3>
+
+<h4>Cardiovascular (1ª causa de muerte)</h4>
+<ul>
+<li>HTA (90 % de pacientes con ERC).</li>
+<li>Hipertrofia ventricular izquierda.</li>
+<li>Aterosclerosis acelerada.</li>
+<li>Calcificación vascular (calcificación de la media — calciphylaxis en estadios avanzados).</li>
+<li>Pericarditis urémica.</li>
+</ul>
+
+<h4>Anemia</h4>
+<ul>
+<li>Déficit de EPO (a partir de FGe &lt; 60). Normocítica normocrómica.</li>
+<li>Objetivo Hb 10-12 g/dL (no sobrecorregir → aumenta eventos CV).</li>
+<li>Tratamiento: hierro (oral o iv) + agentes estimulantes de la eritropoyesis (EPO, darbepoetina, metoxi-PEG-epoetina) + nuevos: HIF-PHI (roxadustat, daprodustat).</li>
+</ul>
+
+<h4>Alteraciones del metabolismo mineral-óseo (CKD-MBD)</h4>
+<ul>
+<li><em>Hiperfosforemia</em> por ↓ excreción renal.</li>
+<li>↑ <em>FGF-23</em> (compensatorio para mantener fosforemia normal inicialmente).</li>
+<li>↓ <em>calcitriol</em> (1,25-OH-D₃) por ↓ 1α-hidroxilasa renal.</li>
+<li>Hipocalcemia y resistencia ósea a PTH → <em>hiperparatiroidismo secundario</em>.</li>
+<li>Lesiones óseas: osteítis fibrosa quística (alto recambio), enfermedad ósea adinámica, osteomalacia, enfermedad mixta.</li>
+<li>Calcificación vascular y tisular.</li>
+<li>Tratamiento:
+  <ul>
+    <li>Restricción dietética de P (lácteos, conservas, refrescos).</li>
+    <li><em>Quelantes de fósforo</em> con las comidas: cálcicos (acetato cálcico, carbonato cálcico — riesgo de hipercalcemia) y no cálcicos (sevelámero, carbonato de lantano).</li>
+    <li><em>Análogos de vitamina D activa</em>: calcitriol, paricalcitol.</li>
+    <li><em>Calcimiméticos</em>: cinacalcet, etelcalcetida — ↓ PTH.</li>
+    <li>Paratiroidectomía si HPS terciario refractario.</li>
+  </ul>
+</li>
+</ul>
+
+<h4>Acidosis metabólica</h4>
+<ul>
+<li>↓ excreción de H⁺ y ↓ regeneración de HCO₃ → acidosis metabólica con AG normal inicial, luego con AG elevado en estadios avanzados.</li>
+<li>Consecuencias: catabolismo proteico, sarcopenia, osteopenia, mayor progresión de la ERC.</li>
+<li>Tratamiento: <em>bicarbonato sódico oral</em> si HCO₃ sérico &lt; 22 mEq/L (objetivo ≥ 22).</li>
+</ul>
+
+<h4>Hiperpotasemia</h4>
+<p>Restricción dietética, evitar fármacos que retienen K (IECA/ARA-II/espironolactona en exceso), resinas de intercambio (patiromer, ciclosilicato de Zr).</p>
+
+<h4>Síndrome urémico</h4>
+<p>En estadios muy avanzados (FGe &lt; 15): astenia, anorexia, náuseas, prurito, encefalopatía, neuropatía, pericarditis, hemorragias por disfunción plaquetaria (DDAVP en urgencias).</p>
+
+<h4>Otras</h4>
+<ul>
+<li>Dislipemia: ↑ triglicéridos, ↓ HDL.</li>
+<li>Trastornos endocrinos: hiperparatiroidismo, hipogonadismo, hipotiroidismo subclínico, resistencia a la insulina.</li>
+<li>Inmunodepresión: ↑ infecciones.</li>
+<li>Desnutrición proteico-calórica.</li>
+</ul>
+
+<h3>11.4 Tratamiento nefroprotector (todos los pacientes)</h3>
+<ul>
+<li><strong>Control de TA</strong> &lt; 130/80 con <em>IECA o ARA-II</em> de elección (especialmente si proteinuria).</li>
+<li><strong>Control glucémico</strong> si DM: HbA1c &lt; 7-7,5 %. Preferir <em>iSGLT2</em> + agonistas GLP-1.</li>
+<li><strong>iSGLT2 (dapagliflozina, empagliflozina)</strong>: en todo paciente con ERC y albuminuria, con o sin DM, hasta FGe ≥ 20 mL/min. Reduce progresión y mortalidad CV.</li>
+<li><strong>Finerenona</strong> en DM2 con albuminuria + IECA/ARA-II + iSGLT2.</li>
+<li>Restricción de sodio (&lt; 5 g/d).</li>
+<li>Restricción proteica moderada (0,6-0,8 g/kg/d).</li>
+<li>Estatinas (todos los pacientes con ERC + FRCV ≥ 50 a.).</li>
+<li>Cese de tabaco, pérdida de peso, actividad física.</li>
+<li>Vigilar y evitar nefrotóxicos (AINE, contrastes, aminoglucósidos).</li>
+<li>Vacunación (gripe, neumococo, hepatitis B, COVID).</li>
+</ul>
+
+<h3>11.5 Preparación para TRS</h3>
+<ul>
+<li>Referir a Nefrología cuando FGe &lt; 30 (G4) — planificar TRS.</li>
+<li>Educación sobre opciones: HD, DP, trasplante (incluso preemptivo de donante vivo).</li>
+<li>Crear acceso vascular (FAV nativa) 3-6 meses antes de prever inicio de HD.</li>
+<li>Vacunación VHB (mejor respuesta antes de diálisis).</li>
+<li>Inicio de TRS cuando indicado clínicamente, no por cifra fija de FG.</li>
+</ul>
+
+<h3>11.6 Preguntas — N11</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Clasificar ERC: FGe 42, UACR 45</summary>
+<div class="qa-body">
+<p>Paciente de 68 a. con HTA y DM2. FGe 42 mL/min, UACR 45 mg/g. ¿Estadio KDIGO?</p>
+<ol type="a">
+<li>G2A2</li>
+<li>G3aA1</li>
+<li><strong>G3bA2</strong></li>
+<li>G4A3</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> FGe 42 = G3b (30-44). UACR 45 = A2 (30-300). Por tanto G3bA2.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Acidosis metabólica en ERC — manejo</summary>
+<div class="qa-body">
+<p>Paciente con ERC y acidosis metabólica. ¿Razón principal y objetivo del tratamiento?</p>
+<ol type="a">
+<li>Aumento de excreción de bicarbonato; mantener pH &lt; 7,2</li>
+<li><strong>Incapacidad de excreción de hidrogeniones; mantener HCO₃ ≥ 22 mEq/L</strong></li>
+<li>Aumento de producción de ácidos orgánicos; disminuir ingesta proteica</li>
+<li>Disminución de reabsorción de bicarbonato; aumentar ingesta de calcio</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En ERC el riñón es incapaz de excretar H⁺. Tratamiento: bicarbonato sódico oral si HCO₃ &lt; 22. Esto mejora la sarcopenia, ralentiza progresión y mejora supervivencia.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) ERC con FGe 25 y UACR 150</summary>
+<div class="qa-body">
+<p>ERC con FGe 25 y UACR 150. ¿Estadio?</p>
+<ol type="a">
+<li>4A2</li>
+<li><strong>4A2 (G4A2)</strong></li>
+<li>3bA1</li>
+<li>5A3</li>
+</ol>
+<div class="answer"><strong>Respuesta: la opción del banco UGR es 4A2.</strong> FGe 25 = G4 (15-29). UACR 150 = A2 (30-300). Por tanto G4A2.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Histología de ERC avanzada</summary>
+<div class="qa-body">
+<p>¿Característica histológica de la ERC avanzada independiente de la etiología?</p>
+<ol type="a">
+<li><strong>Glomérulos con esclerosis</strong></li>
+<li>Necrosis tubular aguda</li>
+<li>Tubulitis</li>
+<li>Nefritis intersticial aguda</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Estadio final común de la ERC = glomeruloesclerosis + fibrosis intersticial + atrofia tubular (independiente de la causa inicial).</div>
+</div></details>
+
+</section>
+
+<!-- =============== N12 =============== -->
+<section class="card" id="n12">
+<h2 class="section-title"><span class="num">N12</span>Tratamiento sustitutivo: diálisis y trasplante renal</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Tres modalidades de TRS: <strong>hemodiálisis (HD)</strong>, <strong>diálisis peritoneal (DP)</strong>, <strong>trasplante renal</strong>.</li>
+<li>El trasplante es el tratamiento de elección. La diálisis es puente o alternativa cuando trasplante no es viable.</li>
+</ul>
+</div>
+
+<h3>12.1 Indicaciones de inicio de TRS en ERC</h3>
+<p>No hay un FG fijo. Se inicia cuando aparecen síntomas o complicaciones no controlables:</p>
+<ul>
+<li><strong>Uremia sintomática</strong>: encefalopatía, neuropatía, pericarditis, asterixis, sangrado por disfunción plaquetaria.</li>
+<li><strong>Hiperpotasemia refractaria</strong> (K &gt; 6,5 a pesar de tratamiento médico).</li>
+<li><strong>Acidosis metabólica severa</strong> (pH &lt; 7,1 / HCO₃ &lt; 12) refractaria.</li>
+<li><strong>Sobrecarga de volumen refractaria</strong> a diuréticos (EAP recurrente).</li>
+<li>Desnutrición proteica progresiva.</li>
+<li>Síntomas constitucionales graves.</li>
+<li>Habitualmente FGe 6-10 mL/min, pero individualizar. <em>La oliguria aislada o la inapetencia ocasional NO son indicación</em> por sí solos.</li>
+</ul>
+
+<h3>12.2 Principios físicos de la diálisis</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Difusión</span><span class="v">Paso de solutos a través de membrana semipermeable según gradiente de concentración. <strong>Mecanismo principal de transporte de solutos en HD y DP</strong>. Elimina solutos pequeños (urea, K, Cr)</span></div>
+<div class="kv"><span class="k">Convección</span><span class="v">Arrastre de solutos junto con el agua (solvente) por gradiente de presión hidrostática. <em>Elimina mejor solutos medianos</em> (β2-microglobulina). Base de la hemodiafiltración</span></div>
+<div class="kv"><span class="k">Ultrafiltración (UF)</span><span class="v">Eliminación de agua del compartimento sanguíneo por gradiente de presión hidrostática. Permite controlar el peso del paciente</span></div>
+<div class="kv"><span class="k">Adsorción</span><span class="v">Algunos solutos se adhieren a la membrana (variable)</span></div>
+</div>
+
+<h3>12.3 Hemodiálisis (HD)</h3>
+<ul>
+<li><strong>Principio:</strong> sangre del paciente atraviesa un filtro/dializador con líquido de diálisis en contracorriente → difusión + UF.</li>
+<li><strong>Sesiones:</strong> 3-4 h, 3 veces/semana (estándar). HD diaria, HD nocturna prolongada como variantes.</li>
+<li><strong>Accesos vasculares:</strong>
+  <ul>
+    <li><em>Fístula arteriovenosa (FAV) nativa</em>: 1ª elección. Radio-cefálica (Brescia-Cimino) la preferida. Madura 4-6 sem.</li>
+    <li><em>Prótesis de PTFE (injerto)</em>: si vasos malos.</li>
+    <li><em>Catéter venoso central (yugular interna o femoral)</em>: temporal o tunelizado de larga duración. Mayor infección y trombosis.</li>
+  </ul>
+</li>
+<li><strong>Hemodiafiltración online postdilucional:</strong> combina HD (difusión) + alta convección con líquido de reposición ultrapuro. <em>Volumen convectivo &gt; 23 L/sesión</em> = mejor supervivencia (ESHOL trial).</li>
+<li><strong>Complicaciones agudas:</strong>
+  <ul>
+    <li>Hipotensión intradiálisis (la más frecuente — UF excesiva).</li>
+    <li>Calambres musculares.</li>
+    <li>Síndrome de desequilibrio osmótico (edema cerebral por descenso brusco de urea — sobre todo al inicio).</li>
+    <li>Reacciones de hipersensibilidad a la membrana.</li>
+    <li>Embolia gaseosa.</li>
+  </ul>
+</li>
+<li><strong>Complicaciones crónicas:</strong>
+  <ul>
+    <li>Cardiovascular (1ª causa de muerte en HD).</li>
+    <li>Infecciones del acceso (S. aureus + frecuente; bacteriemias).</li>
+    <li>Amiloidosis por β2-microglobulina (síndrome del túnel del carpo).</li>
+    <li>Anemia, alteraciones MBD.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>12.4 Diálisis peritoneal (DP)</h3>
+<ul>
+<li><strong>Principio:</strong> el peritoneo es la membrana semipermeable. Se introduce solución de DP en cavidad peritoneal por catéter de Tenckhoff. Solutos pasan por difusión; UF por gradiente osmótico (glucosa hipertónica, icodextrina).</li>
+<li><strong>Modalidades:</strong>
+  <ul>
+    <li><em>DPCA (DP continua ambulatoria)</em>: 4 intercambios manuales/día.</li>
+    <li><em>DPA (DP automatizada nocturna)</em>: cicladora durante la noche, día seco o con un intercambio.</li>
+  </ul>
+</li>
+<li><strong>Ventajas:</strong> domiciliaria, autonomía, sin acceso vascular, preservación de la función renal residual.</li>
+<li><strong>Inconvenientes:</strong> sobrecarga peritoneal, pérdida de proteínas, riesgo de peritonitis.</li>
+<li><strong>Complicaciones:</strong>
+  <ul>
+    <li><strong>Peritonitis</strong> (principal complicación):
+      <ul>
+        <li>Clínica: dolor abdominal + líquido turbio.</li>
+        <li>Diagnóstico: <em>recuento leucocitario en efluente &gt; 100 cél/µL con &gt; 50 % PMN</em> + cultivo.</li>
+        <li>Etiología: S. epidermidis (lo más frecuente), S. aureus, BGN, hongos.</li>
+        <li>Tratamiento: <em>antibioterapia intraperitoneal empírica inmediata</em> (vancomicina + ceftazidima o aminoglucósido); ajustar según antibiograma. Retirar catéter si peritonitis fúngica, micobacteriana o refractaria.</li>
+      </ul>
+    </li>
+    <li>Infección del orificio de salida o túnel.</li>
+    <li>Fallo de la UF.</li>
+    <li>Hernias, hidrotórax.</li>
+    <li>Esclerosis peritoneal encapsulante (rara, tardía, grave).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>12.5 Trasplante renal</h3>
+<p>Ya descrito ampliamente en <a href="#u5">U5</a>. Resumen de aspectos nefrológicos clave:</p>
+<ul>
+<li>Tratamiento de elección: mejor supervivencia y calidad de vida que diálisis.</li>
+<li>Trasplante <em>preemptivo</em> (antes de diálisis) preferido si donante vivo disponible.</li>
+<li><strong>Factores de sensibilización inmunológica</strong> (↑ PRA, dificultan encontrar donante compatible):
+  <ul>
+    <li>Transfusiones sanguíneas previas.</li>
+    <li>Embarazos.</li>
+    <li>Trasplante renal previo.</li>
+    <li><em>NO sensibilizan</em>: infecciones de repetición, ITU.</li>
+  </ul>
+</li>
+<li>Compatibilidad HLA evaluada por antígenos A, B, DR y DQ (8/8 = máxima).</li>
+<li>Crossmatch (+) = contraindicación absoluta.</li>
+<li>Trasplante ABO incompatible: posible con desensibilización (plasmaféresis, rituximab).</li>
+<li>Trasplante cruzado: pares donante-receptor incompatibles intercambian.</li>
+</ul>
+
+<h3>12.6 Comparación entre modalidades de TRS</h3>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>Hemodiálisis</th><th>Diálisis peritoneal</th><th>Trasplante</th></tr></thead>
+<tbody>
+<tr><td>Lugar</td><td>Centro hospitalario</td><td>Domicilio</td><td>Tras alta hospitalaria</td></tr>
+<tr><td>Frecuencia</td><td>3-4 h × 3/sem</td><td>Diaria (4 intercambios/d o nocturna)</td><td>—</td></tr>
+<tr><td>Autonomía</td><td>Baja</td><td>Alta</td><td>Máxima</td></tr>
+<tr><td>Calidad de vida</td><td>Media</td><td>Alta</td><td>Mejor</td></tr>
+<tr><td>Supervivencia</td><td>~85 % al 1er año</td><td>Similar a HD</td><td>~95 % al 1er año, &gt;80 % a 5 a.</td></tr>
+<tr><td>Complicación temida</td><td>Infección de FAV / catéter, eventos CV</td><td>Peritonitis</td><td>Rechazo, infecciones oportunistas, neoplasias</td></tr>
+</tbody></table></div>
+
+<h3>12.7 Preguntas — N12</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Hemodiafiltración online — factor crucial</summary>
+<div class="qa-body">
+<p>Paciente con ERC en hemodiafiltración online postdilucional. ¿Qué factor es crucial para optimizar la eliminación de toxinas urémicas?</p>
+<ol type="a">
+<li><strong>Alto volumen convectivo</strong></li>
+<li>Bajo flujo de sangre</li>
+<li>Bajo coeficiente de ultrafiltración (Kuf)</li>
+<li>Membrana de celulosa</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> En HDF, mayor volumen convectivo (&gt; 23 L/sesión) = mejor eliminación de moléculas medianas (β2-microglobulina) y mejor supervivencia (ESHOL trial).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) DP con líquido turbio y dolor abdominal</summary>
+<div class="qa-body">
+<p>Paciente en DP con líquido peritoneal turbio y dolor abdominal. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Aumentar eritropoyetina</li>
+<li>Ajustar glucosa del líquido</li>
+<li><strong>Recuento leucocitario y cultivo del líquido + antibioterapia intraperitoneal empírica</strong></li>
+<li>Suspender DP y pasar a HD</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Peritonitis (diagnóstico: &gt; 100 leucocitos/µL con &gt; 50 % PMN). Hemocultivo + cultivo del efluente. ATB intraperitoneal empírico inmediato (vancomicina + ceftazidima o aminoglucósido).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Indicación NO de diálisis</summary>
+<div class="qa-body">
+<p>¿Cuál NO es indicación para iniciar TRS con diálisis en ERC?</p>
+<ol type="a">
+<li>Oliguria</li>
+<li>Hiperpotasemia severa que no responde</li>
+<li>Acidosis metabólica severa (pH &lt; 7,2)</li>
+<li><strong>Inapetencia esporádica</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Inapetencia esporádica no es indicación. Sí lo son: uremia sintomática, hiperpotasemia refractaria, acidosis severa, sobrecarga refractaria, pericarditis urémica.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Principios físicos de la diálisis — INCORRECTO</summary>
+<div class="qa-body">
+<p>Sobre los principios físicos de la diálisis, señale lo INCORRECTO:</p>
+<ol type="a">
+<li>Difusión + convección dan lugar al proceso de diálisis</li>
+<li><strong>La convección consiste en una membrana semipermeable con poros que permiten únicamente el paso de solutos del compartimento sanguíneo al de líquido de diálisis</strong></li>
+<li>La convección permite eliminar el exceso de líquido mediante un gradiente de presión hidrostática, permitiendo también el paso de algunos solutos</li>
+<li>La difusión es el principal mecanismo de transporte de solutos</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Esa definición corresponde a la <em>difusión</em>, no a la convección. La convección es el arrastre de solutos junto con el agua por gradiente de presión.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Factor que NO causa sensibilización inmunológica</summary>
+<div class="qa-body">
+<p>¿Cuál condición NO es factor de riesgo para sensibilización inmunológica del paciente con ERC potencial receptor de trasplante?</p>
+<ol type="a">
+<li>Transfusiones sanguíneas previas</li>
+<li><strong>Infecciones de repetición</strong></li>
+<li>Embarazos</li>
+<li>Trasplante renal previo</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Los factores que sensibilizan (↑ PRA) son los que exponen al sistema inmune a HLA extraños: transfusiones, embarazos, trasplantes previos. Las infecciones bacterianas comunes NO sensibilizan.</div>
+</div></details>
+
+</section>
+
+<!-- ============================================================ -->
+<!-- BLOQUE C · INFECCIOSAS -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="bloque-c">
+  <h2>🦠 BLOQUE C · ENFERMEDADES INFECCIOSAS</h2>
+  <div class="b-sub">17 temas · 43 preguntas en el examen (la sección más amplia)</div>
+</div>
+
+<!-- =============== I1 =============== -->
+<section class="card" id="i1">
+<h2 class="section-title"><span class="num">I1</span>Sepsis y shock séptico</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Definiciones Sepsis-3 (2016):</strong>
+  <ul>
+    <li><strong>Sepsis</strong> = disfunción orgánica potencialmente letal causada por una respuesta desregulada del huésped a la infección. Operativamente: ↑ SOFA ≥ 2 puntos en contexto de infección.</li>
+    <li><strong>Shock séptico</strong> = sepsis + <em>hipotensión persistente que requiere vasopresores para mantener PAM ≥ 65 mmHg + lactato &gt; 2 mmol/L</em> a pesar de reposición adecuada de líquidos.</li>
+    <li><em>qSOFA</em> (cribado): FR ≥ 22, alteración mental (Glasgow &lt; 15), PAS ≤ 100. Si ≥ 2 → alta sospecha.</li>
+  </ul>
+</li>
+<li><strong>Bundle de la 1ª hora (Surviving Sepsis 2021):</strong>
+  <ol>
+    <li>Medir lactato.</li>
+    <li>Hemocultivos x2 (antes de antibiótico si no demora).</li>
+    <li><strong>Antibiótico empírico amplio espectro &lt; 1 hora</strong>.</li>
+    <li>Cristaloides 30 mL/kg en 3 h si hipotensión o lactato ≥ 4.</li>
+    <li>Vasopresores (<em>noradrenalina</em> 1ª línea) si PAM &lt; 65 tras fluidos.</li>
+  </ol>
+</li>
+<li><strong>Focos más frecuentes:</strong> respiratorio (40 %), urinario (25 %), abdominal (20 %), bacteriémico de catéter.</li>
+</ul>
+</div>
+
+<h3>1.1 Preguntas — I1</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Diabético con ITU + fiebre + hipotensión + lactato 3,5</summary>
+<div class="qa-body">
+<p>Paciente de 68 a. con DM e ITU reciente. Fiebre + confusión + taquicardia + PAS 85. FR 24, SatO₂ 94 %, diuresis escasa. Lactato 3,5. ¿Qué corresponde al diagnóstico de shock séptico según los criterios actuales?</p>
+<ol type="a">
+<li>Hipotensión que responde a fluidoterapia, sin necesidad de vasopresores</li>
+<li><strong>Sepsis con hipotensión persistente que requiere vasopresores para mantener PAM ≥ 65 mmHg y lactato &gt; 2 mmol/L a pesar de reposición adecuada de líquidos</strong></li>
+<li>Fiebre, taquicardia y leucocitosis con infección documentada</li>
+<li>Disfunción de órganos sin alteración hemodinámica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Definición Sepsis-3 de shock séptico. La opción c es sepsis (antigua SIRS). La opción d no es shock.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Sepsis urinaria — primera medida</summary>
+<div class="qa-body">
+<p>Varón de 65 a. con fiebre, hipotensión (85/50), taquicardia, confusión y oliguria. Se sospecha sepsis de origen urinario. ¿Acción más importante en la primera hora tras hemocultivos?</p>
+<ol type="a">
+<li><strong>Reanimación con cristaloides y administrar antibioterapia empírica</strong></li>
+<li>Iniciar nutrición parenteral</li>
+<li>Administrar β-bloqueantes</li>
+<li>Solicitar TAC abdominal</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Bundle de la 1ª hora: hemocultivos + antibiótico empírico + cristaloides 30 mL/kg. Imagen para localizar foco (TAC) después si no es obvio.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Anciano con sepsis biliar — manejo</summary>
+<div class="qa-body">
+<p>Varón de 72 a. con fiebre, dolor en hipocondrio derecho, vómitos. Hipotenso, taquicárdico, confuso, leucocitosis. ECO: vesícula distendida con pared engrosada, líquido perivesicular. Diagnóstico: sepsis por colecistitis. ¿Conducta inicial?</p>
+<ol type="a">
+<li><strong>Iniciar antibióticos amplio espectro tras hemocultivos + reanimación con líquidos + valoración quirúrgica urgente</strong></li>
+<li>Analgesia y observación</li>
+<li>Colecistectomía electiva tras estabilización total</li>
+<li>Antibióticos orales y alta domiciliaria</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Sepsis biliar grave = ATB iv empírico (piperacilina-tazobactam o ceftriaxona+metronidazol) + reanimación + valoración para colecistectomía urgente o colecistostomía percutánea si inestable.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Sepsis por catéter — postoperatorio</summary>
+<div class="qa-body">
+<p>Postoperado de cáncer gástrico. Fiebre + SatO₂ 90 % + TA 89/54. Se hacen cultivos de luces del catéter. ¿Tratamiento empírico?</p>
+<ol type="a">
+<li>Meropenem + linezolid + fluconazol</li>
+<li><strong>Meropenem + linezolid + caspofungina</strong></li>
+<li>Ertapenem + linezolid + caspofungina</li>
+<li>Ertapenem + linezolid + voriconazol</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Sepsis por catéter en postquirúrgico = cobertura amplia: meropenem (Gram−, Pseudomonas) + linezolid o vancomicina (MRSA, enterococo) + <em>equinocandina</em> (caspofungina) por riesgo de candidemia (NPT, catéter, postcirugía).</div>
+</div></details>
+
+</section>
+
+<!-- =============== I2 =============== -->
+<section class="card" id="i2">
+<h2 class="section-title"><span class="num">I2</span>Uso adecuado de antibióticos</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Tipos de antibioterapia:</strong>
+  <ul>
+    <li><em>Empírica</em>: tratamiento basado en microorganismos más probables, antes del antibiograma.</li>
+    <li><em>Dirigida</em>: tras identificar el germen y antibiograma. Reducir espectro (descalada).</li>
+    <li><em>Profiláctica</em>: prevenir infección (cirugía, contactos).</li>
+    <li><em>Secuencial</em>: pasar de iv a oral cuando el paciente está estable y mejorando.</li>
+  </ul>
+</li>
+<li><strong>Conceptos clave:</strong>
+  <ul>
+    <li>PK/PD: tiempo-dependientes (β-lactámicos: ↑ t &gt; MIC) vs concentración-dependientes (aminoglucósidos, quinolonas: ↑ Cmax/MIC).</li>
+    <li><em>De-escalada</em>: reducir espectro al recibir antibiograma → menos resistencias, menos daño microbiota.</li>
+    <li><em>BLEE</em>: betalactamasas de espectro extendido. <em>E. coli, Klebsiella</em>. Tratamiento: <strong>carbapenémicos</strong> (ertapenem, meropenem, imipenem). Piperacilina-tazobactam menos eficaz.</li>
+    <li><em>Cuidado con quinolonas</em>: efectos adversos serios (tendinopatía/rotura, prolongación QT, neuropatía, aneurisma aórtico). Reservar para casos específicos.</li>
+  </ul>
+</li>
+<li><strong>Cistitis simple no complicada (mujer):</strong> fosfomicina trometamol DU o nitrofurantoína 5 días. <em>NO usar quinolonas como primera línea</em>.</li>
+<li><strong>PNA no complicada con alergia a penicilina:</strong> aztreonam (monobactámico, no reactividad cruzada significativa con β-lactámicos) o quinolona.</li>
+</ul>
+</div>
+
+<h3>2.1 Preguntas — I2</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Anciano institucionalizado con bacteriemia por E. coli BLEE</summary>
+<div class="qa-body">
+<p>Varón de 82 a. institucionalizado, con fiebre, leucocitosis marcada y deterioro general. Hemocultivos: <em>E. coli BLEE</em>. ¿Antibiótico indicado?</p>
+<ol type="a">
+<li>Piperacilina-tazobactam</li>
+<li><strong>Ertapenem</strong></li>
+<li>Ceftazidima</li>
+<li>Levofloxacino</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> BLEE → carbapenémico (ertapenem si no Pseudomonas, meropenem si grave). Piperacilina-tazobactam puede fallar (no recomendado como 1ª línea en bacteriemia BLEE — estudio MERINO).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) PNA en mujer con anafilaxia a penicilina</summary>
+<div class="qa-body">
+<p>Mujer de 63 a. con DM2, fiebre + dolor lumbar bilateral + escalofríos. Antecedente de anafilaxia a penicilina. Urocultivo pendiente. ¿Tratamiento empírico?</p>
+<ol type="a">
+<li>Amoxicilina-clavulánico</li>
+<li>Ceftriaxona</li>
+<li><strong>Aztreonam</strong></li>
+<li>Ciprofloxacino</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Anafilaxia a penicilina → evitar todos los β-lactámicos. <em>Aztreonam</em> (monobactámico) tiene baja reactividad cruzada y cubre Gram−. Ciprofloxacino sería alternativa pero el banco UGR marca aztreonam por la PNA en mujer (cipro tiene resistencias E. coli ↑).</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Antibioterapia dirigida — definición</summary>
+<div class="qa-body">
+<p>Sobre el manejo antibiótico, ¿cuál define correctamente el concepto de "antibioterapia dirigida"?</p>
+<ol type="a">
+<li>Empírica: siempre dirigida al germen aislado</li>
+<li>Secuencial: cambiar a antibiótico de mayor espectro</li>
+<li><strong>Dirigida: basada en el antibiograma del germen aislado</strong></li>
+<li>Profilaxis: utilizada para tratar infecciones establecidas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Dirigida = tras antibiograma. Empírica = antes. Secuencial = paso de iv a oral. Profilaxis = prevenir, no tratar.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Cistitis simple — tratamiento empírico</summary>
+<div class="qa-body">
+<p>Mujer de 35 a. sin antecedentes con disuria leve y polaquiuria, sin fiebre ni dolor lumbar. ¿Tratamiento empírico de elección?</p>
+<ol type="a">
+<li>Ciprofloxacino oral</li>
+<li><strong>Fosfomicina trometamol dosis única</strong></li>
+<li>Amoxicilina-clavulánico</li>
+<li>Meropenem</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cistitis simple en mujer joven sana = fosfomicina 3 g DU (preferido) o nitrofurantoína 5 días. Las quinolonas son alternativa pero NO 1ª línea (efectos adversos, resistencias).</div>
+</div></details>
+
+</section>
+
+<!-- =============== I3 =============== -->
+<section class="card" id="i3">
+<h2 class="section-title"><span class="num">I3</span>Infecciones intraabdominales · anaerobios</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las infecciones intraabdominales son la segunda causa de sepsis grave tras las respiratorias.</li>
+<li>Mayoría son <em>polimicrobianas</em>, con bacterias entéricas (Gram negativos aerobios + anaerobios).</li>
+<li>El tratamiento se basa en <strong>3 pilares: control del foco (drenaje quirúrgico/percutáneo) + antibioterapia + soporte</strong>.</li>
+</ul>
+</div>
+
+<h3>3.1 Clasificación de la peritonitis</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Etiología</th><th>Tratamiento empírico</th></tr></thead>
+<tbody>
+<tr><td><strong>Primaria (PBE)</strong></td><td>Cirrótico con ascitis. Líquido ascítico con &gt; 250 PMN/µL. Monomicrobiana (E. coli, Klebsiella, S. pneumoniae)</td><td>Ceftriaxona 2 g/24 h iv 5-7 d + albúmina 1,5 g/kg día 1 y 1 g/kg día 3 (reduce mortalidad y SHR). Profilaxis secundaria con norfloxacino</td></tr>
+<tr><td><strong>Secundaria</strong></td><td>Perforación de víscera hueca (apendicitis, diverticulitis, úlcera péptica, isquemia intestinal, cirugía). Polimicrobiana</td><td><em>Comunitaria leve-moderada</em>: ceftriaxona + metronidazol, amoxiclav, ertapenem. <em>Grave o nosocomial</em>: piperacilina-tazobactam, meropenem ± vancomicina ± antifúngico</td></tr>
+<tr><td><strong>Terciaria</strong></td><td>Peritonitis persistente o recurrente tras tratamiento, UCI. Multirresistentes, hongos (Candida)</td><td>Cobertura amplia + antifúngico (equinocandina o fluconazol)</td></tr>
+<tr><td><strong>Asociada a DP</strong></td><td>Catéter de DP. S. epidermidis (lo más frecuente), S. aureus, BGN, hongos</td><td>Vancomicina + ceftazidima IP. Retirar catéter si fúngica/refractaria</td></tr>
+</tbody></table></div>
+
+<h3>3.2 Abscesos intraabdominales</h3>
+<ul>
+<li>Colecciones purulentas localizadas tras peritonitis o cirugía abdominal.</li>
+<li>Localizaciones típicas: subfrénicos, subhepáticos, pélvicos, interasas, retroperitoneales.</li>
+<li><strong>Diagnóstico:</strong> <em>TC abdominal con contraste</em> (prueba de elección). Ecografía útil para abdomen superior.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Drenaje</em>: percutáneo guiado por TC/ECO (preferido) o quirúrgico.</li>
+    <li>ATB amplio espectro 7-14 días.</li>
+    <li>Soporte y control de la fuente.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>3.3 Apendicitis aguda</h3>
+<ul>
+<li>Causa más frecuente de abdomen agudo quirúrgico.</li>
+<li>Clínica: dolor periumbilical que migra a fosa iliaca derecha (Punto de McBurney), fiebre, anorexia, leucocitosis. Signos: Blumberg, Rovsing, psoas, obturador.</li>
+<li>Diagnóstico: clínica + eco/TC (criterios de Alvarado).</li>
+<li>Tratamiento: <em>apendicectomía laparoscópica</em>. ATB perioperatorio (ceftriaxona + metronidazol o piperacilina-tazo según gravedad).</li>
+</ul>
+
+<h3>3.4 Colecistitis y colangitis</h3>
+<ul>
+<li><strong>Colecistitis aguda:</strong> dolor HCD + Murphy + fiebre. Gold standard ECO: pared engrosada, signo Murphy ecográfico. Tratamiento: piperacilina-tazo o ceftriaxona + metronidazol + colecistectomía precoz (en 72 h).</li>
+<li><strong>Colangitis aguda:</strong> tríada de <em>Charcot</em> (dolor HCD + fiebre + ictericia) o péntada de <em>Reynolds</em> (+ confusión + shock). Cobertura ATB amplia (piperacilina-tazo o carbapenem) + <em>CPRE urgente con esfinterotomía y drenaje</em>.</li>
+</ul>
+
+<h3>3.5 Diverticulitis aguda</h3>
+<ul>
+<li>Inflamación de divertículos colónicos (sobre todo sigma). Mayores de 60 años.</li>
+<li>Clínica: dolor en fosa iliaca izquierda + fiebre + alteración del tránsito.</li>
+<li>Clasificación de Hinchey (I-IV).</li>
+<li>Tratamiento: ATB (amoxiclav, ciprofloxacino + metronidazol) ± reposo intestinal. Cirugía urgente si perforación libre o peritonitis fecaloidea.</li>
+</ul>
+
+<h3>3.6 Infecciones por anaerobios</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Anaerobio</th><th>Cuadros</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Bacteroides fragilis</strong></td><td>Abdominales (la mayoría), pélvicas. Productor de β-lactamasas</td><td>Metronidazol, clindamicina, amoxiclav, piperacilina-tazobactam, carbapenémicos, tigeciclina</td></tr>
+<tr><td>Clostridium difficile</td><td>Diarrea post-ATB → colitis pseudomembranosa</td><td>Fidaxomicina o vancomicina oral</td></tr>
+<tr><td>Clostridium perfringens</td><td>Gangrena gaseosa (mionecrosis tras traumatismo), gastroenteritis</td><td>Cirugía urgente + penicilina + clindamicina (toxinas)</td></tr>
+<tr><td>Fusobacterium necrophorum</td><td>Síndrome de Lemierre (faringitis + tromboflebitis yugular interna + émbolos sépticos pulmonares)</td><td>Amoxiclav o cefalosporina + metronidazol; anticoagulación discutida</td></tr>
+<tr><td>Prevotella, Peptostreptococcus</td><td>Cavidad oral, infecciones odontológicas, neumonía aspirativa</td><td>Amoxiclav, clindamicina</td></tr>
+<tr><td>Actinomyces</td><td>Cervicofacial, pélvica (DIU), abdominal</td><td>Penicilina prolongada (6-12 meses)</td></tr>
+</tbody></table></div>
+
+<h3>3.7 Infección por Clostridioides difficile</h3>
+<ul>
+<li>Productor de toxinas A y B. Asociado al uso de antibióticos (sobre todo clindamicina, quinolonas, cefalosporinas, amoxiclav) + hospitalización + IBP + edad &gt; 65 a.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Leve-moderada: diarrea acuosa ≥ 3 deposiciones/d, fiebre, dolor abdominal, leucocitosis.</li>
+    <li>Grave: leucocitos &gt; 15.000, Cr ↑, distensión, íleo.</li>
+    <li>Fulminante: shock, megacolon tóxico, perforación.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Solo en heces <em>diarreicas</em>, salvo íleo.</li>
+    <li>Algoritmo 2 pasos: <em>GDH (antígeno) + toxina A/B por EIA</em>; si discordancia → <em>PCR de toxina</em> confirmatoria.</li>
+    <li>Coprocultivo y Gram NO útiles (la flora normal incluye C. difficile no toxigénico).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Retirar ATB causal si posible.</li>
+    <li>Episodio inicial leve-moderado: <em>fidaxomicina 200 mg/12 h × 10 d (1ª línea)</em> o vancomicina oral 125 mg/6 h × 10 d.</li>
+    <li>Episodio grave: vancomicina oral ± metronidazol iv si íleo.</li>
+    <li>Fulminante: vancomicina oral en altas dosis ± fidaxomicina + metronidazol iv ± cirugía (colectomía).</li>
+    <li>Recurrencia: fidaxomicina, vancomicina en pauta prolongada/pulsada, <em>trasplante de microbiota fecal</em> (TMF) si ≥ 2 recidivas, bezlotoxumab (anticuerpo anti-toxina B) como profilaxis.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>3.8 Preguntas — I3</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Peritonitis postquirúrgica de colon — empírico</summary>
+<div class="qa-body">
+<p>Varón de 70 a. intervenido por perforación de colon sigmoide, con peritonitis asociada. ¿Cobertura empírica inicial?</p>
+<ol type="a">
+<li><strong>Ceftriaxona + metronidazol</strong></li>
+<li>Ciprofloxacino</li>
+<li>Meropenem</li>
+<li>Amoxicilina-clavulánico + fluconazol</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Peritonitis secundaria comunitaria (perforación de colon) = Gram− entéricos + anaerobios. Ceftriaxona + metronidazol clásico. Si gravedad o factores de riesgo nosocomiales → piperacilina-tazobactam o meropenem.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Extra 2025) Absceso intraabdominal — actitud</summary>
+<div class="qa-body">
+<p>Varón de 64 a. con cirugía abdominal por perforación de colon. 72 h postop: fiebre, dolor localizado, 18.000 leucos, PCR 231. Sospecha de absceso intraabdominal. ¿Actitud?</p>
+<ol type="a">
+<li>Escalar antibioterapia</li>
+<li><strong>Realizar TC abdominal</strong></li>
+<li>Añadir antifúngico empírico</li>
+<li>Drenaje quirúrgico</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Primero <em>diagnosticar y localizar</em> con TC. Después drenar (percutáneo si abordable, quirúrgico si no) + ATB. No escalar a ciegas ni añadir antifúngico empírico sin datos.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Diarrea por C. difficile tras quinolona</summary>
+<div class="qa-body">
+<p>Mujer de 70 a. ingresada tras cirugía abdominal. Diarrea acuosa (6 deposiciones/24 h) + fiebre. Tomó ciprofloxacino semanas previas. ¿Diagnóstico correcto sobre <em>C. difficile</em>?</p>
+<ol type="a">
+<li><strong>Detección de toxina mediante inmunoanálisis enzimático + confirmación con PCR de la toxina</strong></li>
+<li>Analizar heces aunque sean formadas si antecedentes de ATB</li>
+<li>El cultivo de heces es la prueba de elección</li>
+<li>Coprocultivo general + tinción de Gram</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Diagnóstico: algoritmo de dos pasos = GDH + toxina A/B por EIA, confirmación con PCR si hay discordancia. Solo se analizan heces DIARREICAS (no formadas). El coprocultivo y Gram no son útiles.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I4 =============== -->
+<section class="card" id="i4">
+<h2 class="section-title"><span class="num">I4</span>Infecciones de piel y partes blandas · fascitis necrosante</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Infecciones cutáneas: muy frecuentes en la consulta y urgencias. Espectro de gravedad: desde superficiales (impétigo) a profundas y potencialmente mortales (fascitis necrosante, gangrena gaseosa).</li>
+<li>El elemento clave es <strong>diferenciar infecciones no complicadas de las complicadas y/o necrosantes</strong> que requieren desbridamiento quirúrgico urgente.</li>
+</ul>
+</div>
+
+<h3>4.1 Infecciones superficiales</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Entidad</th><th>Etiología</th><th>Clínica</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Impétigo</strong></td><td>S. pyogenes &gt; S. aureus</td><td>Costras melicéricas, ampollas (impétigo ampolloso por S. aureus)</td><td>Mupirocina o ácido fusídico tópico. Cefalexina o amoxiclav oral si extenso</td></tr>
+<tr><td><strong>Ectima</strong></td><td>S. pyogenes</td><td>Úlcera con costra adherente, cura con cicatriz</td><td>ATB oral (amoxiclav)</td></tr>
+<tr><td><strong>Foliculitis</strong></td><td>S. aureus (también Pseudomonas en jacuzzi)</td><td>Pústulas centradas en folículo piloso, prurito</td><td>Antisépticos + mupirocina. Casos extensos: cefalexina</td></tr>
+<tr><td><strong>Forúnculo</strong></td><td>S. aureus</td><td>Nódulo doloroso con centro purulento</td><td>Drenaje quirúrgico si fluctuante + ATB si sistémicos/MRSA</td></tr>
+<tr><td><strong>Ántrax</strong> (carbunclo cutáneo)</td><td>S. aureus</td><td>Conglomerado de forúnculos. Diabéticos. NO confundir con "anthrax" (Bacillus anthracis)</td><td>Drenaje + ATB sistémico</td></tr>
+</tbody></table></div>
+
+<h3>4.2 Erisipela vs celulitis</h3>
+<div class="compare">
+<div>
+<h4>Erisipela</h4>
+<ul>
+<li>Dermo-hipodermitis aguda <em>superficial</em></li>
+<li>Etiología: <strong>S. pyogenes</strong> casi siempre</li>
+<li><strong>Bordes bien delimitados, sobreelevados, eritema brillante "lengua de fuego"</strong></li>
+<li>Fiebre alta, linfangitis, adenopatías</li>
+<li>Localización: cara (50 %) o MMII</li>
+<li>Factores: linfedema, úlceras, intertrigo, herida cutánea pequeña</li>
+<li>Tratamiento: <em>penicilina o amoxicilina</em> oral o iv 10-14 d</li>
+</ul>
+</div>
+<div>
+<h4>Celulitis</h4>
+<ul>
+<li>Dermo-hipodermitis <em>profunda</em></li>
+<li>Etiología: S. aureus + S. pyogenes</li>
+<li><strong>Bordes mal definidos</strong>, eritema, calor, edema</li>
+<li>Puede haber linfangitis, adenopatías</li>
+<li>Localización: cualquier área traumatizada</li>
+<li>Tratamiento: <em>cefalexina, amoxiclav, cloxacilina</em>. Cobertura MRSA (clindamicina, TMP-SMX, doxiciclina) si comunidad con alta prevalencia</li>
+</ul>
+</div>
+</div>
+
+<h3>4.3 Abscesos cutáneos</h3>
+<ul>
+<li>Colección localizada de pus en piel o partes blandas.</li>
+<li>Etiología: <em>S. aureus</em> (CA-MRSA cada vez más).</li>
+<li>Tratamiento: <strong>incisión y drenaje</strong> (suficiente si pequeño, sin sistémicos ni factores de riesgo MRSA).</li>
+<li>Añadir ATB si: tamaño grande, celulitis circundante, sistémicos, inmunodeprimido, localización facial central o perineal, fracaso del drenaje.</li>
+</ul>
+
+<h3>4.4 Fascitis necrosante (FN) y otras infecciones necrosantes</h3>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🚨</span>Emergencia quirúrgica</div>
+<ul style="margin:6px 0">
+<li><strong>Dolor desproporcionado a los hallazgos cutáneos</strong> = bandera roja clave.</li>
+<li>Mal estado general, sepsis precoz.</li>
+<li>Avance rápido (horas).</li>
+<li>Bullas hemorrágicas, crepitación (gas), anestesia cutánea sobre la lesión.</li>
+<li>Imagen: TC (gas en tejidos, edema).</li>
+<li><strong>Mortalidad 25-50 %</strong> sin tratamiento agresivo.</li>
+</ul>
+</div>
+
+<h4>Clasificación</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Tipo</th><th>Etiología</th><th>Clínica</th></tr></thead>
+<tbody>
+<tr><td><strong>Tipo I (polimicrobiana)</strong></td><td>Gram+ + Gram− + anaerobios</td><td>Diabéticos, abdomen, perineo. <em>Gangrena de Fournier</em> en genitales/perineo</td></tr>
+<tr><td><strong>Tipo II (monomicrobiana)</strong></td><td><strong>S. pyogenes (grupo A)</strong> ± S. aureus</td><td>"Comecarne". Adultos sanos tras herida banal. Síndrome del shock tóxico estreptocócico (TSS)</td></tr>
+<tr><td>Tipo III</td><td><strong>Vibrio vulnificus</strong></td><td>Tras herida en agua de mar / ingesta de marisco crudo, hepatopatía crónica</td></tr>
+<tr><td>Tipo IV</td><td>Hongos (Mucor, Aspergillus)</td><td>Inmunodeprimidos</td></tr>
+<tr><td>Mionecrosis clostridial (gangrena gaseosa)</td><td><strong>Clostridium perfringens</strong></td><td>Tras herida traumática profunda. <em>Crepitación, dolor desproporcionado, gas en tejidos</em></td></tr>
+</tbody></table></div>
+
+<h4>Tratamiento</h4>
+<ol>
+<li><strong>Desbridamiento quirúrgico AGRESIVO Y URGENTE</strong> (en quirófano lo antes posible). Reseccionar todo tejido necrótico hasta encontrar tejido sano sangrante. Re-explorar cada 24-48 h.</li>
+<li><strong>ATB amplio espectro precoz</strong>:
+  <ul>
+    <li>Piperacilina-tazobactam o meropenem (Gram−, anaerobios) + <em>vancomicina o linezolid</em> (MRSA) + <em>clindamicina</em> (efecto antitoxina sobre S. pyogenes).</li>
+    <li>Penicilina G en gangrena gaseosa por Clostridium.</li>
+  </ul>
+</li>
+<li>Soporte (fluidos, vasopresores, IGIV en TSS).</li>
+<li>Oxígeno hiperbárico (adyuvante en gangrena gaseosa, controvertido).</li>
+</ol>
+
+<h3>4.5 Pie diabético</h3>
+<ul>
+<li>Combinación de neuropatía + isquemia + infección. Causa más frecuente de amputación no traumática.</li>
+<li><strong>Clasificación Wagner / Universidad de Texas</strong>: según profundidad y signos.</li>
+<li>Etiología: polimicrobiana en infecciones moderadas-graves (S. aureus, S. pyogenes, BGN, anaerobios; MRSA y Pseudomonas en factores de riesgo).</li>
+<li><strong>Osteomielitis</strong>: clínica + RM (gold standard) + biopsia ósea para cultivo.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Leve sin osteomielitis: amoxiclav 1-2 sem.</li>
+    <li>Moderada-grave: piperacilina-tazo (cubre Pseudomonas) + linezolid/vancomicina (MRSA si factor riesgo). 2-4 sem.</li>
+    <li>Osteomielitis: 4-6 sem dirigido por cultivo + revascularización si isquemia + cirugía (desbridamiento, amputación menor) + control glucémico + descarga.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>4.6 Infecciones por mordeduras</h3>
+<ul>
+<li><strong>Perro / gato:</strong> Pasteurella multocida (1ª en gatos), S. aureus, anaerobios, Capnocytophaga (esplenectomizados). Tratamiento: amoxiclav.</li>
+<li><strong>Humana:</strong> Eikenella corrodens. Amoxiclav.</li>
+<li>Considerar profilaxis antirrábica y antitetánica.</li>
+</ul>
+
+<h3>4.7 Preguntas — I4</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Mujer con lesiones costrosas perioral tras rascado</summary>
+<div class="qa-body">
+<p>Mujer de 34 a. con dermatitis atópica. Lesiones costrosas, eritematosas y pruriginosas periorales tras manipulación por rascado. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Tiña facial</li>
+<li>Erisipela</li>
+<li><strong>Impétigo</strong></li>
+<li>Foliculitis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Impétigo: costras melicéricas, sobre piel previamente irritada. Tratamiento: mupirocina tópica o ácido fusídico; oral en extensas.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Placa eritematosa bien definida y sobreelevada en pierna + fiebre 39</summary>
+<div class="qa-body">
+<p>Hombre de 40 a. con fiebre 39 ºC y placa eritematosa, caliente, dolorosa, bordes bien definidos y sobreelevados en pierna izquierda. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Celulitis</li>
+<li>Piomiositis</li>
+<li><strong>Erisipela</strong></li>
+<li>Fascitis necrosante</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Erisipela = bordes nítidos sobreelevados + S. pyogenes. Celulitis tendría bordes difusos. Tratamiento: penicilina o amoxicilina.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Anciano con dolor inguinal severo desproporcionado</summary>
+<div class="qa-body">
+<p>Hombre de 63 a. con dolor severo en ingle derecha que se extiende a la pierna. Dolor desproporcionado a la palpación. ¿Medida prioritaria?</p>
+<ol type="a">
+<li>Cubrir Gram+, Gram−, anaerobios, BLEE, Pseudomonas y MRSA</li>
+<li>TC para ver la extensión</li>
+<li><strong>Desbridamiento quirúrgico urgente</strong></li>
+<li>Cubrir Gram+, anaerobios y MRSA</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Dolor desproporcionado + signos sistémicos = sospecha de <em>fascitis necrosante / gangrena de Fournier</em> = EMERGENCIA quirúrgica. Desbridamiento + ATB amplio simultáneamente. El TC no debe demorar la cirugía.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Foliculitis</summary>
+<div class="qa-body">
+<p>Varón de 24 a. con lesiones pustulosas centradas en folículos de la barba + picor, sin síntomas sistémicos. ¿Diagnóstico y tratamiento?</p>
+<ol type="a">
+<li><strong>Foliculitis, antisépticos y mupirocina tópica</strong></li>
+<li>Forúnculo, drenaje quirúrgico</li>
+<li>Foliculitis, amoxiclav oral</li>
+<li>Foliculitis, drenaje quirúrgico</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Foliculitis sin signos sistémicos = tópico (mupirocina, ácido fusídico). ATB oral solo si extensa o recurrente. El drenaje es para forúnculos/abscesos.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Absceso glúteo tras inyección IM</summary>
+<div class="qa-body">
+<p>Varón de 23 a. con lesión fluctuante en región glútea tras inyección IM de AINE/relajante. ¿Tratamiento prioritario?</p>
+<ol type="a">
+<li>Antibióticos amplio espectro</li>
+<li><strong>Incisión y drenaje</strong></li>
+<li>Antifúngicos tópicos</li>
+<li>Solo tratamiento si cultivo positivo</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Absceso = incisión y drenaje (suficiente solo si pequeño, sin sistémicos ni MRSA-FR). ATB añadirlos si grande, celulitis circundante, sistémicos o inmunodeprimido.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) Diabético con úlcera en talón + fiebre + leucocitosis</summary>
+<div class="qa-body">
+<p>Varón de 56 a. diabético con fiebre. Pequeña úlcera indolora en talón. ¿Actuación más correcta?</p>
+<ol type="a">
+<li>Cloxacilina empírica y RM</li>
+<li>Meropenem + TC</li>
+<li><strong>Piperacilina-tazobactam + linezolid + RM</strong></li>
+<li>TC + desbridamiento</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Pie diabético con sepsis = cobertura amplia (piperacilina-tazo Gram−/anaerobios + linezolid/vancomicina MRSA) + RM para evaluar osteomielitis. Desbridamiento es secundario tras imagen y estabilización.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I5 =============== -->
+<section class="card" id="i5">
+<h2 class="section-title"><span class="num">I5</span>Fiebre de duración intermedia en nuestra área: Coxiella, Rickettsia, Brucella y otras</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Fiebre de duración intermedia (FDI)</strong>: fiebre de 1-4 semanas sin foco evidente. Distinguir de FOD (&gt; 3 semanas con estudio negativo).</li>
+<li>En el área mediterránea, las causas más frecuentes son <em>infecciosas zoonóticas</em>: fiebre Q, rickettsiosis, brucelosis, leishmaniasis visceral, leptospirosis, fiebre tifoidea.</li>
+<li>Otras causas: TBC, endocarditis, mononucleosis, malaria importada, infecciones intracelulares (chlamydia, mycoplasma), abscesos profundos.</li>
+<li>No infecciosas: linfoma, conectivopatías (Still), enfermedad de Crohn, fármacos.</li>
+</ul>
+</div>
+
+<h3>5.1 Fiebre Q (Coxiella burnetii)</h3>
+<ul>
+<li>Cocobacilo intracelular obligado. Reservorio: <em>ganado (ovejas, cabras, vacas) y otros mamíferos</em>. Transmisión por <em>inhalación de aerosoles</em> de placentas, lana, polvo, leche cruda.</li>
+<li>Endémica en España, sobre todo País Vasco, Cataluña, Andalucía.</li>
+<li><strong>Forma aguda:</strong>
+  <ul>
+    <li>Síndrome pseudogripal + cefalea retroocular intensa.</li>
+    <li><em>Neumonía atípica</em> (frecuente; norte de España).</li>
+    <li><em>Hepatitis granulomatosa</em> (frecuente; sur de España, "fiebre Q hepática"). Granulomas en "anillo de fibrina" (fibrin ring).</li>
+    <li>Tratamiento: <em>doxiciclina 100 mg/12 h × 14-21 días</em>.</li>
+  </ul>
+</li>
+<li><strong>Forma crónica:</strong>
+  <ul>
+    <li><em>Endocarditis con hemocultivos negativos</em> (causa frecuente). Sobre todo en pacientes con valvulopatía, prótesis, inmunodeprimidos. Tratamiento: <em>doxiciclina + hidroxicloroquina &gt; 18 meses</em>.</li>
+    <li>Aortitis, osteomielitis crónica.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> serología por inmunofluorescencia indirecta.
+  <ul>
+    <li><strong>Fase II</strong> alta = aguda.</li>
+    <li><strong>Fase I</strong> alta = crónica (IgG anti-fase I &gt; 1:800).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>5.2 Rickettsiosis (familia Rickettsiaceae)</h3>
+<ul>
+<li>Bacterias intracelulares obligadas transmitidas por <em>artrópodos vectores</em>.</li>
+<li><strong>Fiebre botonosa mediterránea (Rickettsia conorii):</strong>
+  <ul>
+    <li>Endémica en cuenca mediterránea (Sierra Morena, Cazorla, Sierra de Cádiz).</li>
+    <li><em>Garrapata del perro (Rhipicephalus sanguineus)</em>.</li>
+    <li>Estacional (verano-otoño).</li>
+    <li><strong>Tríada clásica:</strong>
+      <ul>
+        <li><em>Fiebre alta</em> + escalofríos + cefalea + mialgias.</li>
+        <li><em>Exantema</em> maculopapular generalizado (incluye palmas y plantas, "botonoso").</li>
+        <li><em>Mancha negra (tache noire)</em>: escara necrótica con halo eritematoso en el sitio de la picadura (no siempre presente).</li>
+      </ul>
+    </li>
+    <li>Diagnóstico: serología IFA, PCR de la escara.</li>
+    <li>Tratamiento: <em>doxiciclina 100 mg/12 h × 7 días</em> (o hasta 48 h afebril).</li>
+  </ul>
+</li>
+<li><strong>Fiebre maculosa de las Montañas Rocosas (R. rickettsii)</strong>: EE.UU. Más grave. Doxiciclina.</li>
+<li><strong>Tifus epidémico (R. prowazekii)</strong>: piojo del cuerpo (Pediculus humanus corporis). Enfermedad de Brill-Zinsser = reactivación tardía.</li>
+<li><strong>Tifus murino (R. typhi)</strong>: pulga de la rata.</li>
+<li><strong>Tifus de los matorrales (Orientia tsutsugamushi)</strong>: ácaro. Asia.</li>
+</ul>
+
+<h3>5.3 Ehrlichiosis y anaplasmosis</h3>
+<ul>
+<li>Bacterias intracelulares (orden Rickettsiales). Garrapata.</li>
+<li><strong>Ehrlichiosis monocítica humana (E. chaffeensis)</strong>: noreste/sur de EE.UU. Mórulas en monocitos. Fiebre + cefalea + mialgias + <em>↓ leucocitos + ↓ plaquetas + ↑ transaminasas</em>.</li>
+<li><strong>Anaplasmosis (Anaplasma phagocytophilum)</strong>: zona norteamericana, también Europa. Mórulas en neutrófilos. Clínica similar.</li>
+<li>Tratamiento: doxiciclina 7-14 días.</li>
+</ul>
+
+<h3>5.4 Brucelosis</h3>
+<ul>
+<li>Cocobacilo Gram−. Especies: <em>B. melitensis</em> (cabras, ovejas — la más virulenta y prevalente en España), B. abortus (vacas), B. suis (cerdos).</li>
+<li>Transmisión: ingesta de productos lácteos no pasteurizados (queso fresco, leche cruda), contacto con animales o sus restos (carniceros, veterinarios, ganaderos), inhalación. <em>NO transmisión persona-persona</em>.</li>
+<li>Incubación 1-4 semanas.</li>
+<li><strong>Clínica</strong> ("enfermedad de los mil rostros"):
+  <ul>
+    <li>Fiebre <em>ondulante</em> (vespertina, sudoración profusa nocturna).</li>
+    <li>Astenia, anorexia, pérdida de peso.</li>
+    <li>Artralgias, mialgias.</li>
+    <li>Hepatoesplenomegalia, adenopatías.</li>
+    <li>Manifestaciones focales: <em>espondilitis lumbar</em> (más frecuente; <strong>signo de Pedro Pons = erosión del ángulo anterosuperior del cuerpo vertebral</strong>), sacroileítis, orquitis/orquiepididimitis, endocarditis (Brucella infiltrativa valvular).</li>
+    <li>Neurobrucelosis: meningitis crónica, mielitis, neuritis.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Hemocultivos prolongados (incubar &gt; 21 d, sistema Bactec) — sensibilidad mayor en fase aguda.</li>
+    <li>Serología: <em>rosa de Bengala</em> (cribado), <em>aglutinación de Wright</em> (titulación), test de Coombs anti-Brucella, ELISA.</li>
+    <li>PCR.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Forma no complicada: <em>doxiciclina 100 mg/12 h × 6 sem + gentamicina IM 5-7 mg/kg/d × 7 d</em> (preferida) o doxiciclina + rifampicina 6 sem.</li>
+    <li>Espondilitis o complicada: ≥ 12 sem.</li>
+    <li>Neurobrucelosis o endocarditis: doxi + rifampicina + ceftriaxona × 3-6 m.</li>
+    <li>Niños y embarazadas: TMP-SMX + rifampicina.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>5.5 Leishmaniasis visceral (kala-azar)</h3>
+<ul>
+<li>Leishmania infantum en mediterráneo, donovani en Asia/África. Transmitida por mosca del género Phlebotomus.</li>
+<li>Clínica: fiebre prolongada + esplenomegalia masiva + hepatomegalia + pancitopenia + caquexia.</li>
+<li>Diagnóstico: punción esplénica o de médula ósea (visualización de amastigotes), serología (rK39), PCR.</li>
+<li>Tratamiento: anfotericina B liposomal (de elección), miltefosina, antimoniales.</li>
+</ul>
+
+<h3>5.6 Fiebre tifoidea (Salmonella typhi)</h3>
+<ul>
+<li>Transmisión fecal-oral en países con saneamiento deficiente.</li>
+<li>Clínica: fiebre prolongada en escalera, bradicardia relativa (signo de Faget), roséola tifoídica (manchas eritematosas en tronco), hepatoesplenomegalia, alteración del nivel de conciencia ("tifus" = estupor).</li>
+<li>Diagnóstico: hemocultivos (1ª semana), coprocultivos (2ª-3ª semana), mielocultivo.</li>
+<li>Tratamiento: ceftriaxona o azitromicina (resistencias crecientes a quinolonas y TMP-SMX).</li>
+</ul>
+
+<h3>5.7 Preguntas — I5</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Fiebre + cefalea + exantema + escara tras Cazorla</summary>
+<div class="qa-body">
+<p>Paciente con fiebre 5 días + cefalea intensa. Estuvo en sierra de Cazorla. Exantema + escara negruzca. ¿Etiología?</p>
+<ol type="a">
+<li>Fiebre Q</li>
+<li><strong>Rickettsiosis</strong></li>
+<li>Brucelosis</li>
+<li>Leptospirosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Fiebre botonosa mediterránea: exantema + <em>tache noire</em> + verano + zona endémica. Tratamiento: doxiciclina.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Viajero EE.UU. + morulas intracitoplasmáticas en monocitos</summary>
+<div class="qa-body">
+<p>Varón de 47 a. tras viaje al noreste de EE.UU. Fiebre + cefalea + mialgias + trombopenia + ↑ transaminasas. Frotis: morulas intracitoplasmáticas en monocitos. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Leptospirosis</li>
+<li>Brucelosis</li>
+<li><strong>Anaplasmosis</strong></li>
+<li>Rickettsiosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c (banco).</strong> Las morulas en monocitos son de <em>ehrlichiosis monocítica</em> (E. chaffeensis) y en neutrófilos de <em>anaplasmosis</em> (A. phagocytophilum). Como conjunto se denominan "ehrlichiosis/anaplasmosis". Tratamiento: doxiciclina.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Brucelosis con espondilitis (Pedro Pons)</summary>
+<div class="qa-body">
+<p>Paciente de 60 a. rural con dolor de espalda, fiebre intermitente, sudoración nocturna y pérdida de peso. Rx columna: espondilitis con erosión de platillos ("signo de Pedro Pons"). ¿Tratamiento?</p>
+<ol type="a">
+<li>Amoxicilina-clavulánico</li>
+<li><strong>Doxiciclina + gentamicina</strong></li>
+<li>Ciprofloxacino</li>
+<li>Levofloxacino</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Brucelosis con espondilitis = doxiciclina 6 sem + gentamicina 2 sem (o doxi + rifampicina 6 sem). El signo de Pedro Pons es la erosión anterosuperior del cuerpo vertebral.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Coxiella tras contacto con ovejas</summary>
+<div class="qa-body">
+<p>Mujer de 50 a. con fiebre 7 días tras contacto con ovejas. Serología positiva para Coxiella burnetii en fase II. ¿Curso y tratamiento?</p>
+<ol type="a">
+<li>Infección aguda y amoxicilina</li>
+<li><strong>Infección aguda y doxiciclina</strong></li>
+<li>Infección crónica y amoxicilina</li>
+<li>Infección crónica y doxiciclina</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Fase II = aguda. Doxiciclina 14-21 días. La fase I (crónica/endocarditis) requiere doxiciclina + hidroxicloroquina &gt; 18 meses.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I6 =============== -->
+<section class="card" id="i6">
+<h2 class="section-title"><span class="num">I6</span>Endocarditis e infecciones intravasculares</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Endocarditis infecciosa (EI)</strong>: infección del endocardio, generalmente valvular. Mortalidad 15-25 % global, 50 % en prótesis/MRSA.</li>
+<li><strong>Patogenia:</strong> daño endotelial → trombo fibrino-plaquetario → bacteriemia → adhesión y crecimiento bacteriano → vegetaciones.</li>
+<li><strong>Manifestaciones clínicas:</strong>
+  <ul>
+    <li>Síndrome infeccioso: fiebre + síndrome general.</li>
+    <li>Cardíacas: soplo nuevo (insuficiencia valvular), IC.</li>
+    <li>Embolismos sépticos: ACV, infartos esplénico/renal, abscesos sistémicos, embolismo pulmonar (en endocarditis derecha de IVDU).</li>
+    <li>Fenómenos inmunológicos: glomerulonefritis, FR+, ↓ complemento, nódulos de Osler (dedos), manchas de Roth (retina), Janeway (palmas-plantas, embólicas).</li>
+    <li>Esplenomegalia, anemia.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>6.1 Etiología por contexto clínico</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Contexto</th><th>Microorganismos más frecuentes</th></tr></thead>
+<tbody>
+<tr><td><strong>Válvula nativa comunitaria</strong></td><td><em>S. viridans</em> (tras procedimientos dentales), <em>S. aureus</em>, <em>Enterococcus</em> (sobre todo en ancianos con foco GU), HACEK</td></tr>
+<tr><td><strong>Válvula nativa de catéter / nosocomial</strong></td><td><strong>S. aureus</strong> (la 1ª causa global actual), S. epidermidis, enterococo, BGN, hongos</td></tr>
+<tr><td><strong>Válvula nativa en IVDU</strong></td><td><strong>S. aureus</strong> (especialmente válvula tricúspide). Hongos, Pseudomonas</td></tr>
+<tr><td><strong>Prótesis precoz (&lt; 12 m post-implante)</strong></td><td><strong>S. epidermidis</strong> (la más frecuente), S. aureus, BGN, hongos</td></tr>
+<tr><td><strong>Prótesis tardía (&gt; 12 m)</strong></td><td>Similar a la EI nativa</td></tr>
+<tr><td><strong>Hemocultivos negativos</strong> (5-10 %)</td><td><em>HACEK</em> (Haemophilus, Aggregatibacter, Cardiobacterium, Eikenella, Kingella), <em>Coxiella</em>, <em>Bartonella</em>, <em>Brucella</em>, <em>Tropheryma whipplei</em>, hongos (Candida, Aspergillus), Mycoplasma</td></tr>
+<tr><td>Endocarditis trombótica no bacteriana (Libman-Sacks)</td><td>LES, neoplasias avanzadas (marántica)</td></tr>
+</tbody></table></div>
+
+<h3>6.2 Criterios diagnósticos de Duke modificados (Li 2023)</h3>
+
+<h4>Criterios MAYORES</h4>
+<ul>
+<li><strong>Microbiológicos:</strong>
+  <ul>
+    <li>Hemocultivos típicos (2 muestras separadas) positivos para germen típico (S. viridans, S. gallolyticus, HACEK, S. aureus, enterococo adquirido en comunidad sin foco).</li>
+    <li>Hemocultivos persistentes (&gt; 12 h separados, o ≥ 3/4 hemocultivos positivos con &gt; 1 h entre primero y último).</li>
+    <li>Cultivo o serología positiva para Coxiella, Bartonella; PCR positiva en válvula.</li>
+  </ul>
+</li>
+<li><strong>Imagen:</strong>
+  <ul>
+    <li>Eco: vegetación, absceso, pseudoaneurisma, perforación, dehiscencia protésica.</li>
+    <li>PET-TC con 18F-FDG (en prótesis &gt; 3 meses).</li>
+    <li>TC cardíaca con lesión típica.</li>
+  </ul>
+</li>
+</ul>
+
+<h4>Criterios MENORES</h4>
+<ul>
+<li>Predisposición (cardiopatía estructural, IVDU, prótesis).</li>
+<li>Fiebre &gt; 38 ºC.</li>
+<li>Fenómenos vasculares: émbolos, infartos sépticos pulmonares, aneurismas micóticos, hemorragias intracraneales/conjuntivales, manchas de Janeway.</li>
+<li>Fenómenos inmunológicos: GN, nódulos de Osler, manchas de Roth, FR+.</li>
+<li>Microbiológicos no mayores.</li>
+</ul>
+
+<h4>Diagnóstico</h4>
+<ul>
+<li><strong>Definitiva:</strong> 2 criterios mayores · O 1 mayor + 3 menores · O 5 menores.</li>
+<li><strong>Posible:</strong> 1 mayor + 1 menor · O 3 menores.</li>
+</ul>
+
+<h3>6.3 Ecocardiografía</h3>
+<ul>
+<li><strong>ETT</strong> (ecocardiograma transtorácico) — primera prueba. Sensibilidad 60-70 %.</li>
+<li><strong>ETE</strong> (transesofágico) — si:
+  <ul>
+    <li>ETT no concluyente con alta sospecha.</li>
+    <li>Prótesis valvular.</li>
+    <li>Sospecha de complicaciones (absceso, perforación).</li>
+    <li>Sensibilidad &gt; 90 %.</li>
+  </ul>
+</li>
+<li>Repetir eco si evolución clínica desfavorable.</li>
+</ul>
+
+<h3>6.4 Hemocultivos</h3>
+<ul>
+<li><strong>3 series</strong> (3 venopunciones distintas), separados &gt; 30 min, antes de iniciar ATB siempre que sea posible.</li>
+<li>Volumen suficiente (10 mL por frasco).</li>
+<li>Cultivos prolongados (3-4 semanas) si sospecha de organismos exigentes.</li>
+<li>Serologías de Coxiella, Bartonella, Brucella si hemocultivos negativos.</li>
+</ul>
+
+<h3>6.5 Tratamiento antibiótico</h3>
+
+<h4>Empírico</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Contexto</th><th>Empírico</th></tr></thead>
+<tbody>
+<tr><td>Nativa comunidad subaguda</td><td>Ampicilina + (flu)cloxacilina + gentamicina (o vancomicina + gentamicina si alergia)</td></tr>
+<tr><td>Nativa comunidad aguda</td><td>Vancomicina + gentamicina (cubrir MRSA)</td></tr>
+<tr><td>IVDU</td><td>Vancomicina iv (cubrir MRSA)</td></tr>
+<tr><td>Prótesis precoz (&lt; 12 m)</td><td>Vancomicina + gentamicina + rifampicina</td></tr>
+<tr><td>Prótesis tardía</td><td>Como nativa</td></tr>
+</tbody></table></div>
+
+<h4>Dirigido (selección)</h4>
+<ul>
+<li>S. viridans sensible a penicilina: penicilina G 4 sem (o 2 sem + gentamicina).</li>
+<li>S. aureus MSSA: cloxacilina 4-6 sem. MRSA: vancomicina o daptomicina 4-6 sem.</li>
+<li>Enterococo: ampicilina + ceftriaxona o ampicilina + gentamicina 4-6 sem.</li>
+<li>HACEK: ceftriaxona 4 sem.</li>
+<li>Coxiella: doxiciclina + hidroxicloroquina &gt; 18 m.</li>
+<li>Hongos: anfotericina B + cirugía precoz.</li>
+</ul>
+
+<h3>6.6 Indicaciones de cirugía</h3>
+<div class="box box-warning">
+<div class="box-title"><span class="icon">🔪</span>Cirugía URGENTE / temprana</div>
+<ul style="margin:6px 0">
+<li><strong>Insuficiencia cardíaca</strong> por regurgitación aguda con EAP refractario (más frecuente).</li>
+<li><strong>Infección no controlada</strong>: bacteriemia persistente &gt; 7-10 d a pesar de ATB, extensión perivalvular (absceso, pseudoaneurisma, fístula), gérmenes resistentes.</li>
+<li><strong>Riesgo embólico alto</strong>: vegetación &gt; 10 mm + embolismo previo; o vegetación &gt; 30 mm; o vegetación &gt; 15 mm con otra indicación quirúrgica.</li>
+<li>Endocarditis fúngica.</li>
+<li>Endocarditis protésica con dehiscencia, fístula, regurgitación grave.</li>
+</ul>
+</div>
+
+<h3>6.7 Profilaxis de la endocarditis</h3>
+<p>Las indicaciones se han RESTRINGIDO drásticamente. Solo en pacientes de <strong>alto riesgo</strong> ante procedimientos específicos.</p>
+
+<h4>Pacientes de alto riesgo</h4>
+<ul>
+<li>Prótesis valvular (mecánica, biológica, transcatéter, anuloplastia).</li>
+<li>Endocarditis previa.</li>
+<li>Cardiopatías congénitas cianóticas no reparadas, reparadas con material protésico residual, o reparadas hace &lt; 6 m.</li>
+<li>Trasplante cardíaco con valvulopatía.</li>
+</ul>
+
+<h4>Procedimientos con riesgo</h4>
+<ul>
+<li><strong>Procedimientos dentales que implican manipulación de tejidos gingivales, región periapical o perforación de la mucosa oral.</strong></li>
+<li>NO se da profilaxis en: cirugía digestiva, urológica, ginecológica, broncoscopia, endoscopia, parto vaginal/cesárea programada.</li>
+</ul>
+
+<h4>Pauta</h4>
+<ul>
+<li><strong>Amoxicilina 2 g VO 30-60 min antes</strong> del procedimiento.</li>
+<li>Alergia a penicilina: clindamicina 600 mg VO, azitromicina 500 mg VO.</li>
+<li>Si vía oral no posible: ampicilina 2 g IM/iv, cefazolina, ceftriaxona.</li>
+</ul>
+
+<h3>6.8 Complicaciones</h3>
+<ul>
+<li>Insuficiencia cardíaca por destrucción valvular (50 %).</li>
+<li>Embolismos sépticos: ictus (35 %), bazo, riñón, pulmón (endocarditis derecha).</li>
+<li>Aneurismas micóticos.</li>
+<li>Insuficiencia renal: GN por inmunocomplejos, ateroembólica, NTA por ATB.</li>
+<li>Sepsis, shock séptico.</li>
+</ul>
+
+<h3>6.9 Preguntas — I6</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Endocarditis con hemocultivos negativos y ETT no concluyente</summary>
+<div class="qa-body">
+<p>Paciente con fiebre persistente, valvulopatía mitral, hemocultivos negativos y ETT no concluyente, con alta sospecha clínica. ¿Conducta más adecuada?</p>
+<ol type="a">
+<li>Repetir hemocultivos e iniciar antibiótico empírico</li>
+<li>Realizar solo seguimiento clínico</li>
+<li><strong>Solicitar ecocardiograma transesofágico (ETE)</strong></li>
+<li>Realizar PET-TC de inmediato</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Cuando la sospecha es alta y el ETT no es concluyente, el siguiente paso es el ETE (mayor sensibilidad, especialmente para vegetaciones pequeñas, absceso, dehiscencia protésica).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Cirugía urgente en endocarditis</summary>
+<div class="qa-body">
+<p>Paciente de 56 a. con válvula aórtica bicúspide, fiebre, disnea aguda, EAP. Vegetación móvil 20 mm en válvula aórtica + regurgitación mitral severa. Hemocultivos: <em>Enterococcus faecium</em>. Shock cardiogénico. ¿Indicación de cirugía urgente?</p>
+<ol type="a">
+<li>Vegetación &gt; 10 mm sin embolismos previos</li>
+<li><strong>Regurgitación aguda severa con EAP refractario e inestabilidad hemodinámica</strong></li>
+<li>Fiebre persistente tras 7 días de ATB</li>
+<li>Endocarditis por microorganismo multirresistente sin IC</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Indicaciones de cirugía urgente (24-48 h): IC refractaria por regurgitación aguda con EAP, infección no controlada (extensión perivalvular, abscesos), embolias recurrentes a pesar de ATB.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Profilaxis ATB para procedimientos dentales</summary>
+<div class="qa-body">
+<p>Hombre de 52 a. con prótesis aórtica mecánica hace 2 a. Extracción dental programada. ¿Profilaxis?</p>
+<ol type="a">
+<li>Solo si enfermedad valvular nativa</li>
+<li><strong>Sí: alto riesgo (prótesis valvular) + procedimiento con manipulación gingival</strong></li>
+<li>No en ningún paciente</li>
+<li>En todos los pacientes</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Profilaxis indicada en <em>alto riesgo</em>: prótesis valvular, EI previa, cardiopatías congénitas cianóticas no reparadas. Procedimientos dentales con manipulación gingival/periapical/perforación de mucosa = amoxicilina 2 g VO 30-60 min antes.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) IVDU con endocarditis por S. aureus</summary>
+<div class="qa-body">
+<p>UDVP de 45 a. con fiebre, fatiga y soplo. Sospecha endocarditis por <em>S. aureus</em>. ¿Tratamiento inicial?</p>
+<ol type="a">
+<li>Amoxicilina oral</li>
+<li><strong>Vancomicina intravenosa</strong></li>
+<li>Ciprofloxacino oral</li>
+<li>Metronidazol iv</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> IVDU + endocarditis → cubrir MRSA con vancomicina iv (o daptomicina). Si confirma MSSA → cambiar a cloxacilina.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Prótesis valvular + fiebre — primera medida</summary>
+<div class="qa-body">
+<p>Portador de prótesis valvular consulta por fiebre. ¿Conducta inicial más adecuada?</p>
+<ol type="a">
+<li>Iniciar antibióticos empíricos inmediatamente</li>
+<li><strong>Solicitar hemocultivos y luego iniciar antibióticos empíricos</strong></li>
+<li>Realizar ecocardiografía antes de cualquier otra acción</li>
+<li>Esperar evolución clínica</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> SIEMPRE hemocultivos (3 series, distintos puntos, separados ≥ 30 min) <em>antes</em> de empezar ATB empírico. Luego ETT/ETE.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I7 =============== -->
+<section class="card" id="i7">
+<h2 class="section-title"><span class="num">I7</span>Neumonías · Legionella</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Neumonía adquirida comunidad (NAC):</strong>
+  <ul>
+    <li><em>S. pneumoniae</em> = primera causa.</li>
+    <li>Otros: <em>H. influenzae</em>, <em>Mycoplasma pneumoniae</em>, <em>Chlamydophila pneumoniae</em>, <em>Legionella</em>, virus (gripe, COVID).</li>
+  </ul>
+</li>
+<li><strong>CURB-65:</strong> Confusión + Urea &gt; 7 mmol/L + FR ≥ 30 + PAS &lt; 90 o PAD ≤ 60 + edad ≥ 65. <em>0-1 ambulatorio; 2 ingreso; ≥ 3 considerar UCI</em>.</li>
+<li><strong>Tratamiento NAC ambulatorio sin comorbilidad:</strong> amoxicilina oral 7 días o amoxiclav. Alergia: azitromicina o doxiciclina.</li>
+<li><strong>NAC hospitalizada:</strong> amoxiclav + macrólido, o cefalosporina + macrólido, o levofloxacino. Cubrir atípicos.</li>
+<li><strong>Legionella pneumophila:</strong>
+  <ul>
+    <li>Adultos mayores fumadores, brotes hospitalarios o turísticos (aerosoles).</li>
+    <li>Clínica: fiebre alta + tos seca + síntomas extrapulmonares (cefalea, diarrea, confusión) + <em>hiponatremia + ↑ CK + ↑ LDH + microhematuria</em>.</li>
+    <li>Diagnóstico: <em>antigenuria L. pneumophila serogrupo 1</em> (detecta solo el serogrupo 1, que causa 80-90 % de casos), cultivo en BCYE, PCR.</li>
+    <li>Tratamiento: <em>levofloxacino</em> o azitromicina.</li>
+  </ul>
+</li>
+<li><strong>EPOC reagudización:</strong> aumento de disnea/expectoración purulenta. ATB si Anthonisen ≥ 2 criterios (purulencia + ↑ disnea + ↑ expectoración) o purulencia + 1 otro. <em>Amoxiclav</em> 1ª línea. Sin foco o purulencia → no ATB.</li>
+<li><strong>Neumonía por aspiración:</strong> alcohólicos, ictus, ancianos. <em>Amoxiclav</em>, clindamicina si Penicilina-alergia.</li>
+<li><strong>Neumonía nosocomial / asociada a cuidados:</strong> cubrir <em>Pseudomonas, MRSA</em>.</li>
+</ul>
+</div>
+
+<h3>7.1 Preguntas — I7</h3>
+
+<details class="qa"><summary>1. (Ord 2025) NAC en EPOC anciano sin FR multirresistente</summary>
+<div class="qa-body">
+<p>Varón de 75 a. con EPOC, fiebre 38,5, disnea progresiva (SatO₂ 92 %), esputo purulento. Rx: infiltrado lobular. No hospitalización reciente. ¿Tratamiento empírico para NAC?</p>
+<ol type="a">
+<li>Ciprofloxacino oral</li>
+<li><strong>Amoxicilina-clavulánico</strong></li>
+<li>Piperacilina-tazobactam</li>
+<li>Meropenem + linezolid</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> NAC comunidad en EPOC sin factores de riesgo de Pseudomonas → amoxiclav (cubre S. pneumoniae y H. influenzae). Mejor añadir macrólido para cubrir atípicos.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Legionella — diagnóstico y tratamiento</summary>
+<div class="qa-body">
+<p>Mujer de 50 a. fumadora con neumonía hipoxémica, leucocitosis, hiponatremia. Antigenuria positiva. ¿Diagnóstico y tratamiento?</p>
+<ol type="a">
+<li>Legionella serotipo 1 + amoxiclav</li>
+<li>Neumococo + amoxiclav</li>
+<li><strong>Legionella serotipo 1 + levofloxacino</strong></li>
+<li>Legionella serotipo 4 + doxiciclina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Antigenuria detecta solo serogrupo 1 (causa 80-90 % de Legionella). Tratamiento: levofloxacino o azitromicina iv. Amoxiclav NO cubre Legionella.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Faringitis aguda — actitud</summary>
+<div class="qa-body">
+<p>Varón de 16 a. con dolor de garganta súbito, fiebre 38,3, odinofagia. No tos ni catarro. EF: faringe eritematosa sin exudados + adenopatías cervicales anteriores dolorosas. ¿Actitud?</p>
+<ol type="a">
+<li>Tratamiento sintomático</li>
+<li>Antibiótico empírico</li>
+<li><strong>Test rápido de detección de antígeno estreptocócico</strong></li>
+<li>Cultivo de exudado faríngeo</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Criterios de Centor: ausencia de tos, fiebre, adenopatías, exudados, edad. Con 3+ se hace test rápido (TDR). Si (+) → penicilina/amoxicilina 10 días. Si (−) → sintomático. NO ATB empírico de entrada en adolescentes (mononucleosis frecuente).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Gripe en diciembre — sospecha</summary>
+<div class="qa-body">
+<p>Diciembre, paciente de 35 a. con fiebre alta súbita + dolor de garganta + congestión nasal + cefalea + mialgias. AC pulmonar normal. ¿Sospecha?</p>
+<ol type="a">
+<li>Faringoamigdalitis bacteriana</li>
+<li>Neumonía bacteriana</li>
+<li><strong>Gripe (influenza)</strong></li>
+<li>Sinusitis aguda</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Estacionalidad (invierno) + síntomas sistémicos (mialgias, cefalea) + síntomas respiratorios = gripe. Test rápido confirma. Oseltamivir si &lt; 48 h.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Neumonía nosocomial con MRSA</summary>
+<div class="qa-body">
+<p>Varón de 68 a. con múltiples ingresos recientes por infecciones respiratorias (última hace 3 sem). Sat 82 %, condensación basal. ¿Qué microorganismo cubrir empíricamente?</p>
+<ol type="a">
+<li>S. pneumoniae</li>
+<li>H. influenzae</li>
+<li><strong>MRSA</strong></li>
+<li>Moraxella catarrhalis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Paciente con factores de riesgo nosocomial → cobertura contra MRSA (vancomicina/linezolid) + Pseudomonas (piperacilina-tazo, meropenem, cefepime).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) CURB-65</summary>
+<div class="qa-body">
+<p>Mujer de 68 a. con fiebre 38,7, tos, disnea. TA 95/60, FR 28, SatO₂ 93 %. Sin alteración del nivel de conciencia. Urea 40. ¿CURB-65 y actitud?</p>
+<ol type="a">
+<li>1 punto – ambulatorio</li>
+<li><strong>2 puntos – hospitalización o seguimiento estrecho</strong></li>
+<li>3 puntos – ingreso hospitalario</li>
+<li>4 puntos – considerar UCI</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> CURB-65: C (no) + U (40 mg/dL ≈ 6,7 mmol/L, &lt; 7 = NO) + R (FR 28, &lt; 30 = NO) + B (TA 95/60 cumple PAD ≤ 60 = SÍ) + 65 (68 a = SÍ) = 2 puntos.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Extra 2025) EPOC reagudización sin consolidación</summary>
+<div class="qa-body">
+<p>Varón de 75 a. con EPOC moderado, aumento de disnea habitual + expectoración purulenta, sin fiebre ni consolidación en Rx. ¿Tratamiento?</p>
+<ol type="a">
+<li>Alta sin antibióticos</li>
+<li><strong>Amoxicilina-clavulánico</strong></li>
+<li>Meropenem</li>
+<li>Azitromicina</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Reagudización EPOC con purulencia + ↑ disnea (Anthonisen ≥ 2) = amoxiclav. Sin purulencia no se da ATB. Meropenem solo si Pseudomonas grave.</div>
+</div></details>
+
+<details class="qa"><summary>8. (Ord 2025) Mononucleosis con esplenomegalia y Paul-Bunnell (+)</summary>
+<div class="qa-body">
+<p>Adolescente de 17 a. con fiebre 7 días + odinofagia intensa + adenopatías + esplenomegalia + faringitis sin exudados. Test de Paul-Bunnell (+). ¿Diagnóstico?</p>
+<ol type="a">
+<li>Mononucleosis por CMV</li>
+<li><strong>Mononucleosis por VEB</strong></li>
+<li>Faringitis estreptocócica</li>
+<li>Linfoma de Hodgkin</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Paul-Bunnell detecta anticuerpos heterófilos producidos en respuesta al VEB. Característico de mononucleosis por VEB. CMV no produce heterófilos.</div>
+</div></details>
+
+<details class="qa"><summary>9. (Extra 2025) Faringitis viral aguda</summary>
+<div class="qa-body">
+<p>Mujer de 30 a. con fiebre, odinofagia, rinorrea, malestar súbito. EF: adenopatías + congestión faríngea sin exudados. ¿Etiología más probable?</p>
+<ol type="a">
+<li>S. pyogenes</li>
+<li><strong>Adenovirus</strong></li>
+<li>Mycoplasma pneumoniae</li>
+<li>Chlamydia pneumoniae</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Faringitis vírica = la más frecuente (rinorrea + ausencia de exudados orientan a viral). Adenovirus, rinovirus, coronavirus, virus gripales. Tratamiento sintomático.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I8 =============== -->
+<section class="card" id="i8">
+<h2 class="section-title"><span class="num">I8</span>Gripe · COVID-19</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las infecciones respiratorias víricas pandémicas son la mayor amenaza sanitaria emergente. <em>Influenza</em> y <em>SARS-CoV-2</em> son los más importantes.</li>
+</ul>
+</div>
+
+<h3>8.1 Gripe (Influenza)</h3>
+<ul>
+<li><strong>Virus:</strong>
+  <ul>
+    <li><em>Influenza A</em>: causa pandemias. Subtipos H1N1, H3N2, H5N1 (aviar), H7N9. Variación antigénica: <em>drift</em> (cambios menores → epidemias) y <em>shift</em> (cambios mayores → pandemias).</li>
+    <li><em>Influenza B</em>: solo epidemias, en humanos exclusivamente.</li>
+    <li><em>Influenza C</em>: leve.</li>
+  </ul>
+</li>
+<li><strong>Epidemiología:</strong> estacional (otoño-invierno en hemisferio norte: noviembre-marzo). Transmisión aérea, gotitas, fómites.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Incubación 1-4 d.</li>
+    <li>Inicio <em>súbito</em>: fiebre alta (38-40 °C), escalofríos, cefalea, mialgias intensas, tos seca, odinofagia, malestar general, anorexia.</li>
+    <li>Duración 3-7 d. Recuperación con astenia 1-2 sem.</li>
+  </ul>
+</li>
+<li><strong>Complicaciones:</strong>
+  <ul>
+    <li><em>Neumonía vírica primaria</em>: en grupos de riesgo, rápida progresión a SDRA.</li>
+    <li><em>Neumonía bacteriana secundaria</em>: <strong>S. pneumoniae</strong> (la más frecuente), <strong>S. aureus</strong> (puede ser MRSA con cepa de Panton-Valentine — necrosante grave), H. influenzae.</li>
+    <li>Miocarditis, pericarditis.</li>
+    <li>Encefalitis, mielitis, síndrome de Guillain-Barré.</li>
+    <li>Síndrome de Reye en niños (uso de AAS).</li>
+    <li>Reagudización de comorbilidades (EPOC, IC, asma).</li>
+  </ul>
+</li>
+<li><strong>Grupos de riesgo:</strong>
+  <ul>
+    <li>&gt; 65 años.</li>
+    <li>Embarazadas (cualquier trimestre y 6 sem postparto).</li>
+    <li>Niños &lt; 5 años (sobre todo &lt; 2).</li>
+    <li>Inmunodeprimidos, oncológicos.</li>
+    <li>Comorbilidades: cardiopatía, neumopatía (asma, EPOC), DM, ERC, hepatopatía, neurológicas (epilepsia, ELA).</li>
+    <li>Obesidad mórbida (IMC ≥ 40).</li>
+    <li>Residentes en centros sociosanitarios.</li>
+    <li>Sanitarios.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li><em>Test rápido de antígeno</em> (sensibilidad 50-70 %, especificidad alta — útil en cabecera).</li>
+    <li><em>PCR / RT-PCR</em> (más sensible y específica, distingue tipo A/B y subtipo).</li>
+    <li>Cultivo (no usado clínicamente).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento antiviral:</strong>
+  <ul>
+    <li><em>Oseltamivir oral 75 mg/12 h × 5 d</em> (1ª elección). Ajuste en IR.</li>
+    <li><em>Zanamivir inhalado</em>: alternativa.</li>
+    <li><em>Baloxavir marboxil oral DU</em>: inhibidor de endonucleasa, nuevo.</li>
+    <li>Iniciar lo antes posible (idealmente &lt; 48 h, pero útil incluso después en graves).</li>
+    <li>Indicaciones: grupos de riesgo, gravedad, hospitalización, complicaciones.</li>
+    <li>En sanos sin riesgo: sintomático (paracetamol, hidratación).</li>
+  </ul>
+</li>
+<li><strong>Vacunación:</strong>
+  <ul>
+    <li>La medida más eficaz. Reduce mortalidad y complicaciones.</li>
+    <li>Anual (cepa cambia).</li>
+    <li>Vacunas inactivadas (varias plataformas) y atenuada nasal.</li>
+    <li>Grupos prioritarios: &gt; 65 a., embarazadas (segura en cualquier trimestre), comorbilidad, sanitarios, residencias, niños 6-59 m, contactos de inmunodeprimidos.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>8.2 COVID-19 (SARS-CoV-2)</h3>
+<ul>
+<li>Coronavirus emergente desde 2019. Pandemia global.</li>
+<li><strong>Transmisión:</strong> aérea (aerosoles + gotas), fómites secundarios. Incubación 2-14 d (mediana 5).</li>
+<li><strong>Espectro clínico:</strong>
+  <ul>
+    <li>Asintomático (40 %).</li>
+    <li>Leve: fiebre + tos seca + malestar + cefalea + <em>anosmia/ageusia</em> (clásica), mialgias, diarrea.</li>
+    <li>Moderado/grave: neumonía bilateral con hipoxemia (saturación &lt; 94 %), linfopenia, ↑ D-dímero, ↑ ferritina, ↑ PCR. Riesgo de SDRA, tromboembolismo, miocarditis, AKI.</li>
+    <li>Crítico: SDRA + fallo multiorgánico.</li>
+  </ul>
+</li>
+<li><strong>Factores de riesgo de gravedad:</strong> &gt; 60 a., obesidad, HTA, DM, EPOC, ERC, cardiopatía, cáncer, IS, embarazo.</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>PCR (gold standard).</li>
+    <li>Antígeno rápido (menos sensible pero específico).</li>
+    <li>Serología (post-infección/vacunación).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Ambulatorio leve: sintomático.</li>
+    <li>Alto riesgo de progresión, &lt; 5 d: <em>nirmatrelvir/ritonavir (Paxlovid)</em> oral 5 d (cuidado con interacciones).</li>
+    <li>Hospitalizado con hipoxemia: <em>dexametasona</em> 6 mg/d × 10 d + oxígeno + <em>profilaxis con HBPM</em>.</li>
+    <li>Crítico/UCI: + tocilizumab (anti-IL-6), baricitinib (JAK), remdesivir, ventilación protectora.</li>
+    <li>Anticoagulación a dosis profiláctica (HBPM) en hospitalizados.</li>
+  </ul>
+</li>
+<li><strong>Vacunación:</strong> ARNm (Pfizer, Moderna), adenovirus (Janssen, AstraZeneca), proteína recombinante. Dosis de refuerzo periódicas en grupos de riesgo.</li>
+<li><strong>COVID persistente (long COVID):</strong> síntomas &gt; 3 m: fatiga, disnea, niebla mental, anosmia, palpitaciones.</li>
+</ul>
+
+<h3>8.3 Preguntas — I8</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Diabético con gripe A confirmada — manejo</summary>
+<div class="qa-body">
+<p>Varón de 68 a. diabético, HTA. Fiebre 39, tos seca, mialgias, disnea 48 h. SatO₂ 91 %. Test rápido gripe A positivo. No vacunado. ¿Manejo?</p>
+<ol type="a">
+<li>Sintomático y reevaluar en 48 h</li>
+<li>Antibiótico empírico</li>
+<li><strong>Iniciar oseltamivir lo antes posible</strong></li>
+<li>Aislamiento domiciliario sin tratamiento específico</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Grupos de riesgo (mayor + DM + comorbilidad + hipoxemia) = oseltamivir aunque hayan pasado &gt; 48 h. Evaluar si necesita ATB para sobreinfección.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Embarazada y prevención de gripe</summary>
+<div class="qa-body">
+<p>Mujer embarazada de 28 a. en otoño. Compañera de trabajo diagnosticada de gripe. ¿Medida más eficaz para prevenir?</p>
+<ol type="a">
+<li>Vitamina C diaria</li>
+<li>Mascarilla en lugares públicos</li>
+<li><strong>Vacunación antigripal</strong></li>
+<li>Evitar cambios bruscos de temperatura</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Vacunación antigripal está indicada en TODAS las embarazadas (vacuna inactivada, segura). Reduce complicaciones para madre y feto.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Gripe en sano — tratamiento</summary>
+<div class="qa-body">
+<p>Hombre de 45 a. sano con fiebre alta + mialgias + tos seca 36 h. Sin signos de alarma. Test rápido gripe positivo. ¿Conducta?</p>
+<ol type="a">
+<li>Antibiótico amplio espectro</li>
+<li><strong>Tratamiento sintomático y reposo</strong></li>
+<li>Corticoides sistémicos inmediato</li>
+<li>Antivirales solo si &gt; 72 h</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Paciente sano sin factores de riesgo y sin signos de gravedad → sintomático. Oseltamivir solo si grupo de riesgo o gravedad.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I9 =============== -->
+<section class="card" id="i9">
+<h2 class="section-title"><span class="num">I9</span>Infecciones en inmigrantes y viajeros</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Malaria (paludismo):</strong>
+  <ul>
+    <li>Especies: <em>P. falciparum</em> (la más grave, África subsahariana), P. vivax (recidivas), P. ovale, P. malariae, P. knowlesi.</li>
+    <li>Clínica: fiebre + escalofríos + sudoración (paroxismos cada 48 o 72 h según especie) + esplenomegalia + anemia. En P. falciparum: malaria cerebral, IRA, edema pulmonar, hipoglucemia, acidosis.</li>
+    <li>Diagnóstico: <em>frotis grueso y fino + test rápido</em>.</li>
+    <li>Tratamiento:
+      <ul>
+        <li><em>P. falciparum grave: ARTESUNATO IV</em> (de elección, sustituye a quinina iv).</li>
+        <li>No complicada: artemeter-lumefantrina, atovaquona-proguanilo.</li>
+        <li>P. vivax/ovale: cloroquina + <em>primaquina</em> (eliminar hipnozoítos hepáticos).</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>Amebiasis (E. histolytica):</strong> diarrea sanguinolenta, absceso hepático ("anchoa"). Diagnóstico: serología, PCR. Tratamiento: <em>metronidazol + paromomicina</em> (luminal).</li>
+<li><strong>Esquistosomiasis:</strong>
+  <ul>
+    <li><em>S. haematobium</em>: África. Hematuria, fibrosis vesical, carcinoma escamoso.</li>
+    <li><em>S. mansoni</em>: Sudamérica/África. Hepato-esplénica, hipertensión portal.</li>
+    <li>Tratamiento: <em>praziquantel</em>.</li>
+    <li>Diagnóstico: huevos en orina (haematobium) o heces (mansoni). <em>Avisar al laboratorio</em>.</li>
+  </ul>
+</li>
+<li><strong>Fiebre de Katayama:</strong> reacción de hipersensibilidad a esquistosomas en fase aguda. Fiebre + eosinofilia + tos.</li>
+<li><strong>Eosinofilia en inmigrante sin causa aclarada:</strong> tratamiento empírico con <em>albendazol + praziquantel + ivermectina</em> (cubre nematodos, cestodos, Strongyloides).</li>
+<li><strong>Chagas (T. cruzi):</strong> Latinoamérica. Fase aguda asintomática o leve (chagoma, signo de Romaña). Fase crónica: <em>cardiopatía dilatada (miocardiopatía chagásica), megaesófago, megacolon</em>. Tratamiento: <em>benznidazol o nifurtimox</em>; eficaz en fase aguda y limitada en crónica.</li>
+<li><strong>Tripanosomiasis africana (T. brucei):</strong> "enfermedad del sueño". Tsé-tsé. Fenómenos neurológicos progresivos.</li>
+</ul>
+</div>
+
+<h3>9.1 Preguntas — I9</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Inmigrante de Mali con hematuria — sospecha</summary>
+<div class="qa-body">
+<p>Paciente de 24 a. de Mali, en España 3 a., sin viajes. Orina con sangre intermitente. Sin disuria/fiebre. ¿Qué hacer?</p>
+<ol type="a">
+<li>Sedimento, coagulación, hemograma, bioquímica</li>
+<li>Urocultivo y ATB</li>
+<li>Praziquantel empírico</li>
+<li><strong>Contactar con el laboratorio indicándoles que sospechamos esquistosomiasis y nos ponemos de acuerdo en cómo recoger la orina</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Hematuria intermitente en inmigrante africano + ausencia de síntomas urinarios = esquistosomiasis genitourinaria. Aviso al laboratorio para preparar técnica de detección de huevos en orina (recoger la última orina del día tras ejercicio).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Viajero a México con absceso hepático</summary>
+<div class="qa-body">
+<p>Paciente tras viaje a México. Fiebre + dolor HCD. Eco: imagen hipoecoica de 10 cm en lóbulo derecho. Cultivo de la punción: estéril. ¿Diagnóstico y tratamiento?</p>
+<ol type="a">
+<li><strong>Amebiasis / metronidazol + paromomicina</strong></li>
+<li>Quiste hidatídico / albendazol</li>
+<li>Amebiasis / cirugía</li>
+<li>Absceso por anaerobios / drenaje + amoxiclav</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Absceso hepático único + viaje a área endémica + cultivo estéril = amebiasis hepática (E. histolytica). Tratamiento: metronidazol (sistémico) + paromomicina (luminal, para eliminar quistes). No requiere drenaje si responde a ATB.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Malaria grave de Nigeria</summary>
+<div class="qa-body">
+<p>Paciente de Nigeria con fiebre 39, disnea importante, Hb 6, plaq 10.000, glucemia 40. Frotis: Plasmodium. ¿Tratamiento?</p>
+<ol type="a">
+<li>Quinina oral</li>
+<li>Quinidina oral</li>
+<li><strong>Artesunato intravenoso</strong></li>
+<li>Cloroquina oral</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Malaria grave (de África = P. falciparum hasta demostrar otra) con anemia severa, trombocitopenia, hipoglucemia, disnea = malaria grave. <em>Artesunato iv</em> sustituye a la quinina como tratamiento de elección.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Eosinofilia en inmigrante sin causa</summary>
+<div class="qa-body">
+<p>Tras estudio exhaustivo de eosinofilia de 800/µL en inmigrante, sin causa aclarada. ¿Actitud?</p>
+<ol type="a">
+<li><strong>Tratar con albendazol + praziquantel + ivermectina</strong></li>
+<li>Dar albendazol solo</li>
+<li>Corticoides</li>
+<li>Mebendazol</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Eosinofilia inexplicada en inmigrante → tratamiento empírico de "amplio espectro antiparasitario": albendazol (nematodos), praziquantel (cestodos, esquistosomas), ivermectina (Strongyloides, filarias).</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Viajero de Kenia con fiebre — descartar primero</summary>
+<div class="qa-body">
+<p>Paciente de 60 a. tras viaje de placer a Kenia, urgencias por náuseas, vómitos y fiebre 37,8. ¿Qué descartar?</p>
+<ol type="a">
+<li>Gastritis por anisakis</li>
+<li><strong>Malaria</strong></li>
+<li>Fiebre de Katayama</li>
+<li>T. cruzi</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Fiebre tras viaje a África subsahariana = <em>MALARIA hasta demostrar lo contrario</em>. Frotis urgente. La fiebre puede ser baja o ausente en fases. T. cruzi es de América.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) Enfermedad de Chagas — tratamiento</summary>
+<div class="qa-body">
+<p>Sobre el tratamiento de la enfermedad de Chagas:</p>
+<ol type="a">
+<li>Se mantiene 7 días</li>
+<li><strong>Benznidazol y nifurtimox son los fármacos de elección</strong></li>
+<li>Con el tratamiento etiológico remiten los síntomas cardiacos y digestivos</li>
+<li>Las reacciones adversas no son relevantes</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Benznidazol o nifurtimox 60-90 días. Eficaz en fase aguda; en fase crónica la eficacia es limitada y NO revierte la cardiopatía/megacolon establecidos. Efectos adversos importantes (dermatitis, neuropatía).</div>
+</div></details>
+
+</section>
+
+<!-- =============== I10 =============== -->
+<section class="card" id="i10">
+<h2 class="section-title"><span class="num">I10</span>Infecciones por virus emergentes</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>"Virus emergente" = virus de aparición reciente o reemergencia con potencial epidémico/pandémico, debido a factores ambientales, cambio climático, movilidad humana, deforestación, contacto humano-animal.</li>
+<li>Ejemplos relevantes: SARS-CoV-2 (COVID-19), virus de la viruela del mono (MPXV/monkeypox), Zika, Chikungunya, Dengue, virus del Nilo Occidental, Ébola, Marburg, Lassa, Hantavirus, Crimean-Congo, fiebre del valle del Rift, Nipah, Hendra, gripe aviar H5N1 / H7N9.</li>
+<li>En España son especialmente relevantes: <em>SARS-CoV-2, MPXV, Dengue importado, Zika importado, fiebre del Nilo Occidental, fiebre Crimea-Congo, virus Toscana, hantavirus</em>.</li>
+</ul>
+</div>
+
+<h3>10.1 Arbovirus (Dengue, Zika, Chikungunya)</h3>
+<ul>
+<li><strong>Vector:</strong> mosquitos Aedes (aegypti, albopictus — presente en España).</li>
+<li><strong>Dengue:</strong>
+  <ul>
+    <li>4 serotipos (DEN-1 a 4). Incubación 4-10 días.</li>
+    <li>Fase febril: fiebre alta + cefalea retroocular + mialgias-artralgias intensas ("fiebre rompehuesos") + exantema + leucopenia/trombopenia.</li>
+    <li>Fase crítica (3-7 días tras inicio): aumento de permeabilidad capilar → choque, hemorragias (<em>"signos de alarma": dolor abdominal intenso, vómitos persistentes, sangrado de mucosas, letargia, hepatomegalia, hipotensión postural, ↑ Htto + ↓ plaquetas</em>).</li>
+    <li>Diagnóstico: NS1 + IgM/IgG.</li>
+    <li>Tratamiento: soporte (hidratación). <em>NO AINE/AAS</em> (sangrado). Vacuna Dengvaxia/Qdenga en estudio.</li>
+  </ul>
+</li>
+<li><strong>Zika:</strong>
+  <ul>
+    <li>Exantema + fiebre baja + conjuntivitis + artralgias (cuadro leve).</li>
+    <li>Grave: <em>microcefalia fetal</em> si infección en embarazo, síndrome de Guillain-Barré.</li>
+    <li>Transmisión sexual también demostrada.</li>
+    <li>Tratamiento: sintomático. No vacuna.</li>
+  </ul>
+</li>
+<li><strong>Chikungunya:</strong>
+  <ul>
+    <li>Fiebre alta + artralgias <em>incapacitantes</em> bilaterales simétricas que pueden persistir meses-años.</li>
+    <li>Diagnóstico: PCR (fase aguda) o serología.</li>
+    <li>Tratamiento: sintomático. Vacuna IXCHIQ (2023).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>10.2 Fiebre del Nilo Occidental</h3>
+<ul>
+<li>Flavivirus, transmitido por mosquito Culex. Aves son reservorio. Casos en sur de España.</li>
+<li>80 % asintomático. 20 %: fiebre + cefalea + exantema. &lt; 1 %: meningoencefalitis con secuelas neurológicas, parálisis flácida (similar polio).</li>
+<li>Diagnóstico: PCR o IgM en LCR/suero.</li>
+<li>Tratamiento: soporte. Vacuna ecuestre, no humana.</li>
+</ul>
+
+<h3>10.3 Hantavirus</h3>
+<ul>
+<li>Reservorio roedores (orina, heces, saliva).</li>
+<li>Síndrome <em>cardiopulmonar</em> (Sin Nombre virus, Andes — América): EAP no cardiogénico + shock.</li>
+<li>Síndrome <em>renal con fiebre hemorrágica (FRSR)</em> (Puumala, Hantaan — Europa, Asia): fiebre + IRA + hemorragia. Mortalidad &lt; 1 % Puumala, 10 % Hantaan.</li>
+<li>Tratamiento: soporte. Ribavirina iv en formas graves.</li>
+</ul>
+
+<h3>10.4 Fiebre hemorrágica de Crimea-Congo (FHCC)</h3>
+<ul>
+<li>Transmitida por garrapata Hyalomma o sangre/fluidos. Brotes en Extremadura y Castilla-León.</li>
+<li>Mortalidad 5-30 %. Fiebre + cefalea + mialgias + petequias + hemorragias generalizadas + hepatitis.</li>
+<li>Tratamiento: aislamiento, soporte, ribavirina temprana.</li>
+</ul>
+
+<h3>10.5 Virus Toscana</h3>
+<ul>
+<li>Phlebovirus transmitido por mosquito Phlebotomus en cuenca mediterránea.</li>
+<li>Causa de meningitis aséptica estival en verano (España, Italia, Francia).</li>
+<li>Pronóstico bueno. Tratamiento sintomático.</li>
+</ul>
+
+<h3>10.6 Virus de la viruela del mono (MPXV / Mpox)</h3>
+<ul>
+<li>Reservorio en África central/occidental. Brote global 2022 con transmisión sexual entre HSH.</li>
+<li>Incubación 5-21 días. Fiebre + adenopatías + exantema vesículopustuloso umbilicado en distinta fase, sobre todo genital, perianal, oral.</li>
+<li>Diagnóstico: PCR de exudado.</li>
+<li>Tratamiento: sintomático. Tecovirimat en formas graves o inmunodeprimidos. Vacuna JYNNEOS para grupos de riesgo y contactos.</li>
+</ul>
+
+<h3>10.7 Filovirus (Ébola, Marburg)</h3>
+<ul>
+<li>África subsahariana. Transmisión por contacto con fluidos.</li>
+<li>Fiebre hemorrágica con mortalidad 25-90 %.</li>
+<li>Tratamiento: soporte intensivo + anti-Ébola (ansuvimab/Ebanga, REGN-EB3/Inmazeb). Vacuna rVSV-ZEBOV (Ervebo).</li>
+</ul>
+
+<h3>10.8 Gripe aviar H5N1 / H7N9</h3>
+<ul>
+<li>Contacto con aves de corral. Síndrome respiratorio grave. Vigilancia epidemiológica internacional por riesgo de adaptación al humano y pandemia.</li>
+<li>Tratamiento: oseltamivir (gripe aviar es susceptible).</li>
+</ul>
+
+<h3>10.9 Otras emergencias virales relevantes</h3>
+<ul>
+<li><strong>SARS-CoV-2 / COVID-19</strong>: ver I8.</li>
+<li><strong>Nipah / Hendra</strong>: encefalitis grave, murciélagos como reservorio, Asia.</li>
+<li><strong>Lassa</strong>: África occidental, ribavirina.</li>
+<li><strong>Fiebre del valle del Rift</strong>: ganado, África.</li>
+</ul>
+</section>
+
+<!-- =============== I11 =============== -->
+<section class="card" id="i11">
+<h2 class="section-title"><span class="num">I11</span>Tétanos · botulismo · Bartonella</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Tres entidades clásicas por bacterias específicas con mecanismos clínicos peculiares.</li>
+</ul>
+</div>
+
+<h3>11.1 Tétanos (Clostridium tetani)</h3>
+<ul>
+<li>Bacilo Gram+ anaerobio formador de esporas presentes en suelo, polvo, heces.</li>
+<li><strong>Patogenia:</strong> tras herida (sucia, anfractuosa, profunda, con necrosis), las esporas germinan en condiciones anaerobias y producen <em>tetanoespasmina</em>. Esta toxina viaja retrógradamente por axones y bloquea la liberación de GABA y glicina en las interneuronas inhibitorias de la médula → <em>espasmos musculares</em>.</li>
+<li><strong>Formas clínicas:</strong>
+  <ul>
+    <li><em>Generalizado (la más frecuente)</em>: <strong>trismus</strong> ("risa sardónica" por espasmo facial), disfagia, rigidez nucal, opistótonos, espasmos generalizados desencadenados por estímulos. Disautonomía (HTA, taquicardia, hipertermia). <em>Sin alteración del nivel de conciencia</em>.</li>
+    <li><em>Cefálico</em>: tras herida en cara, parálisis de pares craneales.</li>
+    <li><em>Local</em>: rigidez en torno a la herida.</li>
+    <li><em>Neonatal</em>: en países en desarrollo, por contaminación umbilical (madres no vacunadas).</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> clínico (cultivo y toxina poco útiles).</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Desbridamiento quirúrgico</em> de la herida.</li>
+    <li><em>Inmunoglobulina antitetánica humana (IGT)</em> 3.000-6.000 UI IM (neutraliza toxina circulante).</li>
+    <li><em>ATB</em>: metronidazol iv 7-10 d (preferido) o penicilina G.</li>
+    <li>Sedoanalgesia: benzodiacepinas (diazepam, midazolam) iv para controlar los espasmos. Si refractario: bloqueo neuromuscular + IOT + VM.</li>
+    <li>Soporte de UCI: control de disautonomía (sulfato de magnesio, β-bloqueantes), nutrición, prevención de complicaciones.</li>
+    <li>Iniciar vacunación durante la convalecencia (la enfermedad no genera inmunidad).</li>
+  </ul>
+</li>
+<li><strong>Profilaxis postexposición — algoritmo:</strong></li>
+</ul>
+<div class="table-wrap"><table>
+<thead><tr><th>Estado vacunal</th><th>Herida limpia menor</th><th>Herida tetanígena (sucia, anfractuosa, profunda, isquémica, mordedura)</th></tr></thead>
+<tbody>
+<tr><td>&lt; 3 dosis o desconocida</td><td>Td (vacuna)</td><td><strong>Td + IGT</strong> en sitios separados</td></tr>
+<tr><td>3 dosis (última &lt; 5 a.)</td><td>Nada</td><td>Nada (algunos protocolos: Td si herida muy tetanígena)</td></tr>
+<tr><td>3 dosis (última &gt; 5-10 a.)</td><td>Nada</td><td>Td</td></tr>
+<tr><td>3 dosis (última &gt; 10 a.)</td><td>Td</td><td>Td</td></tr>
+<tr><td>Inmunodeprimido</td><td>Td</td><td>Td + IGT</td></tr>
+</tbody></table></div>
+
+<h3>11.2 Botulismo (Clostridium botulinum)</h3>
+<ul>
+<li>Bacilo Gram+ anaerobio formador de esporas que produce <em>toxina botulínica</em> (la neurotoxina más potente conocida).</li>
+<li><strong>Patogenia:</strong> la toxina bloquea la liberación presináptica de acetilcolina en la unión neuromuscular y los ganglios autónomos → <em>parálisis flácida</em>.</li>
+<li><strong>Formas clínicas:</strong>
+  <ul>
+    <li><em>Alimentario</em>: ingestión de toxina preformada (conservas caseras, especialmente vegetales mal esterilizados, embutidos, miel). Familiares afectados.</li>
+    <li><em>Infantil (&lt; 1 año)</em>: ingestión de esporas (miel — <em>no dar miel a &lt; 1 año</em>) que germinan en el intestino. "Floppy baby" (hipotonía, llanto débil, mala succión, estreñimiento).</li>
+    <li><em>De heridas</em>: en IVDU heroína "black tar".</li>
+    <li><em>Inhalado</em>: bioterrorismo.</li>
+  </ul>
+</li>
+<li><strong>Clínica clásica:</strong>
+  <ul>
+    <li><strong>Parálisis flácida descendente bilateral simétrica</strong> que empieza por pares craneales (visión borrosa, diplopía, ptosis, midriasis bilateral arreactiva, disartria, disfagia) → desciende a tronco y extremidades.</li>
+    <li><em>Disfunción autonómica</em>: sequedad de boca, estreñimiento, retención urinaria, hipotensión postural.</li>
+    <li><em>SIN fiebre. SIN alteraciones sensitivas. SIN alteración de la conciencia</em> (claves).</li>
+    <li>Insuficiencia respiratoria por parálisis diafragmática → necesidad de VM.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> clínica + detección de toxina en suero, heces, alimento (ratón). EMG con patrón mioasténico.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Antitoxina equina trivalente (A, B, E)</em> lo antes posible — no revierte la parálisis instaurada pero impide su progresión.</li>
+    <li>Inmunoglobulina humana botulínica iv (BabyBIG) en botulismo infantil.</li>
+    <li><em>Soporte ventilatorio</em> y nutricional prolongado (semanas-meses).</li>
+    <li>ATB controvertido (los aminoglucósidos pueden empeorar bloqueo NM); en botulismo de heridas: desbridamiento + penicilina G o metronidazol.</li>
+    <li>NO dar antitoxina en botulismo infantil rutinariamente (no aprobada).</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico diferencial:</strong> miastenia gravis (afecta primero a pares craneales pero fluctúa con el día, anti-AChR+, edrofonio+), síndrome de Guillain-Barré (parálisis flácida ASCENDENTE simétrica), ACV de tronco, intoxicación por organofosforados.</li>
+</ul>
+
+<h3>11.3 Bartonelosis</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Especie</th><th>Vector / fuente</th><th>Cuadro clínico</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>B. henselae</strong></td><td>Arañazo o mordedura de gato (sobre todo gatitos)</td><td><strong>Enfermedad por arañazo de gato</strong>: pápula/pústula en el sitio + <em>linfadenopatía regional</em> dolorosa (1-2 sem después) + fiebre. Resolución espontánea en semanas-meses. Formas atípicas: <em>síndrome oculoglandular de Parinaud</em> (conjuntivitis + adenopatía preauricular), encefalitis, hepatitis, endocarditis. Bacteriana intracelular en biopsia con granulomas.</td><td>Mayoría autolimitada. Azitromicina 5 d en formas graves o adenitis. Doxiciclina + rifampicina en endocarditis</td></tr>
+<tr><td><strong>B. quintana</strong></td><td>Piojo del cuerpo (Pediculus humanus corporis) — indigentes, hacinamiento, guerras</td><td><strong>Fiebre de las trincheras</strong>: fiebre recurrente cada 5 días + dolor óseo + mialgias. Endocarditis con hemocultivos negativos. Angiomatosis bacilar en VIH+</td><td>Doxiciclina + gentamicina (endocarditis)</td></tr>
+<tr><td>B. bacilliformis</td><td>Mosca Lutzomyia (Andes peruanos)</td><td><strong>Enfermedad de Carrión / Verruga peruana</strong>: anemia hemolítica grave (fiebre de Oroya) → fase eruptiva con verrugas</td><td>Ciprofloxacino</td></tr>
+<tr><td>Angiomatosis bacilar / peliosis hepática</td><td>B. henselae o quintana en VIH avanzado</td><td>Pápulas vasculares cutáneas (similares a Kaposi) + lesiones hepáticas con sangrado</td><td>Eritromicina o doxiciclina prolongada</td></tr>
+</tbody></table></div>
+
+<h3>11.4 Preguntas — I11</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Herida anfractuosa + estado vacunal desconocido</summary>
+<div class="qa-body">
+<p>Paciente de 35 a. con herida anfractuosa en pierna mientras trabajaba en el campo. Estado vacunal desconocido. ¿Profilaxis antitetánica tras limpieza quirúrgica?</p>
+<ol type="a">
+<li>Solo vacuna Td</li>
+<li>Solo inmunoglobulina antitetánica</li>
+<li><strong>Vacuna antitetánica e inmunoglobulina antitetánica en lugares separados</strong></li>
+<li>Nada si la herida se limpia bien</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Herida tetanígena (sucia/anfractuosa) + estado vacunal desconocido = vacuna Td + inmunoglobulina antitetánica IM en sitios anatómicos distintos. Completar pauta vacunal posteriormente.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Visión borrosa + sequedad + ptosis + midriasis arreactiva — botulismo</summary>
+<div class="qa-body">
+<p>Varón adulto con visión borrosa bilateral fluctuante, sequedad de boca, sudor frío, debilidad, midriasis bilateral arreactiva, ptosis, estreñimiento. No fiebre ni alteraciones sensitivas. ¿Cuál es verdadera sobre botulismo en adultos?</p>
+<ol type="a">
+<li>Suele presentar fiebre y alteraciones del nivel de conciencia</li>
+<li><strong>Parálisis descendente, disfunción autonómica y afectación de pares craneales, sin alteraciones sensitivas</strong></li>
+<li>El diagnóstico se confirma siempre con EMG y detección de toxina</li>
+<li>El tratamiento antibiótico es fundamental</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Botulismo: parálisis flácida descendente + afectación bulbar (visión, deglución, habla) + disfunción autonómica + SIN fiebre + SIN alteración sensitiva + SIN alteración de la consciencia. Tratamiento: antitoxina equina + soporte ventilatorio.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) Enfermedad por arañazo de gato — correcta</summary>
+<div class="qa-body">
+<p>¿Cuál es correcta sobre la enfermedad por arañazo de gato?</p>
+<ol type="a">
+<li>El síntoma principal es fiebre alta persistente y convulsiones</li>
+<li><strong>La manifestación clínica más frecuente es la linfadenopatía regional cerca del sitio del arañazo</strong></li>
+<li>Solo afecta a inmunodeprimidos</li>
+<li>El diagnóstico siempre requiere biopsia ganglionar</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> B. henselae causa linfadenopatía regional unilateral indolora o leve, fiebre baja, semanas-meses. Diagnóstico: serología o PCR; biopsia solo si dudoso. Tratamiento: azitromicina (5 días).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Ord 2025) Bartonella quintana en indigente</summary>
+<div class="qa-body">
+<p>Varón de 42 a., calle. Fiebre recurrente + cefalea + dolor óseo en piernas. Episodios de 4-5 días. Infestación por piojos. Esplenomegalia + exantema. ¿Cuál es verdadera sobre B. quintana?</p>
+<ol type="a">
+<li>Se transmite por mordedura de gato</li>
+<li>Es causa frecuente de endocarditis en inmunocompetentes</li>
+<li><strong>El vector principal es el piojo del cuerpo humano (Pediculus humanus corporis)</strong></li>
+<li>La fiebre es continua sin recaídas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> B. quintana = piojo del cuerpo (no del cabello ni de gato). Tratamiento: doxiciclina + gentamicina si endocarditis.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Tétanos grave — medida terapéutica más importante</summary>
+<div class="qa-body">
+<p>Varón de 18 a. con herida penetrante en pie por clavo. Recibió toxoide tetánico. Tras 3 días desarrolla trismo, espasmos, opistótonos, fallo respiratorio. UCI con inmunoglobulina, ceftriaxona + metronidazol, relajantes. Además, ¿medida más importante?</p>
+<ol type="a">
+<li>Administrar toxoide tetánico</li>
+<li>Aumentar inmunoglobulina antitetánica</li>
+<li><strong>Desbridar la herida y administrar antibióticos</strong></li>
+<li>Sedar y relajar con benzodiacepinas</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Eliminar el foco productor de toxina = desbridamiento de la herida + ATB. Sin esto, la toxina sigue produciéndose. Inmunoglobulina neutraliza solo la toxina circulante.</div>
+</div></details>
+
+<details class="qa"><summary>6. (Extra 2025) Niño con arañazo de gato + adenopatía + lesión cutánea</summary>
+<div class="qa-body">
+<p>Paciente de 13 a. con fiebre 6 días, adenopatía axilar + lesión interescapular + contacto con gato. Biopsia: linfadenitis con focos necrotizantes. Mejora con azitromicina. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Linfoma</li>
+<li>Tuberculosis ganglionar</li>
+<li><strong>Enfermedad por arañazo de gato</strong></li>
+<li>Mononucleosis</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Bartonella henselae. Granulomas con necrosis estrellada en ganglio. Respuesta a azitromicina.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I12 =============== -->
+<section class="card" id="i12">
+<h2 class="section-title"><span class="num">I12</span>Síndromes mononucleósicos · herpesvirus</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>El <strong>síndrome mononucleósico</strong> = fiebre + faringoamigdalitis + adenopatías ± esplenomegalia + linfocitosis con linfocitos atípicos (células de Downey).</li>
+<li><strong>Etiologías:</strong>
+  <ul>
+    <li><em>Virus de Epstein-Barr (VEB)</em> — la causa más frecuente.</li>
+    <li><em>Citomegalovirus (CMV)</em>.</li>
+    <li><em>Toxoplasma gondii</em>.</li>
+    <li><em>VIH primario</em> (siempre descartar).</li>
+    <li>VHS-1/2 (rara como síndrome mono).</li>
+    <li>VHB aguda, sífilis secundaria, rubéola, brucelosis, fiebre tifoidea (mononucleosis-like).</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>12.1 Familia Herpesviridae (8 herpesvirus humanos)</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">VHS-1 (HHV-1)</span><span class="v">Herpes labial, gingivoestomatitis, queratitis, <em>encefalitis lobular temporal</em></span></div>
+<div class="kv"><span class="k">VHS-2 (HHV-2)</span><span class="v">Herpes genital, meningitis aséptica recurrente (Mollaret)</span></div>
+<div class="kv"><span class="k">VVZ (HHV-3)</span><span class="v">Varicela (primoinfección), herpes zóster (reactivación)</span></div>
+<div class="kv"><span class="k">VEB (HHV-4)</span><span class="v">Mononucleosis, linfomas (Burkitt, Hodgkin, primario SNC), carcinoma nasofaríngeo, leucoplasia oral vellosa</span></div>
+<div class="kv"><span class="k">CMV (HHV-5)</span><span class="v">Mononucleosis, infección congénita, retinitis y colitis en VIH, neumonitis y enfermedad del injerto en trasplante</span></div>
+<div class="kv"><span class="k">HHV-6</span><span class="v">Exantema súbito (roséola), encefalitis</span></div>
+<div class="kv"><span class="k">HHV-7</span><span class="v">Pityriasis rosada, exantema súbito (variante)</span></div>
+<div class="kv"><span class="k">HHV-8</span><span class="v">Sarcoma de Kaposi, Castleman multicéntrico, linfoma de cavidades</span></div>
+</div>
+
+<h3>12.2 Mononucleosis infecciosa por VEB</h3>
+<ul>
+<li><strong>Epidemiología:</strong> adolescentes-jóvenes (15-25 a.), "enfermedad del beso". Transmisión por saliva.</li>
+<li><strong>Incubación:</strong> 30-50 días.</li>
+<li><strong>Clínica:</strong>
+  <ul>
+    <li>Tríada clásica: <em>fiebre + faringoamigdalitis (con exudados blanquecinos extensos) + adenopatías cervicales bilaterales</em>.</li>
+    <li>Esplenomegalia (50 %), hepatomegalia, hepatitis leve.</li>
+    <li>Astenia marcada, mialgias.</li>
+    <li>Edema palpebral, exantema (10 % espontáneo; <em>90 % si se administra ampicilina/amoxicilina</em>).</li>
+    <li>Linfocitosis con &gt; 50 % linfocitos, &gt; 10 % atípicos.</li>
+  </ul>
+</li>
+<li><strong>Complicaciones:</strong>
+  <ul>
+    <li>Rotura esplénica espontánea (rara pero potencialmente mortal) — <em>evitar deportes de contacto 3-4 sem</em>.</li>
+    <li>Anemia hemolítica autoinmune (crioaglutininas anti-i).</li>
+    <li>Trombopenia.</li>
+    <li>Hepatitis colestásica.</li>
+    <li>Síndrome de Guillain-Barré, encefalitis, mielitis.</li>
+    <li>Obstrucción de vía aérea por hiperplasia adenoidea.</li>
+    <li>Síndrome linfoproliferativo ligado a X (Duncan) en niños con XLP.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li><em>Test de Paul-Bunnell / monospot</em>: detecta anticuerpos heterófilos (aglutinan eritrocitos de carnero/caballo). Sensibilidad 85 %.</li>
+    <li><em>Serología específica</em>: anti-VCA IgM (fase aguda), anti-VCA IgG, anti-EBNA (aparece a los 2-3 m, indica infección pasada).</li>
+    <li>Linfocitos atípicos en frotis.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong> sintomático (paracetamol, reposo). Corticoides solo si obstrucción de vía aérea, hemólisis o trombopenia severa. NO aciclovir rutinario.</li>
+</ul>
+
+<h3>12.3 Mononucleosis por CMV</h3>
+<ul>
+<li>Cuadro similar al VEB pero <em>SIN adenopatías ni esplenomegalia prominentes, SIN exudados faríngeos importantes, Paul-Bunnell (−)</em>.</li>
+<li>Hepatitis frecuente.</li>
+<li>Diagnóstico: IgM CMV +, antigenemia pp65, PCR CMV.</li>
+<li>Inmunocompetentes: sintomático.</li>
+<li>CMV congénito (TORCH): microcefalia, calcificaciones periventriculares, sordera, coriorretinitis, hepatoesplenomegalia.</li>
+<li>CMV en trasplantados/IS: ver U5. Neumonitis, hepatitis, colitis, retinitis. Tratamiento: ganciclovir iv o valganciclovir oral 3 sem + reducción de IS.</li>
+</ul>
+
+<h3>12.4 Infección por VHS</h3>
+<ul>
+<li>VHS-1: orofaríngeo (herpes labial), encefalitis temporal aguda hemorrágica.</li>
+<li>VHS-2: genital, meningitis recurrente (Mollaret).</li>
+<li><strong>Encefalitis por VHS</strong>: fiebre + alteraciones de conducta + convulsiones temporales + signos focales. LCR: linfocitos + hematíes (necrosis hemorrágica). PCR VHS-1 en LCR. RM: lesiones temporales bilaterales hemorrágicas. <em>Tratamiento URGENTE con aciclovir iv 10 mg/kg/8 h × 14-21 d</em>; mortalidad &gt; 70 % sin tratamiento.</li>
+<li>Tratamiento de herpes labial/genital: aciclovir, valaciclovir, famciclovir oral.</li>
+</ul>
+
+<h3>12.5 Varicela y herpes zóster (VVZ)</h3>
+<ul>
+<li><strong>Varicela</strong> (primoinfección, niños): vesículas en distintos estadios + fiebre. Aciclovir si adulto, IS, embarazada. Vacuna en calendario.</li>
+<li><strong>Herpes zóster</strong> (reactivación): vesículas dermatómicas unilaterales. Adultos &gt; 50 a., IS. Complicaciones: neuralgia postherpética (en &gt; 50 a.), zóster oftálmico, encefalitis, mielitis.</li>
+<li>Tratamiento: <em>aciclovir/valaciclovir/famciclovir oral 7 d</em> si &lt; 72 h del inicio. Iv si oftálmico, diseminado, IS.</li>
+<li>Vacuna Shingrix (recombinante) en &gt; 50 a. (preferida) o Zostavax (viva, evitar en IS).</li>
+</ul>
+
+<h3>12.6 Toxoplasmosis ganglionar</h3>
+<ul>
+<li>Adenopatías cervicales posteriores indoloras, no fistulizantes, ± febrícula y astenia.</li>
+<li>Biopsia: <em>patrón de Piringer-Kuchinka</em> = hiperplasia folicular + agregados de histiocitos epitelioides + acúmulos de linfocitos B monocitoides.</li>
+<li>Serología: IgM Toxo + IgG con avidez baja.</li>
+<li>Tratamiento: inmunocompetentes con adenopatías = no tratar (autolimitada). Embarazadas (riesgo congénito): espiramicina; pirimetamina + sulfadiazina + ácido folínico si confirmación fetal. Inmunodeprimidos (toxoplasmosis cerebral en VIH): pirimetamina + sulfadiazina + ácido folínico.</li>
+</ul>
+
+<h3>12.7 Otros herpesvirus</h3>
+<ul>
+<li><strong>HHV-6</strong>: exantema súbito o roséola en lactantes (fiebre alta 3-5 d que cede al aparecer el exantema). Encefalitis en post-trasplantados.</li>
+<li><strong>HHV-8</strong>: sarcoma de Kaposi, Castleman multicéntrico, linfoma primario de cavidades. Asociación con VIH avanzado.</li>
+</ul>
+
+<h3>12.8 Preguntas — I12</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Adolescente con CMV IgM (+) sin adenopatías</summary>
+<div class="qa-body">
+<p>Adolescente de 19 a. con fiebre persistente + ligera elevación de transaminasas. Serología: CMV IgM (+). Sin adenopatías ni esplenomegalia. ¿Recomendación?</p>
+<ol type="a">
+<li>Reposo absoluto</li>
+<li><strong>No realizar deportes de contacto</strong></li>
+<li>Antibióticos preventivos</li>
+<li>Descartar VIH</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> CMV puede dar esplenomegalia subclínica → evitar deportes de contacto 4 semanas. No requiere antivirales ni reposo absoluto.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Adenopatías cervicales + Piringer-Kuchinka</summary>
+<div class="qa-body">
+<p>Varón de 27 a. con adenopatías cervicales posteriores de 2 sem. Febrícula. Biopsia: <em>patrón de Piringer-Kuchinka + hiperplasia folicular + granulomas</em>. Doxiciclina sin respuesta. ¿Diagnóstico y tratamiento?</p>
+<ol type="a">
+<li><strong>Toxoplasmosis, no requiere tratamiento en inmunocompetentes</strong></li>
+<li>Mononucleosis VEB, no requiere tratamiento</li>
+<li>Linfoma, derivar a hematología</li>
+<li>Mononucleosis CMV, no requiere tratamiento</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El patrón de Piringer-Kuchinka es típico de toxoplasmosis ganglionar. En inmunocompetentes resuelve espontáneamente y NO se trata.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Leucoplasia oral vellosa en VIH</summary>
+<div class="qa-body">
+<p>Paciente VIH+ con CD4 &lt; 200 presenta lesiones blanquecinas en bordes laterales de la lengua, no desprendibles al raspado. ¿Diagnóstico y etiología?</p>
+<ol type="a">
+<li>Candidiasis por Candida albicans</li>
+<li><strong>Leucoplasia oral vellosa por VEB</strong></li>
+<li>Carcinoma oral por VEB</li>
+<li>Herpes simple por VHS-1</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Leucoplasia oral vellosa = lesiones blanquecinas verrucosas en bordes laterales de la lengua, no desprendibles. Causada por VEB. Marcador de inmunosupresión avanzada en VIH.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Trasplantada renal con neumonitis intersticial + IgG CMV (+)</summary>
+<div class="qa-body">
+<p>Paciente de 60 a., trasplantada renal, con neumonitis intersticial + disnea progresiva. IgG CMV positiva. ¿Actuación y tratamiento?</p>
+<ol type="a">
+<li>Investigar más, IgG es infección pasada</li>
+<li><strong>PCR; si positiva → ganciclovir iv</strong></li>
+<li>Ganciclovir iv directamente</li>
+<li>PCR; si positiva → valaciclovir</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En trasplantado, IgG (+) indica infección previa o reactivación. Confirmar reactivación activa con PCR cuantitativa de CMV. Si (+) y enfermedad de órgano (neumonitis) → ganciclovir iv. Valaciclovir no es eficaz para CMV.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Herpes zóster torácico</summary>
+<div class="qa-body">
+<p>Varón de 52 a. con dolor urente en hemitórax izquierdo + lesiones vesiculosas agrupadas en un dermatomo. ¿Diagnóstico y tratamiento?</p>
+<ol type="a">
+<li>Hemocultivos y amoxiclav</li>
+<li>No requiere pruebas, es neuralgia</li>
+<li><strong>PCR de las vesículas y aciclovir</strong></li>
+<li>Cultivo de vesículas y amoxiclav</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Herpes zóster = reactivación de VVZ. Confirmar con PCR de vesículas (más sensible que cultivo). Tratamiento antiviral oral (aciclovir/valaciclovir/famciclovir) lo antes posible (&lt; 72 h) para reducir riesgo de neuralgia postherpética.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I13 =============== -->
+<section class="card" id="i13">
+<h2 class="section-title"><span class="num">I13</span>Infecciones por hongos</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las infecciones fúngicas invasivas afectan principalmente a inmunodeprimidos: neutropénicos, trasplantados, VIH avanzado, UCI prolongada, diabéticos descompensados.</li>
+<li>Antifúngicos: <em>azoles</em> (fluconazol, itraconazol, voriconazol, posaconazol, isavuconazol), <em>equinocandinas</em> (caspofungina, micafungina, anidulafungina), <em>polienos</em> (anfotericina B liposomal), <em>flucitosina</em>.</li>
+</ul>
+</div>
+
+<h3>13.1 Candidiasis</h3>
+<ul>
+<li><strong>Mucocutánea:</strong> muguet oral, vaginitis (Candida albicans típica), esofágica (VIH, IS). Tratamiento tópico (nistatina, clotrimazol) o fluconazol oral.</li>
+<li><strong>Candiduria asintomática</strong>: en sonda vesical, diabéticos. <em>Cambiar la sonda</em>; fluconazol oral si persiste, sintomática o riesgo alto.</li>
+<li><strong>Candidemia / candidiasis invasiva:</strong>
+  <ul>
+    <li>FR: ATB amplio espectro, IS, catéter venoso central, NPT, cirugía abdominal, UCI prolongada, neutropenia.</li>
+    <li>Especies:
+      <ul>
+        <li><em>C. albicans</em>: la más frecuente, sensible a fluconazol.</li>
+        <li><em>C. glabrata</em>: resistencia parcial a azoles.</li>
+        <li><em>C. krusei</em>: <em>resistencia intrínseca al fluconazol</em>.</li>
+        <li><em>C. parapsilosis</em>: catéteres, neonatos.</li>
+        <li><em>C. auris</em>: emergente, multirresistente, brotes nosocomiales.</li>
+      </ul>
+    </li>
+    <li>Diagnóstico: hemocultivos (positivos 50-70 %), β-D-glucano sérico, T2Candida (PCR rápida).</li>
+    <li><strong>Tratamiento empírico:</strong> <em>equinocandina iv</em> hasta antibiograma. Cambio a fluconazol si C. albicans sensible y mejoría.</li>
+    <li>Imprescindible: <em>retirar catéter central, fondo de ojo (endoftalmitis), ETT/ETE (endocarditis)</em>, TC abdominal (microabscesos).</li>
+    <li>Duración: ≥ 14 d tras último hemocultivo negativo.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>13.2 Aspergilosis</h3>
+<ul>
+<li>Aspergillus fumigatus (la mayoría), A. flavus, A. niger, A. terreus.</li>
+<li><strong>Formas clínicas:</strong>
+  <ul>
+    <li><em>Aspergilosis pulmonar invasiva (API)</em>: neutropénicos, trasplantados, corticoides prolongados, EPOC grave. Fiebre + tos + hemoptisis. TC: <strong>nódulos con halo en vidrio deslustrado</strong> (precoz) → <strong>signo del menisco aéreo / creciente</strong> (tardío).</li>
+    <li><em>Aspergiloma</em>: bola fúngica en cavidad preformada (TBC residual). Hemoptisis posible.</li>
+    <li><em>ABPA</em>: hipersensibilidad en asmáticos/FQ. IgE total muy elevada, eosinofilia.</li>
+    <li>Aspergilosis crónica necrotizante.</li>
+  </ul>
+</li>
+<li>Diagnóstico: galactomanano sérico/BAL, β-D-glucano, PCR, biopsia (hifas hialinas <em>septadas en ángulo agudo de 45°</em>).</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Voriconazol</em> (1ª línea, atraviesa BHE; monitorizar niveles, toxicidad ocular y hepática).</li>
+    <li><em>Isavuconazol</em>: alternativa con mejor perfil.</li>
+    <li><em>Anfotericina B liposomal</em>: rescate.</li>
+    <li>ABPA: corticoides + antifúngico.</li>
+    <li>Aspergiloma: cirugía si hemoptisis.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>13.3 Mucormicosis (zigomicosis)</h3>
+<ul>
+<li>Mucorales: Rhizopus, Mucor, Rhizomucor.</li>
+<li>FR: <strong>diabetes en cetoacidosis</strong>, IS, neutropenia, deferoxamina, COVID grave (CAM).</li>
+<li><strong>Formas:</strong>
+  <ul>
+    <li><em>Rino-orbito-cerebral</em>: dolor facial + secreción nasal sanguinolenta + necrosis del paladar/cornete + exoftalmos + extensión a SNC. Mortalidad alta.</li>
+    <li>Pulmonar (similar API).</li>
+    <li>Cutánea (heridas/quemaduras).</li>
+    <li>Diseminada.</li>
+  </ul>
+</li>
+<li>Diagnóstico: biopsia con <em>hifas anchas no septadas en ángulo recto (90°)</em>. Galactomanano y β-D-glucano <em>negativos</em> (clave diferencial vs Aspergillus).</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>Anfotericina B liposomal a dosis altas</em> (5-10 mg/kg/d) — 1ª línea.</li>
+    <li><em>Cirugía radical urgente</em>: desbridamiento del tejido necrótico.</li>
+    <li>Control de causa (cetoacidosis, reducir IS).</li>
+    <li>Isavuconazol / posaconazol como mantenimiento o alternativa.</li>
+  </ul>
+</li>
+</ul>
+
+<h3>13.4 Criptococosis</h3>
+<ul>
+<li>Cryptococcus neoformans (excrementos de paloma). C. gattii (eucaliptos, tropical).</li>
+<li><strong>Formas:</strong>
+  <ul>
+    <li><em>Meningitis criptocócica</em> en VIH avanzado (CD4 &lt; 100). Cefalea + fiebre + ↑ PIC, signos meníngeos sutiles.</li>
+    <li>Neumonía.</li>
+    <li>Diseminada.</li>
+  </ul>
+</li>
+<li>Diagnóstico: <em>antígeno criptocócico (CrAg) en LCR y suero</em> (alta S/E), tinción de tinta china, cultivo.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Inducción 2 sem: <em>anfotericina B liposomal + flucitosina</em>.</li>
+    <li>Consolidación 8 sem: fluconazol 400-800 mg/d.</li>
+    <li>Mantenimiento: fluconazol 200 mg/d hasta CD4 &gt; 200 ≥ 6 m.</li>
+    <li>PL evacuadora para control de PIC (factor pronóstico).</li>
+    <li>Diferir TAR 4-6 sem (riesgo de IRIS).</li>
+  </ul>
+</li>
+</ul>
+
+<h3>13.5 Pneumocystis jirovecii (PJP)</h3>
+<ul>
+<li>Hongo atípico. Infección oportunista clásica del SIDA.</li>
+<li>FR: VIH con CD4 &lt; 200, corticoides ≥ 20 mg prednisona × 4 sem, IS, trasplante.</li>
+<li>Clínica: <em>disnea progresiva + tos seca + fiebre + hipoxemia desproporcionada</em>.</li>
+<li>Lab: LDH muy ↑, β-D-glucano +.</li>
+<li>Rx/TC: <em>infiltrados bilaterales perihiliares "en alas de mariposa"</em>; puede ser normal en fases iniciales.</li>
+<li>Diagnóstico: Grocott/PAS/IF en esputo inducido o BAL.</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li><em>TMP-SMX 15-20 mg/kg/d (de TMP) × 21 días</em>.</li>
+    <li><em>Corticoides</em> si pO₂ &lt; 70 (prednisona 40 mg/12 h × 5 d, descenso).</li>
+    <li>Alternativas: pentamidina iv, atovacuona, clindamicina + primaquina, dapsona + TMP.</li>
+  </ul>
+</li>
+<li>Profilaxis primaria en VIH con CD4 &lt; 200: TMP-SMX 1 comp/d.</li>
+</ul>
+
+<h3>13.6 Endemias y otras micosis</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Histoplasmosis</span><span class="v">Histoplasma capsulatum. Valle Mississippi/Ohio, Sudamérica. Cuevas con murciélagos/aves. Pulmonar similar TBC; diseminada en IS. <em>Itraconazol</em>; anfo B en grave</span></div>
+<div class="kv"><span class="k">Coccidioidomicosis</span><span class="v">Coccidioides immitis. SW EE.UU. (Arizona). "Fiebre del Valle". Fluconazol</span></div>
+<div class="kv"><span class="k">Blastomicosis</span><span class="v">Blastomyces dermatitidis. Pulmonar + cutánea. Itraconazol</span></div>
+<div class="kv"><span class="k">Paracoccidioidomicosis</span><span class="v">Sudamérica. Lesiones mucosas + pulmonar + adenopatías</span></div>
+<div class="kv"><span class="k">Esporotricosis</span><span class="v">Sporothrix schenckii. "Enfermedad del jardinero". Nódulos linfocutáneos siguiendo trayecto linfático. Itraconazol</span></div>
+<div class="kv"><span class="k">Hongos dimórficos</span><span class="v">Levaduras a 37 °C, mohos a 25 °C: Histoplasma, Coccidioides, Blastomyces, Paracoccidioides, Sporothrix, Talaromyces</span></div>
+</div>
+
+<h3>13.7 Preguntas — I13</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Candidiasis urinaria asintomática en diabético sondado</summary>
+<div class="qa-body">
+<p>Paciente diabético de 70 a. con sonda vesical de larga evolución, aisla Candida albicans en urocultivo asintomático. ¿Conducta?</p>
+<ol type="a">
+<li><strong>No requiere tratamiento antifúngico; cambiar la sonda</strong></li>
+<li>Cambiar sonda + fluconazol oral</li>
+<li>Cambiar sonda + anfotericina B liposomal</li>
+<li>B y C son correctas</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> Candiduria asintomática en sonda = no tratar, solo cambiar la sonda. Si persiste o aparecen síntomas, fluconazol oral 1-2 sem. Anfotericina solo en pielonefritis fúngica grave o resistencia.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Mucormicosis rino-orbitaria en trasplantado diabético</summary>
+<div class="qa-body">
+<p>Diabético inmunodeprimido (trasplante renal) con sinusitis severa + necrosis de cornetes + exoftalmos. Biopsia: hifas anchas no septadas en ángulo recto. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Aspergilosis invasiva</li>
+<li><strong>Mucormicosis rino-orbitaria</strong></li>
+<li>Candidiasis invasiva</li>
+<li>Blastomicosis pulmonar</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Hifas anchas no septadas en ángulo recto = mucormicosis (Rhizopus, Mucor). Aspergillus tiene hifas septadas en 45°. Tratamiento: anfotericina B liposomal + desbridamiento quirúrgico urgente.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Histoplasmosis tras cuevas en Sudamérica</summary>
+<div class="qa-body">
+<p>Paciente de 55 a. tras actividades en cuevas de Sudamérica. Fiebre + tos seca + disnea. TC: micronodular + adenopatías hiliares. Serología (+) Histoplasma. ¿Tratamiento?</p>
+<ol type="a">
+<li>Fluconazol</li>
+<li>Voriconazol</li>
+<li><strong>Itraconazol</strong></li>
+<li>Caspofungina</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Histoplasmosis no grave = itraconazol VO. Graves = anfotericina B liposomal seguida de itraconazol. Fluconazol y caspofungina no tienen actividad. Voriconazol es para Aspergillus.</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) Aspergilosis invasiva — tratamiento</summary>
+<div class="qa-body">
+<p>Paciente oncohematológico con neutropenia prolongada, fiebre persistente y disnea. TC: nódulos pulmonares con signo del halo. β-D-glucano positivo. ¿Tratamiento?</p>
+<ol type="a">
+<li>Caspofungina</li>
+<li>Fluconazol</li>
+<li><strong>Voriconazol</strong></li>
+<li>Posaconazol</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Aspergilosis invasiva (halo + galactomanano/β-D-glucano +) = voriconazol 1ª línea (mejor que anfotericina). Alternativas: isavuconazol, anfotericina liposomal. Caspofungina y posaconazol son 2ª línea/rescate.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I14 =============== -->
+<section class="card" id="i14">
+<h2 class="section-title"><span class="num">I14</span>Leptospira · Borrelia</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las espiroquetas son bacterias en forma de hélice que causan infecciones sistémicas con cursos en fases. Las relevantes en práctica son: <em>Leptospira, Borrelia burgdorferi (Lyme), Borrelia recurrentis (fiebre recurrente), Treponema pallidum (sífilis — ver ETS U9)</em>.</li>
+</ul>
+</div>
+
+<h3>14.1 Leptospirosis</h3>
+<ul>
+<li><strong>Etiología:</strong> Leptospira interrogans (varios serotipos).</li>
+<li><strong>Reservorio:</strong> roedores (ratas), perros, ganado. La bacteria se elimina por orina y persiste en agua estancada o suelo húmedo.</li>
+<li><strong>Transmisión:</strong> contacto de piel (microabrasiones) o mucosas con agua contaminada. Riesgo en: campesinos, alcantarilleros, mataderos, militares, inundaciones (Filipinas, Sudamérica, <em>DANA en Valencia 2024</em>).</li>
+<li><strong>Incubación:</strong> 7-14 días (rango 2-30).</li>
+<li><strong>Cuadro clínico bifásico:</strong>
+  <ul>
+    <li><em>Fase septicémica/leptospirémica (1ª semana)</em>: fiebre alta de inicio brusco + cefalea + <strong>mialgias intensas en pantorrillas</strong> + <strong>inyección conjuntival (sin secreción)</strong> + náuseas + vómitos + exantema fugaz.</li>
+    <li><em>Fase inmune (2ª semana)</em>: meningitis aséptica, fallo orgánico, uveítis tardía. Los anticuerpos aparecen aquí y los hemocultivos se negativizan.</li>
+  </ul>
+</li>
+<li><strong>Síndrome de Weil (forma grave, 5-10 %):</strong>
+  <ul>
+    <li><em>Ictericia</em> (bilirrubina directa muy ↑).</li>
+    <li><em>Insuficiencia renal aguda</em> (NIA, NTA).</li>
+    <li><em>Hemorragia</em> (pulmonar, GI, conjuntival).</li>
+    <li><em>Miocarditis</em>, miopatía con ↑ CK.</li>
+    <li>Trombopenia, ↑ transaminasas leve, leucocitosis con desviación izquierda.</li>
+    <li>Mortalidad 5-15 %.</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Sospecha clínica + epidemiología.</li>
+    <li><em>Hemocultivos</em> (1ª sem) y urocultivos (a partir de 2ª sem) en medios especiales.</li>
+    <li><em>Serología por MAT (microaglutinación)</em> — gold standard, requiere seroconversión.</li>
+    <li>PCR — útil temprano.</li>
+    <li>ELISA IgM.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Leve/precoz: <em>doxiciclina 100 mg/12 h</em> o amoxicilina × 7 días.</li>
+    <li>Grave/hospitalizado: <em>penicilina G 1,5 millones UI/6 h iv</em> o ceftriaxona 1-2 g/d × 7-10 d.</li>
+    <li>Soporte: diálisis si IRA, ventilación si hemorragia alveolar.</li>
+    <li>Iniciar lo antes posible (mejor pronóstico).</li>
+  </ul>
+</li>
+<li><strong>Profilaxis postexposición:</strong> doxiciclina 200 mg semanal en alto riesgo.</li>
+</ul>
+
+<h3>14.2 Enfermedad de Lyme (Borrelia burgdorferi)</h3>
+<ul>
+<li><strong>Vector:</strong> garrapatas duras del género <em>Ixodes</em> (I. scapularis en EE.UU., I. ricinus en Europa). Para transmitir hace falta &gt; 24-36 h de adherencia.</li>
+<li><strong>Geografía:</strong> noreste y medio oeste de EE.UU., Europa central, norte de España (sobre todo Galicia, Asturias, País Vasco, Pirineos).</li>
+<li><strong>Estadios clínicos:</strong>
+  <ul>
+    <li><em>Fase precoz localizada (días-semanas)</em>:
+      <ul>
+        <li><strong>Eritema migratorio</strong>: lesión anular roja, expansiva, con centro pálido (en "diana"), &gt; 5 cm, sin dolor, en el sitio de la picadura. <em>Patognomónico</em>. Aparece 3-30 días tras picadura.</li>
+        <li>Síndrome pseudogripal.</li>
+      </ul>
+    </li>
+    <li><em>Fase precoz diseminada (semanas-meses)</em>:
+      <ul>
+        <li>Eritemas migratorios múltiples.</li>
+        <li>Neurológica (neuroborreliosis): <strong>parálisis facial periférica</strong> (a menudo bilateral), meningitis linfocitaria, radiculoneuritis dolorosa de Bannwarth.</li>
+        <li>Cardíaca: <strong>bloqueo AV de grado variable</strong>, miopericarditis (raro).</li>
+        <li>Oligoartritis migratoria.</li>
+      </ul>
+    </li>
+    <li><em>Fase tardía (meses-años)</em>:
+      <ul>
+        <li><strong>Artritis crónica (rodilla)</strong>: la articulación más afectada, monoarticular o pauciarticular.</li>
+        <li>Encefalomielitis crónica.</li>
+        <li><em>Acrodermatitis crónica atroficante</em> de Herxheimer (Europa).</li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong>
+  <ul>
+    <li>Eritema migratorio típico = diagnóstico CLÍNICO; no necesita serología.</li>
+    <li>Resto: ELISA → confirmar con <em>Western blot</em>. IgM precoz, IgG tardía.</li>
+    <li>PCR en LCR o líquido sinovial.</li>
+  </ul>
+</li>
+<li><strong>Tratamiento:</strong>
+  <ul>
+    <li>Eritema migratorio: <em>doxiciclina 100 mg/12 h × 14-21 d</em> (1ª línea); amoxicilina/cefuroxima en niños y embarazadas.</li>
+    <li>Neuroborreliosis o carditis grave: <em>ceftriaxona iv 14-28 d</em>.</li>
+    <li>Artritis: doxiciclina 28 d (o ceftriaxona iv).</li>
+    <li>Profilaxis postpicadura: doxiciclina DU 200 mg si garrapata Ixodes y &gt; 36 h de adherencia (zona endémica).</li>
+  </ul>
+</li>
+<li><strong>Reacción de Jarisch-Herxheimer:</strong> al iniciar tratamiento (fiebre, escalofríos, mialgias) por liberación de antígenos. Autolimitada en horas. Pretratar con corticoides en casos graves.</li>
+</ul>
+
+<h3>14.3 Fiebre recurrente (Borrelia recurrentis y otras)</h3>
+<ul>
+<li>Transmitida por <em>piojo del cuerpo</em> (B. recurrentis, epidémica) o <em>garrapatas blandas Ornithodoros</em> (endémica).</li>
+<li>Episodios repetidos de fiebre alta (3-5 d) separados por apirexia (5-7 d).</li>
+<li>Diagnóstico: espiroquetas en sangre periférica (Wright, Giemsa, campo oscuro) durante fase febril.</li>
+<li>Tratamiento: doxiciclina o eritromicina; vigilar Jarisch-Herxheimer.</li>
+</ul>
+
+<h3>14.4 Preguntas — I14</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Trabajador en la DANA con fiebre + mialgias + ictericia + oliguria</summary>
+<div class="qa-body">
+<p>Varón de 35 a. con fiebre alta + cefalea + mialgias en pantorrillas + inyección conjuntival. Trabajó en limpieza de la DANA en Valencia. Días después: ictericia, oliguria, ↑ Cr y CK. ¿Cuál es correcta sobre el manejo de leptospirosis?</p>
+<ol type="a">
+<li>Diagnóstico solo con hemocultivo + en 2ª semana</li>
+<li><strong>Tratamiento: penicilina o doxiciclina, lo antes posible ante sospecha clínica</strong></li>
+<li>No produce afectación renal/hepática</li>
+<li>Se descarta si no hay ictericia</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Tratamiento empírico precoz con doxiciclina o penicilina G ante sospecha. La ictericia puede o no aparecer (forma anictérica también existe). La afectación renal y hepática son típicas de la forma grave (Weil).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Artritis de Lyme tardío</summary>
+<div class="qa-body">
+<p>Mujer de 62 a. con dolor e hinchazón persistente en rodilla derecha, fatiga, dificultad de concentración. Viaje a norte de España hace 1 año, eritema migratorio tratado con ATB orales 2 sem. EF: hinchazón articular sin eritema. IgG Borrelia (+), IgM (−). ¿Diagnóstico?</p>
+<ol type="a">
+<li>Artritis reumatoide</li>
+<li><strong>Artritis de Lyme tardía</strong></li>
+<li>LES</li>
+<li>Fiebre reumática</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Lyme tardío puede dar artritis (especialmente rodilla) + síntomas neurocognitivos crónicos. IgG (+) refleja exposición pasada. Tratamiento: doxiciclina 28 días o ceftriaxona iv si neuroborreliosis.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Extra 2025) Trabajador rural con ictericia y oliguria — etiología</summary>
+<div class="qa-body">
+<p>Hombre de 50 a. en tareas agrícolas, fiebre + mialgias + ictericia + oliguria. Aguas estancadas. ¿Etiología más probable?</p>
+<ol type="a">
+<li>Brucelosis</li>
+<li><strong>Leptospirosis</strong></li>
+<li>Endocarditis</li>
+<li>Fiebre Q</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Cuadro clásico del síndrome de Weil (leptospirosis grave). Brucelosis no produce ictericia ni oliguria.</div>
+</div></details>
+
+</section>
+
+<!-- =============== I15 =============== -->
+<section class="card" id="i15">
+<h2 class="section-title"><span class="num">I15</span>Infecciones por micobacterias</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li>Las micobacterias son bacilos ácido-alcohol resistentes (BAAR), de crecimiento lento, pared cerosa rica en ácidos micólicos.</li>
+<li><strong>Clasificación:</strong>
+  <ul>
+    <li><em>Complejo M. tuberculosis</em>: M. tuberculosis, M. bovis (incluyendo BCG), M. africanum, M. microti, M. canettii.</li>
+    <li><em>M. leprae</em>: lepra.</li>
+    <li><em>Micobacterias atípicas o no tuberculosas (NTM)</em>: complejo M. avium (MAI/MAC), M. kansasii, M. marinum, M. fortuitum, M. abscessus.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<h3>15.1 Tuberculosis (TBC)</h3>
+
+<h4>Epidemiología y patogenia</h4>
+<ul>
+<li>10 millones de casos/año mundialmente. España 8-10 casos/100.000.</li>
+<li><strong>Transmisión:</strong> aérea (gotitas pequeñas de Wells) por persona con TBC pulmonar bacilífera.</li>
+<li><strong>Infección primaria:</strong> bacilo en alveolo → fagocitado por macrófagos → granuloma con necrosis caseosa (foco de Ghon en parénquima + adenopatía hiliar = complejo de Ranke). En 90 % se controla; el bacilo queda latente.</li>
+<li><strong>Reactivación (5-10 % a lo largo de la vida):</strong> en ápices pulmonares (mejor oxigenación). Mayor riesgo: VIH, IS, DM, ERC, malnutrición, anti-TNF, edad.</li>
+</ul>
+
+<h4>Clínica</h4>
+<ul>
+<li>TBC pulmonar: tos &gt; 2-3 sem, expectoración, hemoptisis, dolor torácico, sudores nocturnos, fiebre, pérdida de peso.</li>
+<li>TBC extrapulmonar (sobre todo en VIH+ o inmigrantes): ganglionar (escrófula), pleural, miliar (diseminada), meníngea, ósea (Pott), genitourinaria (ver U9), pericárdica, peritoneal.</li>
+</ul>
+
+<h4>Diagnóstico de infección activa</h4>
+<ul>
+<li><strong>Rx tórax:</strong> infiltrados en lóbulos superiores, cavitaciones, adenopatías hiliares, miliar. Normal NO descarta.</li>
+<li><strong>Baciloscopia</strong> (Ziehl-Neelsen o Auramina) de esputo × 3 muestras consecutivas. Sensibilidad limitada (necesitan 10⁴ bacilos/mL).</li>
+<li><strong>Xpert MTB/RIF (PCR)</strong>: rápida (2 h), detecta M. tuberculosis y resistencia a rifampicina. <em>Prueba de elección actual</em>.</li>
+<li><strong>Cultivo en Löwenstein-Jensen o líquidos (BACTEC, MGIT)</strong>: gold standard. Lento (2-8 sem). Permite antibiograma completo.</li>
+<li>Toracocentesis (pleural): ADA &gt; 40 U/L muy sugestivo de pleuritis TBC. Biopsia pleural con histología (granulomas) y cultivo es la prueba de elección.</li>
+</ul>
+
+<h4>Diagnóstico de infección latente (ITL)</h4>
+<div class="table-wrap"><table>
+<thead><tr><th></th><th>Mantoux (PPD)</th><th>IGRA</th></tr></thead>
+<tbody>
+<tr><td>Técnica</td><td>Inyección ID + lectura a 48-72 h del diámetro de induración</td><td>Análisis de sangre con producción de IFN-γ por linfocitos T en respuesta a antígenos TBC específicos (QuantiFERON-Gold, T-SPOT.TB)</td></tr>
+<tr><td>Visitas</td><td>2</td><td>1</td></tr>
+<tr><td>Falsos + con BCG</td><td><strong>Sí</strong> (puede dar + en años recientes)</td><td>NO (antígenos no presentes en BCG)</td></tr>
+<tr><td>Inmunodeprimidos</td><td>Anergia (falsos negativos)</td><td>Indeterminado si CD4 muy bajos</td></tr>
+<tr><td>Distingue activa-latente</td><td>NO</td><td>NO</td></tr>
+<tr><td>Puntos de corte</td><td>≥ 5 mm en VIH, contactos, IS; ≥ 10 mm en países alta incidencia, sanitarios, niños; ≥ 15 mm en general</td><td>+ o −</td></tr>
+</tbody></table></div>
+
+<h4>Tratamiento de la TBC activa</h4>
+<ul>
+<li><strong>Esquema estándar 6 meses (2HRZE/4HR):</strong>
+  <ul>
+    <li><em>Fase intensiva (2 meses)</em>: <strong>Isoniazida (H) + Rifampicina (R) + Pirazinamida (Z) + Etambutol (E)</strong>.</li>
+    <li><em>Fase de continuación (4 meses)</em>: <strong>H + R</strong>.</li>
+  </ul>
+</li>
+<li>Variantes:
+  <ul>
+    <li>TBC meníngea o miliar: prolongar a 9-12 meses + corticoides.</li>
+    <li>TBC ósea: 9-12 meses.</li>
+    <li>VIH+: igual + ajustar interacciones con TAR (rifabutina en vez de rifampicina si TAR contiene inhibidores de proteasa o algunos II).</li>
+  </ul>
+</li>
+<li><strong>Efectos adversos:</strong>
+  <ul>
+    <li>Isoniazida: <em>hepatitis</em>, <em>neuropatía periférica</em> (asociar piridoxina/B6 25 mg/d).</li>
+    <li>Rifampicina: <em>color naranja</em> de secreciones, hepatitis, inducción enzimática (interacciones).</li>
+    <li>Pirazinamida: <em>hepatitis</em>, hiperuricemia.</li>
+    <li>Etambutol: <em>neuritis óptica</em> (vigilar agudeza visual y discriminación rojo/verde).</li>
+  </ul>
+</li>
+<li>Notificación obligatoria. Aislamiento respiratorio del paciente bacilífero hasta &gt; 2 baciloscopias negativas + clínica/Rx mejorada (típicamente 2-3 sem).</li>
+<li>Estudio de contactos: cribado con Mantoux/IGRA + Rx.</li>
+</ul>
+
+<h4>Tratamiento de la ITL</h4>
+<ul>
+<li>Indicaciones: contactos de bacilíferos, VIH+, IS, anti-TNF, conversión reciente, lesiones residuales no tratadas en Rx, niños &lt; 5 a. expuestos.</li>
+<li><strong>Opciones</strong>:
+  <ul>
+    <li>Rifampicina 4 meses (preferido por efectos adversos).</li>
+    <li>Isoniazida 6-9 meses.</li>
+    <li>Isoniazida + rifampicina 3 meses (3HR).</li>
+    <li>Isoniazida + rifapentina semanal × 12 dosis (3HP).</li>
+  </ul>
+</li>
+</ul>
+
+<h4>TBC multirresistente (MDR-TB) y extensamente resistente (XDR-TB)</h4>
+<ul>
+<li>MDR: resistencia a INH + RIF.</li>
+<li>XDR: MDR + resistencia a quinolona + un inyectable.</li>
+<li>Tratamiento prolongado (18-24 meses) con fármacos de 2ª línea: <em>bedaquilina, pretomanid, linezolid, fluoroquinolonas</em> (esquema BPaL aprobado).</li>
+</ul>
+
+<h3>15.2 Lepra (Mycobacterium leprae)</h3>
+<ul>
+<li>Incubación muy larga (años). Endémica en India, Brasil, África.</li>
+<li><strong>Formas (espectro de Ridley-Jopling):</strong>
+  <ul>
+    <li><em>Tuberculoide (TT)</em>: pocas lesiones bien definidas, hipopigmentadas, anestésicas. Buen pronóstico. Inmunidad celular conservada.</li>
+    <li><em>Lepromatosa (LL)</em>: lesiones numerosas, simétricas, facies leonina, madarosis (caída de cejas), neuritis periférica multifocal. Inmunidad celular pobre.</li>
+    <li>Formas intermedias.</li>
+  </ul>
+</li>
+<li>Diagnóstico: biopsia con BAAR (no cultivable in vitro).</li>
+<li>Tratamiento (OMS): <em>rifampicina + dapsona + clofazimina</em> durante 6 m (paucibacilar) o 12 m (multibacilar).</li>
+<li>Reacciones leprosas tipo I (regreso) y II (eritema nudoso leproso) durante el tratamiento — corticoides, talidomida.</li>
+</ul>
+
+<h3>15.3 Micobacterias no tuberculosas (NTM)</h3>
+<ul>
+<li><strong>Complejo M. avium (MAC)</strong>: infección oportunista en VIH avanzado (CD4 &lt; 50). Diseminada con fiebre, sudoración, pérdida de peso, organomegalias, citopenias. Tratamiento: <em>azitromicina o claritromicina + etambutol + rifabutina</em>. En pulmonar (mujeres ancianas — "Lady Windermere"): infiltrados nodulares + bronquiectasias.</li>
+<li><strong>M. kansasii</strong>: pulmonar similar a TBC. Tratamiento: HRE × 12-18 m.</li>
+<li><strong>M. marinum</strong>: "granuloma de los acuarios". Lesiones cutáneas nodulares en manos tras contacto con agua. Tratamiento: claritromicina + etambutol o rifampicina + etambutol.</li>
+<li><strong>M. fortuitum, M. abscessus, M. chelonae</strong>: crecimiento rápido. Infecciones cutáneas/postquirúrgicas. Resistencia múltiple.</li>
+<li><strong>M. ulcerans</strong>: úlcera de Buruli (África). Rifampicina + claritromicina.</li>
+</ul>
+
+<h3>15.4 Profilaxis BCG</h3>
+<ul>
+<li>Vacuna viva atenuada (M. bovis). Protege de formas graves (meníngea, miliar) en niños.</li>
+<li>Calendario español: NO se vacuna sistemáticamente (sí en algunas CCAA con alta incidencia).</li>
+<li>Contraindicada en inmunodeprimidos.</li>
+<li>Falsos positivos en Mantoux durante años (no en IGRA).</li>
+</ul>
+
+<h3>15.5 Preguntas — I15</h3>
+
+<details class="qa"><summary>1. (Ord 2025) TBC latente — manejo</summary>
+<div class="qa-body">
+<p>Varón de 30 a. asintomático, contacto con TBC bacilífera. IGRA (+). Rx tórax normal. ¿Siguiente paso?</p>
+<ol type="a">
+<li>Iniciar tratamiento para TBC activa</li>
+<li>No tratar, está asintomático</li>
+<li><strong>Diagnosticar infección tuberculosa latente e iniciar tratamiento (rifampicina 4 meses), tras descartar enfermedad activa</strong></li>
+<li>Repetir IGRA en 1 semana</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> IGRA (+) + Rx normal + asintomático = TBC latente. Tratar con rifampicina 4 m (o INH 6-9 m). Previene reactivación.</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) Inicio de TAR en VIH + TBC pulmonar</summary>
+<div class="qa-body">
+<p>Varón de 32 a. con VIH (CV 120.000, CD4 97) + TBC pulmonar miliar. Tras inicio antituberculosos. ¿Cuándo iniciar TAR?</p>
+<ol type="a">
+<li>Tratar primero TBC, demorar TAR 4-8 semanas</li>
+<li><strong>Iniciar TAR en las primeras 2 semanas, independientemente de CD4, excepto en meningitis tuberculosa</strong></li>
+<li>Iniciar TAR en 2 semanas independiente, aunque haya meningitis</li>
+<li>Esperar a terminar el tratamiento TBC</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En coinfección TBC-VIH con CD4 bajos se inicia TAR en 2 sem (mejor pronóstico). Excepción: meningitis TBC, donde el riesgo de empeoramiento neurológico por síndrome de reconstitución obliga a demorar 4-8 sem.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) TBC + VIH — tratamiento estándar</summary>
+<div class="qa-body">
+<p>¿Tratamiento inicial de TBC pulmonar en VIH?</p>
+<ol type="a">
+<li>Isoniazida sola</li>
+<li>Rifampicina + pirazinamida 18 m</li>
+<li><strong>HRZE × 2 m + HR × 4 m</strong></li>
+<li>Isoniazida + rifampicina × 12 m</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Esquema estándar 6 meses: 2HRZE/4HR. En VIH se usa igual, ajustando interacciones con TAR (rifabutina en vez de rifampicina si conflicto con TAR).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Extra 2025) IGRA — ventaja sobre Mantoux</summary>
+<div class="qa-body">
+<p>¿Cuál es una VENTAJA notable de los test IGRA frente a Mantoux?</p>
+<ol type="a">
+<li>IGRA menos específicos</li>
+<li>IGRA requieren dos visitas</li>
+<li><strong>El IGRA permite establecer el concepto "indeterminado" en inmunodeprimidos, que Mantoux interpretaría como negativo</strong></li>
+<li>IGRA diferencia infección latente de activa</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> En inmunodeprimidos con anergia, el Mantoux puede dar falso negativo. El IGRA, gracias a un control mitogénico interno, permite la categoría "indeterminado", que alerta al clínico.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Extra 2025) Pleuritis tuberculosa — diagnóstico más útil</summary>
+<div class="qa-body">
+<p>Mujer de 13 a. con tos + disnea + fiebre + pérdida de peso. Derrame pleural izquierdo serofibrinoso linfocitario, baciloscopia (−). ¿Qué prueba sería más útil?</p>
+<ol type="a">
+<li>Líquido pleural con predominio de PMN</li>
+<li><strong>Niveles altos de ADA en líquido pleural</strong></li>
+<li>Baciloscopia de esputo</li>
+<li>LDH en líquido pleural</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> ADA &gt; 40 U/L en líquido pleural exudado linfocitario es altamente sugestivo de pleuritis TBC. Confirmación con biopsia pleural (granulomas + bacilos).</div>
+</div></details>
+
+</section>
+
+<!-- =============== I16 =============== -->
+<section class="card" id="i16">
+<h2 class="section-title"><span class="num">I16</span>Estudio de las infestaciones por cestodos y nematodos</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Helmintos</strong> = gusanos parásitos. Tres grupos: <em>nematodos</em> (gusanos redondos), <em>cestodos</em> (tenias), <em>trematodos</em> (duelas, Schistosoma).</li>
+<li><strong>Causan eosinofilia</strong> casi todos durante la fase migratoria/sistémica (excepto los puramente intestinales adultos). En inmigrante con eosinofilia inexplicada → tratamiento empírico de "amplio espectro antiparasitario" (<em>albendazol + praziquantel + ivermectina</em>).</li>
+</ul>
+</div>
+
+<h3>16.1 Nematodos (gusanos redondos)</h3>
+
+<h4>Geohelmintos (transmisión fecal-oral o por penetración cutánea desde el suelo)</h4>
+<div class="table-wrap"><table>
+<thead><tr><th>Parásito</th><th>Transmisión</th><th>Clínica</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Ascaris lumbricoides</strong></td><td>Ingesta de huevos</td><td>Asintomático &gt; sintomático: obstrucción intestinal, biliar, pancreática. Migración pulmonar: síndrome de Löffler (tos, eosinofilia)</td><td>Albendazol DU 400 mg o mebendazol</td></tr>
+<tr><td><strong>Trichuris trichiura</strong></td><td>Ingesta de huevos</td><td>Diarrea crónica, prolapso rectal, anemia ferropénica</td><td>Albendazol 3 d o mebendazol</td></tr>
+<tr><td><strong>Anquilostomas</strong> (Ancylostoma duodenale, Necator)</td><td>Penetración cutánea de larvas</td><td>Prurito cutáneo + síndrome de Löffler + <em>anemia ferropénica</em> grave por pérdida sangre intestinal</td><td>Albendazol 3 d</td></tr>
+<tr><td><strong>Strongyloides stercoralis</strong></td><td>Penetración cutánea + autoinfestación</td><td>Asintomático crónico (eosinofilia + dolor abdominal). En IS: <em>síndrome de hiperinfección</em> con sepsis BGN, neumonía, mortal</td><td><strong>Ivermectina 200 µg/kg DU</strong> (o repetida)</td></tr>
+<tr><td><strong>Enterobius vermicularis</strong> (oxiuros)</td><td>Fecal-oral</td><td>Prurito anal nocturno en niños</td><td>Albendazol/mebendazol DU + repetir a las 2 sem · tratar familia</td></tr>
+</tbody></table></div>
+
+<h4>Filarias (transmitidas por insectos vectores en trópicos)</h4>
+<div class="kv-grid">
+<div class="kv"><span class="k">Wuchereria bancrofti / Brugia malayi</span><span class="v"><em>Filariasis linfática</em> → linfangitis recurrente, elefantiasis. Mosquito vector. Tratamiento: dietilcarbamazina (DEC), ivermectina + albendazol</span></div>
+<div class="kv"><span class="k">Onchocerca volvulus</span><span class="v"><em>Ceguera de los ríos (oncocercosis)</em>. Simulium (mosca negra). África. Tratamiento: <strong>ivermectina</strong> anual + doxiciclina</span></div>
+<div class="kv"><span class="k">Loa loa</span><span class="v">Conjuntiva visible. África. Calabar swellings. DEC, ivermectina (cuidado con encefalopatía)</span></div>
+<div class="kv"><span class="k">Dracunculus medinensis</span><span class="v">Dracunculiasis ("gusano de Guinea"). En extinción</span></div>
+</div>
+
+<h4>Trichinella spiralis</h4>
+<p>Ingesta de carne de cerdo o jabalí mal cocinada. Fiebre + mialgias + <em>edema periorbitario + eosinofilia + ↑ CK</em>. Triquinosis. Tratamiento: albendazol/mebendazol + corticoides.</p>
+
+<h4>Larva migrans cutánea</h4>
+<p>Ancylostoma braziliense (perros, gatos en playas tropicales). Surco serpiginoso pruriginoso. Tratamiento: albendazol oral o ivermectina.</p>
+
+<h4>Toxocara canis/cati</h4>
+<p>Larva migrans visceral (niños) o ocular. Eosinofilia + hepatomegalia + fiebre + neumonitis. Tratamiento: albendazol + corticoides.</p>
+
+<h4>Anisakiosis</h4>
+<ul>
+<li>Anisakis simplex en pescado crudo (sushi, boquerón en vinagre).</li>
+<li>Clínica: dolor abdominal súbito horas tras ingesta + náuseas + vómitos. Reacciones alérgicas (urticaria, anafilaxia).</li>
+<li>Diagnóstico: endoscopia (visualización + extracción del gusano).</li>
+<li>Prevención: <em>congelación &lt; -20 °C × 24 h</em> antes de consumir crudo. Cocción adecuada.</li>
+</ul>
+
+<h3>16.2 Cestodos (tenias)</h3>
+<div class="table-wrap"><table>
+<thead><tr><th>Parásito</th><th>Transmisión</th><th>Clínica</th><th>Tratamiento</th></tr></thead>
+<tbody>
+<tr><td><strong>Taenia saginata</strong> (de la vaca)</td><td>Carne de vacuno cruda/poco cocinada</td><td>Asintomática o leve, salida de proglótides por ano</td><td>Praziquantel DU 10 mg/kg o niclosamida</td></tr>
+<tr><td><strong>Taenia solium</strong> (del cerdo)</td><td>Carne de cerdo o ingesta de huevos (cisticercosis)</td><td>Tenia intestinal asintomática. <em>Cisticercosis (huevos)</em>: quistes en músculo, ojo, <strong>SNC (neurocisticercosis = causa más frecuente de epilepsia adquirida en países endémicos)</strong></td><td>Tenia: praziquantel/niclosamida. Neurocisticercosis: <em>albendazol + corticoides + antiepilépticos</em>; cuidado con la respuesta inflamatoria</td></tr>
+<tr><td><strong>Echinococcus granulosus</strong></td><td>Contacto con perros (huevos)</td><td><em>Quiste hidatídico</em> hepático (más frecuente), pulmonar, cerebral. Asintomático años, complicaciones (rotura, anafilaxia, infección, fistulización)</td><td><strong>Cirugía</strong> (quistectomía o resección) ± <em>albendazol</em> peri-quirúrgico. Alternativa: PAIR (punción-aspiración-inyección de etanol-reaspiración). NUNCA pinchar sin protocolo (anafilaxia)</td></tr>
+<tr><td><strong>Echinococcus multilocularis</strong></td><td>Zorros (Norte de España)</td><td>Equinococosis alveolar — similar a tumor maligno hepático, infiltrativa</td><td>Resección + albendazol prolongado</td></tr>
+<tr><td><strong>Diphyllobothrium latum</strong></td><td>Pescado de agua dulce crudo</td><td>Asintomática o <em>anemia megaloblástica</em> (consume vit B12)</td><td>Praziquantel</td></tr>
+<tr><td><strong>Hymenolepis nana</strong></td><td>Fecal-oral</td><td>Niños. Asintomática</td><td>Praziquantel</td></tr>
+</tbody></table></div>
+
+<h4>Quiste hidatídico hepático</h4>
+<ul>
+<li><em>Echinococcus granulosus</em>. Endémico en zonas rurales, especialmente con pastoreo (España, Argentina, Marruecos, Australia).</li>
+<li>Diagnóstico: ecografía (clasificación de Gharbi/OMS — CE1-CE5), TAC/RM, serología (ELISA, Western blot), eosinofilia variable.</li>
+<li>Tratamiento según fase de Gharbi/CE:
+  <ul>
+    <li>CE1-CE2 (activos): cirugía o PAIR + albendazol.</li>
+    <li>CE3 (transición): albendazol ± PAIR.</li>
+    <li>CE4-CE5 (inactivos): observación.</li>
+  </ul>
+</li>
+<li><em>Punción evitada antiguamente</em> por riesgo de anafilaxia y siembra; hoy PAIR es opción válida con protocolo.</li>
+</ul>
+
+<h3>16.3 Trematodos</h3>
+<div class="kv-grid">
+<div class="kv"><span class="k">Schistosoma haematobium</span><span class="v">Esquistosomiasis urinaria (ver U9). Hematuria, fibrosis vesical, carcinoma escamoso. Praziquantel</span></div>
+<div class="kv"><span class="k">Schistosoma mansoni / japonicum</span><span class="v">Esquistosomiasis hepatoesplénica, hipertensión portal. Praziquantel</span></div>
+<div class="kv"><span class="k">Fasciola hepatica</span><span class="v">Berro contaminado. Hepatitis, cólico biliar. Triclabendazol</span></div>
+<div class="kv"><span class="k">Paragonimus</span><span class="v">Cangrejos crudos. Quistes pulmonares. Praziquantel</span></div>
+</div>
+
+<h3>16.4 Fiebre de Katayama</h3>
+<p>Reacción de hipersensibilidad sistémica durante la fase aguda de Schistosoma. Fiebre + urticaria + eosinofilia + tos + hepatoesplenomegalia 4-8 semanas tras exposición a agua dulce contaminada. Tratamiento: corticoides + praziquantel (tras inflamación inicial).</p>
+
+<h3>16.5 Tratamiento empírico antiparasitario en eosinofilia de inmigrante</h3>
+<div class="box box-tip">
+<div class="box-title"><span class="icon">💊</span>Tras estudio negativo</div>
+<p style="margin:0">Ante <em>eosinofilia &gt; 500/µL en inmigrante sin etiología clara</em> tras estudio razonable (parásitos en heces, orina, serologías), se da empíricamente:</p>
+<ul style="margin:6px 0">
+<li><strong>Albendazol 400 mg/12 h × 5-7 días</strong> (nematodos intestinales, Strongyloides, ascaris, larva migrans).</li>
+<li><strong>Praziquantel 40 mg/kg DU</strong> (esquistosomas, tenias).</li>
+<li><strong>Ivermectina 200 µg/kg DU (± repetir)</strong> (Strongyloides, filarias).</li>
+</ul>
+</div>
+</section>
+
+<!-- =============== I17 =============== -->
+<section class="card" id="i17">
+<h2 class="section-title"><span class="num">I17</span>Infección por VIH</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Historia natural:</strong>
+  <ul>
+    <li><em>Primoinfección (síndrome retroviral agudo)</em>: 2-4 sem post-contagio. Fiebre + adenopatías + faringitis + <em>exantema maculopapular en cara/tronco/palmas/plantas</em> + úlceras orales. Test rápido y serología pueden ser (−); CV de VIH muy alta (millones/mL).</li>
+    <li>Asintomática crónica.</li>
+    <li>SIDA: CD4 &lt; 200 o enfermedad definitoria (PJP, toxoplasmosis cerebral, CMV retinitis, Kaposi, linfoma cerebral primario, criptococosis…).</li>
+  </ul>
+</li>
+<li><strong>TAR (terapia antirretroviral):</strong>
+  <ul>
+    <li><em>Iniciar en TODOS los pacientes con VIH</em> lo antes posible, independiente de CD4 y CV.</li>
+    <li>Combinación preferida actual: <em>2 INTI + 1 INI</em> (inhibidor de integrasa).</li>
+    <li>Combinación frecuente: <em>tenofovir alafenamida (TAF) + emtricitabina (FTC) + bictegravir o dolutegravir</em> (combo en 1 píldora).</li>
+    <li>Combinaciones obsoletas: zidovudina, stavudina, didanosina, indinavir.</li>
+  </ul>
+</li>
+<li><strong>Inicio en coinfección:</strong>
+  <ul>
+    <li><em>VIH + TBC</em>: TAR en 2 sem (excepto meningitis TBC: 4-8 sem).</li>
+    <li><em>VIH + PJP</em>: TAR en 2 sem.</li>
+    <li><em>VIH + meningitis criptocócica</em>: demorar 4-6 sem.</li>
+  </ul>
+</li>
+<li><strong>PrEP (profilaxis preexposición):</strong>
+  <ul>
+    <li>Indicada en personas de alto riesgo: HSH con múltiples parejas, parejas serodiscordantes, IVDU con prácticas de riesgo, trabajadores sexuales.</li>
+    <li>Pauta: TDF/FTC diaria o "a demanda" (esquema 2-1-1 antes/después del coito).</li>
+    <li>Antes de iniciar: confirmar VIH (−). Controles serológicos cada 3 m.</li>
+    <li><em>Fracaso raro</em>: incluso con buena adherencia, posible por exposición a virus con resistencias.</li>
+  </ul>
+</li>
+<li><strong>Manifestaciones por CD4:</strong>
+  <ul>
+    <li>CD4 &lt; 200: PJP, candidiasis esofágica.</li>
+    <li>CD4 &lt; 100: toxoplasmosis cerebral, criptococosis.</li>
+    <li>CD4 &lt; 50: CMV retinitis, MAC, linfoma cerebral primario.</li>
+  </ul>
+</li>
+<li><strong>Toxoplasmosis cerebral:</strong> VIH + CD4 &lt; 100 + lesiones hipodensas múltiples con realce anular en TC. Tratamiento: pirimetamina + sulfadiazina + ácido folínico.</li>
+</ul>
+</div>
+
+<h3>17.1 Preguntas — I17</h3>
+
+<details class="qa"><summary>1. (Ord 2025) Primoinfección VIH con exantema</summary>
+<div class="qa-body">
+<p>Mujer de 20 a. con fiebre + adenopatías + exantema, 3 sem tras relación sexual de riesgo. ¿Cuál es verdadera sobre la infección aguda por VIH?</p>
+<ol type="a">
+<li>Exantema pruriginoso solo en extremidades</li>
+<li><strong>Lesiones maculopapulosas, eritematosas, pueden afectar cara, cuello, tronco, palmas y plantas</strong></li>
+<li>La primoinfección nunca presenta síntomas</li>
+<li>La serología es siempre positiva en la 1ª semana</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Exantema generalizado (incluye palmas y plantas, similar a la sífilis 2ª) + odinofagia + fiebre + adenopatías = síndrome retroviral agudo. Test rápido puede ser (−). Pedir <em>carga viral</em> de VIH (es muy alta).</div>
+</div></details>
+
+<details class="qa"><summary>2. (Ord 2025) HSH con exantema y test VIH/RPR negativos — primoinfección</summary>
+<div class="qa-body">
+<p>Varón de 28 a., HSH receptivo sin protección hace 3 sem. Fiebre + odinofagia + exantema + adenopatías. Test rápido VIH y RPR negativos. ¿Diagnóstico más probable?</p>
+<ol type="a">
+<li><strong>Primoinfección por VIH</strong></li>
+<li>Infección crónica por VIH</li>
+<li>Mononucleosis por VEB</li>
+<li>Sífilis secundaria</li>
+</ol>
+<div class="answer"><strong>Respuesta: a.</strong> El intervalo de "ventana serológica" puede dar test rápido y RPR (−) en primoinfección. Pedir CV de VIH y repetir serología en 4-6 sem.</div>
+</div></details>
+
+<details class="qa"><summary>3. (Ord 2025) VIH + PJP — inicio de TAR</summary>
+<div class="qa-body">
+<p>Varón 35 a. con VIH + PJP. CD4 90, CV 345.625. Se inicia TMP-SMX. ¿Sobre el TAR?</p>
+<ol type="a">
+<li>Retrasar hasta conocer resistencias</li>
+<li><strong>Iniciar TAR lo antes posible, independientemente de CD4 o CV</strong></li>
+<li>Solo si síntomas graves</li>
+<li>Contraindicado si infecciones oportunistas activas</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> En coinfección VIH-PJP, iniciar TAR en 2 sem mejora pronóstico. Excepción: criptococosis y meningitis TBC (demorar 4-6 sem por riesgo de IRIS grave).</div>
+</div></details>
+
+<details class="qa"><summary>4. (Ord 2025) Toxoplasmosis cerebral en VIH</summary>
+<div class="qa-body">
+<p>Varón 38 a. con VIH no tratado. Convulsiones, cefalea, debilidad de hemicuerpo derecho. TAC: lesiones hipodensas múltiples con edema. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Meningitis criptocócica</li>
+<li>Encefalopatía por VIH</li>
+<li><strong>Toxoplasmosis cerebral</strong></li>
+<li>LMP</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> VIH no tratado + lesiones focales múltiples con realce anular = toxoplasmosis cerebral hasta demostrar lo contrario. Tratamiento: pirimetamina + sulfadiazina + ácido folínico. Si no respuesta en 2 sem: biopsia para descartar linfoma primario SNC.</div>
+</div></details>
+
+<details class="qa"><summary>5. (Ord 2025) Caquexia + diarrea + candidiasis oral en VIH</summary>
+<div class="qa-body">
+<p>Varón 38 a. con fiebre + diarrea crónica + pérdida 8 kg + astenia + candidiasis oral + linfadenopatía. Linfocitos totales 400/µL. ¿Diagnóstico?</p>
+<ol type="a">
+<li>Primoinfección VIH</li>
+<li>Infección crónica asintomática</li>
+<li><strong>SIDA</strong></li>
+<li>Reacción alérgica</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Síndrome consuntivo + candidiasis oral (definitoria de SIDA) en VIH avanzado. Iniciar TAR + tratar infecciones oportunistas + profilaxis (TMP-SMX, azitromicina).</div>
+</div></details>
+
+<details class="qa"><summary>6. (Ord 2025) PrEP con CV detectable</summary>
+<div class="qa-body">
+<p>Varón de 32 a., HSH, en PrEP (TDF/FTC) 12 m. Serología VIH (−) pero CV 600 copias/mL. ITS recientes, pareja con VIH no tratado. ¿Cuál es correcta?</p>
+<ol type="a">
+<li>PrEP no es eficaz en HSH</li>
+<li>Fracaso de PrEP suele producirse cuando hay ITS</li>
+<li><strong>La transmisión durante PrEP puede ocurrir excepcionalmente por exposición a virus con resistencias, aunque la adherencia sea óptima</strong></li>
+<li>Si la serología es negativa, no hace falta CV</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Los fracasos de PrEP son raros y suelen deberse a exposición a virus con resistencias a los fármacos de la PrEP (especialmente TDF/FTC). Confirmar con CV en cada control y derivar a especialista.</div>
+</div></details>
+
+<details class="qa"><summary>7. (Ord 2025) Inicio temprano de TAR</summary>
+<div class="qa-body">
+<p>Sobre el inicio temprano del TAR:</p>
+<ol type="a">
+<li>No afecta a la transmisión</li>
+<li><strong>Reduce la progresión de eventos clínicos relacionados con SIDA</strong></li>
+<li>Aumenta enfermedad CV</li>
+<li>No impacta en mortalidad</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Inicio precoz (estudios START, TEMPRANO) reduce progresión a SIDA, mortalidad, eventos clínicos y transmisión (U=U: undetectable = untransmittable).</div>
+</div></details>
+
+<details class="qa"><summary>8. (Extra 2025) TAR de primera elección actual</summary>
+<div class="qa-body">
+<p>Paciente de 35 a. VIH-1 recién diagnosticado. ¿Combinación inicial preferente?</p>
+<ol type="a">
+<li>Zidovudina/lamivudina + efavirenz</li>
+<li><strong>Tenofovir alafenamida/emtricitabina/bictegravir (combo)</strong></li>
+<li>Abacavir + didanosina + nevirapina</li>
+<li>Stavudina + lamivudina + raltegravir</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Combinaciones modernas con INI (bictegravir, dolutegravir) + 2 INTI (TAF/FTC) = preferidas por eficacia, tolerabilidad y barrera genética. Stavudina y didanosina están abandonadas por toxicidad.</div>
+</div></details>
+
+<details class="qa"><summary>9. (Extra 2025) PrEP en HSH — indicaciones</summary>
+<div class="qa-body">
+<p>¿Cuál es correcta sobre las indicaciones de PrEP en HSH?</p>
+<ol type="a">
+<li>Solo en HSH VIH-positivos</li>
+<li>Solo en HSH con parejas estables</li>
+<li><strong>Se recomienda en HSH con múltiples parejas y que no usan preservativos regularmente</strong></li>
+<li>Solo para hombres heterosexuales</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> PrEP indicada en personas VIH-negativas de alto riesgo: HSH/MTS con prácticas sin protección, parejas serodiscordantes, IVDU.</div>
+</div></details>
+
+<details class="qa"><summary>10. (Extra 2025) Sífilis con afectación meníngea — diagnóstico</summary>
+<div class="qa-body">
+<p>¿Método más efectivo para diagnosticar afectación meníngea en sífilis?</p>
+<ol type="a">
+<li>TC</li>
+<li>RM</li>
+<li><strong>Análisis de LCR con VDRL</strong></li>
+<li>FTA-ABS en sangre</li>
+</ol>
+<div class="answer"><strong>Respuesta: c.</strong> Neurosífilis = análisis del LCR. Hallazgos: pleocitosis linfocitaria, ↑ proteínas, VDRL (+) en LCR (muy específica aunque sensibilidad baja). Tratamiento: penicilina G iv 10-14 días.</div>
+</div></details>
+
+<details class="qa"><summary>11. (Extra 2025) Sífilis latente de duración desconocida — tratamiento</summary>
+<div class="qa-body">
+<p>¿Tratamiento de la sífilis latente de duración desconocida?</p>
+<ol type="a">
+<li>1 dosis de penicilina benzatínica IM</li>
+<li><strong>3 dosis de penicilina benzatínica IM (1,2 millones UI en cada glúteo, semanal, 3 semanas)</strong></li>
+<li>28 días de doxiciclina oral</li>
+<li>2 dosis de penicilina benzatínica IM</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Sífilis tardía o de duración desconocida = 3 dosis semanales de penicilina G benzatínica 2,4 millones IM (1,2 + 1,2 en cada glúteo). Sífilis precoz (&lt; 1 año) = 1 dosis única.</div>
+</div></details>
+
+</section>
+
+<!-- ============================================================ -->
+<!-- SEMINARIOS -->
+<!-- ============================================================ -->
+<div class="bloque-banner" id="sem">
+  <h2>🎓 SEMINARIOS</h2>
+  <div class="b-sub">Sífilis e ITS · Infecciones SNC · Inmunodeprimidos · Casos clínicos urológicos</div>
+</div>
+
+<section class="card">
+<h2 class="section-title"><span class="num">S1</span>Sífilis e ITS (Dr. Andrés Ruiz Sancho)</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Treponema pallidum</strong>. Fases:
+  <ul>
+    <li><em>Primaria</em>: chancro (úlcera indolora, indurada, no purulenta) + adenopatía regional indolora. 3 sem post-contagio.</li>
+    <li><em>Secundaria</em>: 6-8 sem después. Exantema maculopapular en tronco + palmas + plantas, condilomas planos, linfadenopatía generalizada, fiebre.</li>
+    <li><em>Latente</em>: precoz (&lt; 1 a) vs tardía (&gt; 1 a) o de duración desconocida.</li>
+    <li><em>Terciaria</em>: gomas, neurosífilis, sífilis cardiovascular (aortitis).</li>
+  </ul>
+</li>
+<li><strong>Diagnóstico:</strong> serología treponémica (FTA-ABS, TPHA, EIA) + no treponémica (VDRL, RPR). VDRL/RPR útiles para seguimiento.</li>
+<li><strong>Tratamiento:</strong> penicilina benzatínica IM (1 dosis si precoz, 3 dosis si tardía). Neurosífilis: penicilina G iv 10-14 d.</li>
+<li>Otras ITS frecuentes: gonococo (ceftriaxona + azitromicina), Chlamydia (doxiciclina), Trichomonas (metronidazol), VPH, VHS, VIH.</li>
+</ul>
+</div>
+</section>
+
+<section class="card">
+<h2 class="section-title"><span class="num">S2</span>Infecciones del SNC (Dr. Manuel Colmenero)</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Meningitis bacteriana aguda:</strong> emergencia. Iniciar <em>antibiótico empírico inmediatamente</em> tras toma de hemocultivos, sin esperar a TC ni a la PL si hay alta sospecha clínica.</li>
+<li>Tríada clásica: fiebre + cefalea + rigidez de nuca. + alteración del nivel de conciencia, fotofobia, vómitos, signos focales.</li>
+<li><strong>Etiología por edad:</strong>
+  <ul>
+    <li>Recién nacidos: S. agalactiae, E. coli, Listeria.</li>
+    <li>Niños/adultos jóvenes: N. meningitidis, S. pneumoniae.</li>
+    <li>Mayores/comorbilidad: S. pneumoniae, Listeria (cubrir con ampicilina en &gt; 50 a o inmunodeprimidos).</li>
+  </ul>
+</li>
+<li><strong>Tratamiento empírico:</strong> <em>ceftriaxona + vancomicina ± ampicilina (si &gt; 50 a o inmunodeprimido) ± aciclovir si sospecha de encefalitis VHS</em>. Dexametasona 0,15 mg/kg/6 h antes/con la primera dosis de ATB (reduce mortalidad y secuelas en neumococo).</li>
+<li><strong>PL:</strong> tras TC si signos focales/papiledema/coma. Análisis: presión, células, glucosa, proteínas, Gram, cultivo, PCR.</li>
+<li><strong>Patrones LCR:</strong>
+  <ul>
+    <li>Bacteriana: pleocitosis PMN, ↓ glucosa, ↑ proteínas.</li>
+    <li>Viral: pleocitosis linfocitaria, glucosa normal, proteínas N/↑.</li>
+    <li>TBC: linfocitaria, ↓ glucosa, ↑ proteínas. ADA ↑.</li>
+    <li>Criptococo: linfocitaria, ↓ glucosa. Tinción con tinta china.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<details class="qa"><summary>(Ord 2025) Otalgia + fiebre + cefalea + somnolencia — sospecha de meningitis</summary>
+<div class="qa-body">
+<p>Paciente de 45 a. con otalgia 4 días + fiebre 39 + cefalea + náuseas + somnolencia. ¿Tratamiento correcto?</p>
+<ol type="a">
+<li>Identificar germen antes de iniciar ATB</li>
+<li><strong>Ante sospecha de meningitis debe iniciarse ATB empírico lo antes posible</strong></li>
+<li>Esperar TAC craneal y PL antes de iniciar ATB</li>
+<li>El tratamiento inicial es con monoterapia</li>
+</ol>
+<div class="answer"><strong>Respuesta: b.</strong> Ante sospecha alta de meningitis bacteriana → iniciar ATB empírico INMEDIATAMENTE tras hemocultivos. NO esperar a TC/PL. La PL puede demorarse pero el ATB no.</div>
+</div></details>
+</section>
+
+<section class="card">
+<h2 class="section-title"><span class="num">S3</span>Infecciones en inmunodeprimidos (Dra. Carmen Hidalgo Tenorio)</h2>
+
+<div class="box box-resumen">
+<div class="box-title"><span class="icon">⚡</span>Resumen exprés</div>
+<ul>
+<li><strong>Causas de inmunocompromiso:</strong> corticoides &gt; 20 mg/d prednisona, quimioterapia, trasplante, VIH, ERC/diálisis, DM mal controlada, malnutrición, edad avanzada.</li>
+<li><strong>Neutropenia febril:</strong>
+  <ul>
+    <li>Neutrófilos &lt; 500/µL (grave) o &lt; 100 (profunda).</li>
+    <li>Fiebre = uniaxilar &gt; 38,3 ºC o &gt; 38 ºC durante &gt; 1 h.</li>
+    <li>Foco más frecuente: respiratorio (30-40 %). Mortalidad ~5-10 % (no 30 %).</li>
+    <li>Tratamiento empírico inmediato: <em>piperacilina-tazobactam o cefepima o meropenem ± vancomicina si catéter/mucositis</em>. Añadir antifúngico si fiebre persiste &gt; 4-7 d.</li>
+  </ul>
+</li>
+<li><strong>Profilaxis en VIH avanzado:</strong>
+  <ul>
+    <li>CD4 &lt; 200: TMP-SMX para PJP.</li>
+    <li>CD4 &lt; 100: añadir profilaxis para toxoplasmosis (TMP-SMX cubre).</li>
+    <li>CD4 &lt; 50: azitromicina semanal para MAC.</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<details class="qa"><summary>(Ord 2025) Condiciones de inmunocompromiso</summary>
+<div class="qa-body">
+<p>Las condiciones que pueden llevar a un estado de inmunocompromiso incluyen:</p>
+<ol type="a">
+<li>Corticosteroides a dosis altas (&gt; 20 mg/d prednisona)</li>
+<li>DM, ERC (uremia), malnutrición</li>
+<li>Edad avanzada</li>
+<li><strong>Todas las anteriores</strong></li>
+</ol>
+<div class="answer"><strong>Respuesta: d.</strong> Todas son condiciones que comprometen la inmunidad. La mayoría son combinables.</div>
+</div></details>
+
+<details class="qa"><summary>(Extra 2025) Neutropenia febril — FALSA</summary>
+<div class="qa-body">
+<p>Sobre la neutropenia febril, señale la FALSA:</p>
+<ol type="a">
+<li>La tasa de complicaciones mayores en neutropenia febril es 25-30 %</li>
+<li><strong>La mortalidad en neutropenia febril es del 30 %</strong></li>
+<li>Neutropenia grave = neutrófilos &lt; 500/µL; profunda &lt; 100/µL</li>
+<li>Foco más común: tracto respiratorio (30-40 %)</li>
+</ol>
+<div class="answer"><strong>Respuesta: b (FALSA).</strong> La mortalidad global en neutropenia febril es del 5-10 % (no 30 %). En sepsis grave la mortalidad sube, pero la mortalidad global con tratamiento empírico precoz es baja.</div>
+</div></details>
+</section>
+
+<!-- ============================================================ -->
+<!-- CONSEJOS FINALES -->
+<!-- ============================================================ -->
+<section class="card" id="final" style="background:linear-gradient(135deg,#eff6ff,#dbeafe);border:2px solid var(--primary);">
+<h2 class="section-title"><span class="num">⭐</span>Consejos finales — cómo usar este skrypt</h2>
+
+<ol style="font-size:15px;line-height:1.8">
+<li><strong>Estructura del examen:</strong> 100 preguntas (32 Urología + 25 Nefrología + 43 Infecciosas). 4 opciones, 1 correcta. <em>Cada error resta 0,33</em> → marca solo si estás razonablemente seguro.</li>
+<li><strong>Aprobado por bloques:</strong> necesitas 50 % en cada bloque. <em>Si suspendes solo un bloque, en convocatoria extraordinaria solo te examinas de ese</em> (no pierdes lo aprobado).</li>
+<li><strong>Estrategia de estudio:</strong>
+  <ul>
+    <li>Empieza por los <em>resúmenes exprés</em> de cada tema → te dan el 70 % del valor.</li>
+    <li>Haz una <em>pasada general</em> rápida de cada bloque sin profundizar.</li>
+    <li>Practica con las preguntas (~95 ya resueltas aquí + las que añadas de otros exámenes).</li>
+    <li>Repaso final: tablas comparativas + reglas mnemotécnicas.</li>
+  </ul>
+</li>
+</ol>
+
+<div class="box box-mnemo">
+<div class="box-title"><span class="icon">🧠</span>Reglas mnemotécnicas que valen oro</div>
+<ul>
+<li><strong>UROLOGÍA</strong>
+  <ul>
+    <li>Lactante VARÓN con hidronefrosis bilateral + ITU → VUP</li>
+    <li>Polo SUPERIOR del uréter duplicado = caudal-interno + ureterocele (Weigert-Meyer)</li>
+    <li>Pielonefritis OBSTRUCTIVA = derivación urinaria URGENTE + ATB</li>
+    <li>Garden III-IV = artroplastia · Garden I-II = tornillos</li>
+    <li>Trauma renal grado III = laceración &gt; 1 cm sin sistema colector; grado IV = urohematoma</li>
+    <li>Cistitis simple = fosfomicina trometamol 3 g DU</li>
+    <li>Hematuria + fumador + &gt; 50 a = CISTOSCOPIA (cáncer vesical hasta demostrar lo contrario)</li>
+    <li>Tu = AFP en seminoma puro = imposible</li>
+    <li>Varicocele DERECHO de novo en adulto = TAC retroperitoneal</li>
+    <li>Inhibidores PDE-5 + nitritos = CONTRAINDICADO</li>
+  </ul>
+</li>
+<li><strong>NEFROLOGÍA</strong>
+  <ul>
+    <li>IRA prerrenal: FENa &lt; 1, Na urinario &lt; 20, urea/Cr &gt; 20, osmU &gt; 500</li>
+    <li>NIA por fármacos: fiebre + exantema + eosinofilia + IRA → suspender fármaco</li>
+    <li>GN membranosa = SN + "spikes" + anti-PLA2R</li>
+    <li>Anti-MBG + hemorragia alveolar = Goodpasture → plasmaféresis URGENTE</li>
+    <li>Bartter = furosemida-like (hipocalciuria, alcalosis, ↓K)</li>
+    <li>Gitelman = tiazidas-like (hipocalciuria, ↓K, ↓Mg)</li>
+    <li>Cromosoma 16 = PKD1 + esclerosis tuberosa</li>
+    <li>iSGLT2 en ERC con albuminuria, incluso sin DM</li>
+    <li>ERC: T-score & Z-score son de DXA — para ERC se usa G (FG) + A (albuminuria)</li>
+  </ul>
+</li>
+<li><strong>INFECCIOSAS</strong>
+  <ul>
+    <li>Shock séptico = sepsis + vasopresores para PAM ≥ 65 + lactato &gt; 2</li>
+    <li>Bundle 1ª hora: hemocultivos → ATB &lt; 1 h → cristaloides 30 mL/kg</li>
+    <li>E. coli BLEE = ertapenem o meropenem</li>
+    <li>Tache noire + verano + sierra = Rickettsiosis (doxiciclina)</li>
+    <li>Pedro Pons + sudores + cabras = brucelosis (doxi + genta)</li>
+    <li>Endocarditis con HMC (−) + valvular = ETE → considerar HACEK, Coxiella, Bartonella</li>
+    <li>Legionella + hiponatremia + ↑LDH + extrapulmonar = levofloxacino</li>
+    <li>Hifas en ángulo recto, no septadas = mucormicosis → anfo + cirugía</li>
+    <li>Halo signo + galactomanano = aspergilosis → voriconazol</li>
+    <li>VIH + lesiones cerebrales múltiples con anillo = toxoplasmosis</li>
+    <li>VIH + TBC pulmonar = TAR en 2 sem (excepto meningitis TBC: 4-8 sem)</li>
+    <li>Mantoux/IGRA (+) + Rx normal = TBC latente → rifampicina 4 m o INH 6-9 m</li>
+    <li>Tétanos = desbridar + IGT + vacuna + benzodiacepinas</li>
+    <li>Botulismo = parálisis flácida descendente + autonómica + SIN fiebre/sensitiva</li>
+    <li>Sífilis tardía/desconocida = 3 dosis de penicilina benzatínica semanales</li>
+    <li>Neurosífilis = LCR con VDRL → penicilina G iv 10-14 d</li>
+  </ul>
+</li>
+</ul>
+</div>
+
+<div class="box box-tip">
+<div class="box-title"><span class="icon">💪</span>Mensaje final</div>
+<p style="margin:0;font-size:15px"><strong>¡Mucha suerte, Jan!</strong> Este examen tiene 3 bloques independientes, así que organiza el estudio en 3 fases. Si dedicas 4-5 días a cada bloque + 2 días de repaso integrador, llegas al examen con sobrada preparación. Acuérdate: <em>cada error resta 0,33</em>, así que solo marca pregunta cuando estás razonablemente convencido. Y si tienes dudas: las preguntas de los exámenes 2025 que están aquí son altísimamente predictivas de lo que cae. ¡A por ello!</p>
+</div>
+</section>
+
+</main>
+</div>
+
+<footer>
+  Documento elaborado para Jan Fedak · mayo 2026 · a partir de materiales del prof. Arrabal, Cózar, Colmenero, Hidalgo, Ruiz Sancho, Ortego y col. (UGR), exámenes ordinaria/extraordinaria 2025, bancos MIR de Nefrología, Urología y Enfermedades Infecciosas. <br>
+  <em>Compendio personal de estudio · uso exclusivo</em>
+</footer>
+
+<script src="script.js"></script>
+
+</body>
+</html>

--- a/jasiu/granada/urinaria-infecciosas/script.js
+++ b/jasiu/granada/urinaria-infecciosas/script.js
@@ -1,0 +1,68 @@
+// Filtro del índice
+(function () {
+  var search = document.getElementById('tocSearch');
+  if (!search) return;
+  search.addEventListener('input', function () {
+    var q = this.value.toLowerCase().trim();
+    var list = document.querySelectorAll('#tocList li');
+    list.forEach(function (li) {
+      if (li.classList.contains('group-title')) { li.style.display = ''; return; }
+      var txt = (li.textContent || '').toLowerCase();
+      li.style.display = (!q || txt.indexOf(q) >= 0) ? '' : 'none';
+    });
+  });
+})();
+
+// TOC plegable en móvil
+(function () {
+  var sidebar = document.querySelector('.sidebar');
+  if (!sidebar) return;
+  var h3 = sidebar.querySelector('h3');
+  if (!h3) return;
+
+  var mq = window.matchMedia('(max-width: 1100px)');
+
+  function applyState() {
+    if (mq.matches) {
+      sidebar.classList.add('is-collapsible');
+      h3.setAttribute('role', 'button');
+      h3.setAttribute('tabindex', '0');
+      h3.setAttribute('aria-expanded', sidebar.classList.contains('is-open') ? 'true' : 'false');
+    } else {
+      sidebar.classList.remove('is-collapsible');
+      sidebar.classList.remove('is-open');
+      h3.removeAttribute('role');
+      h3.removeAttribute('tabindex');
+      h3.removeAttribute('aria-expanded');
+    }
+  }
+
+  function toggle() {
+    if (!mq.matches) return;
+    var nowOpen = !sidebar.classList.contains('is-open');
+    sidebar.classList.toggle('is-open', nowOpen);
+    h3.setAttribute('aria-expanded', nowOpen ? 'true' : 'false');
+  }
+
+  h3.addEventListener('click', toggle);
+  h3.addEventListener('keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    }
+  });
+
+  // Auto-close after clicking a TOC link on mobile
+  sidebar.addEventListener('click', function (e) {
+    if (!mq.matches) return;
+    var a = e.target.closest && e.target.closest('a');
+    if (a && sidebar.contains(a)) {
+      sidebar.classList.remove('is-open');
+      h3.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  if (mq.addEventListener) mq.addEventListener('change', applyState);
+  else if (mq.addListener) mq.addListener(applyState);
+  applyState();
+})();

--- a/jasiu/granada/urinaria-infecciosas/style.css
+++ b/jasiu/granada/urinaria-infecciosas/style.css
@@ -1,0 +1,185 @@
+/* Palette: Baltic Blue · Cerulean · Alabaster Grey · Yale Blue · Sky Blue Light */
+:root{
+  /* Original brand variables remapped to the new palette */
+  --navy:#16425b;          /* yale-blue (darkest) */
+  --primary:#2f6690;       /* baltic-blue */
+  --primary-dark:#1e5577;  /* interpolated yale↔baltic for gradient depth */
+  --primary-mid:#3a7ca5;   /* cerulean */
+  --secondary:#3a7ca5;     /* cerulean */
+  --sky:#81c3d7;           /* sky-blue-light */
+  --light:#d9e8ee;         /* pale sky tint for backgrounds */
+  --lighter:#eef4f7;       /* paler still */
+  --bg:#f7f9fa;            /* near-white with slight cool tint */
+  --card:#ffffff;
+  --text:#0f172a;
+  --muted:#5a7382;
+  --border:#c5ccc8;        /* alabaster-grey deeper */
+  --soft-border:#d9dcd6;   /* alabaster-grey */
+  --amber:#f59e0b; --amber-light:#fef3c7;
+  --green:#10b981; --green-light:#d1fae5;
+  --red:#dc2626; --red-light:#fee2e2;
+  --purple:#7c3aed;
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{margin:0;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.65;font-size:15.5px}
+.hero{background:linear-gradient(135deg,var(--navy) 0%,var(--primary) 50%,var(--secondary) 100%);color:#fff;padding:48px 40px 56px;box-shadow:0 8px 28px rgba(22,66,91,.28)}
+.hero h1{margin:0 0 8px;font-size:38px;font-weight:700;letter-spacing:-.5px}
+.hero .subtitle{font-size:17px;opacity:.93;margin-bottom:18px}
+.hero-meta{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px}
+.chip{display:inline-flex;align-items:center;gap:6px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.3);padding:6px 14px;border-radius:20px;font-size:13px;backdrop-filter:blur(4px)}
+
+.wrap{display:grid;grid-template-columns:280px 1fr;gap:24px;max-width:1400px;margin:0 auto;padding:24px 32px 80px}
+@media (max-width:1100px){
+  .wrap{grid-template-columns:1fr;padding:16px}
+  .sidebar{position:static;max-height:none}
+
+  /* Collapsible TOC on mobile/tablet */
+  .sidebar.is-collapsible h3{
+    cursor:pointer;user-select:none;display:flex;align-items:center;
+    justify-content:space-between;gap:8px;margin-bottom:0;
+    border-bottom:none;padding-bottom:0;
+  }
+  .sidebar.is-collapsible h3::after{
+    content:"▼";font-size:11px;color:var(--primary);
+    transition:transform .25s ease;flex-shrink:0;
+  }
+  .sidebar.is-collapsible.is-open h3{
+    margin-bottom:12px;padding-bottom:8px;border-bottom:2px solid var(--light);
+  }
+  .sidebar.is-collapsible.is-open h3::after{transform:rotate(180deg)}
+  .sidebar.is-collapsible h3:hover{color:var(--primary)}
+  .sidebar.is-collapsible h3:focus-visible{outline:2px solid var(--primary);outline-offset:2px;border-radius:4px}
+
+  .sidebar.is-collapsible > .toc-search,
+  .sidebar.is-collapsible > ol{display:none}
+  .sidebar.is-collapsible.is-open > .toc-search{display:block}
+  .sidebar.is-collapsible.is-open > ol{display:block}
+}
+
+.sidebar{position:sticky;top:16px;align-self:start;max-height:calc(100vh - 32px);overflow-y:auto;background:var(--card);border:1px solid var(--soft-border);border-radius:14px;padding:18px 16px;box-shadow:0 2px 12px rgba(22,66,91,.08)}
+.sidebar h3{margin:0 0 12px;color:var(--primary-dark);font-size:13px;text-transform:uppercase;letter-spacing:1.2px;border-bottom:2px solid var(--light);padding-bottom:8px}
+.sidebar ol{list-style:none;padding:0;margin:0}
+.sidebar li{font-size:13.5px;margin:2px 0}
+.sidebar a{color:var(--muted);text-decoration:none;display:block;padding:5px 8px;border-radius:6px;border-left:3px solid transparent;transition:all .15s}
+.sidebar a:hover{background:var(--lighter);color:var(--primary);border-left-color:var(--primary)}
+.sidebar .group-title{font-weight:700;color:var(--navy);font-size:11.5px;text-transform:uppercase;letter-spacing:1px;margin:14px 0 4px 8px;padding-top:8px;border-top:1px dashed var(--border)}
+.sidebar .group-title:first-of-type{border-top:none;padding-top:0}
+
+main{min-width:0}
+.bloque-banner{background:linear-gradient(120deg,var(--primary-dark),var(--primary));color:#fff;padding:24px 28px;border-radius:14px;margin:32px 0 24px;box-shadow:0 4px 18px rgba(47,102,144,.28)}
+.bloque-banner h2{margin:0;font-size:26px;font-weight:700}
+.bloque-banner .b-sub{opacity:.9;font-size:14px;margin-top:4px}
+
+.card{background:var(--card);border:1px solid var(--soft-border);border-radius:14px;padding:28px 32px;margin:0 0 24px;box-shadow:0 2px 10px rgba(22,66,91,.06);scroll-margin-top:16px}
+.card h2.section-title{margin:0 0 6px;color:var(--primary-dark);font-size:24px;font-weight:700;letter-spacing:-.3px;display:flex;align-items:center;gap:12px}
+.card h2.section-title .num{display:inline-flex;align-items:center;justify-content:center;width:36px;height:36px;background:linear-gradient(135deg,var(--primary),var(--sky));color:#fff;border-radius:10px;font-size:16px;font-weight:700;flex-shrink:0}
+.card h3{color:var(--primary-dark);font-size:18px;margin:24px 0 10px;padding-left:12px;border-left:4px solid var(--secondary)}
+.card h4{color:var(--primary);font-size:16px;margin:18px 0 8px}
+
+.box{border-radius:12px;padding:16px 20px;margin:14px 0;position:relative;border-left:5px solid}
+.box-title{font-weight:700;font-size:13px;text-transform:uppercase;letter-spacing:1px;margin-bottom:8px;display:flex;align-items:center;gap:8px}
+.box-title .icon{display:inline-flex;align-items:center;justify-content:center;width:24px;height:24px;border-radius:50%;font-size:14px;font-weight:700}
+.box-resumen{background:var(--lighter);border-left-color:var(--primary)}
+.box-resumen .box-title{color:var(--primary-dark)}
+.box-resumen .icon{background:var(--primary);color:#fff}
+.box-clave{background:#e8f4f8;border-left-color:var(--sky)}
+.box-clave .box-title{color:#1e5577}
+.box-clave .icon{background:var(--sky);color:#fff}
+.box-mnemo{background:#fffbeb;border-left-color:var(--amber)}
+.box-mnemo .box-title{color:#b45309}
+.box-mnemo .icon{background:var(--amber);color:#fff}
+.box-warning{background:var(--red-light);border-left-color:var(--red)}
+.box-warning .box-title{color:#991b1b}
+.box-warning .icon{background:var(--red);color:#fff}
+.box-tip{background:var(--green-light);border-left-color:var(--green)}
+.box-tip .box-title{color:#065f46}
+.box-tip .icon{background:var(--green);color:#fff}
+.box ul{margin:6px 0;padding-left:22px}
+.box li{margin:4px 0}
+
+.table-wrap{overflow-x:auto;margin:14px 0;border-radius:10px;border:1px solid var(--soft-border)}
+table{width:100%;border-collapse:collapse;font-size:14px;background:#fff}
+table th{background:linear-gradient(135deg,var(--primary-dark),var(--primary));color:#fff;padding:11px 12px;text-align:left;font-weight:600;font-size:13px;letter-spacing:.3px}
+table td{padding:10px 12px;border-top:1px solid var(--soft-border);vertical-align:top}
+table tr:nth-child(even) td{background:var(--lighter)}
+table tr:hover td{background:#dde7ee}
+
+details.qa{background:var(--card);border:1px solid var(--soft-border);border-radius:10px;margin:10px 0;overflow:hidden;transition:all .2s}
+details.qa[open]{border-color:var(--secondary);box-shadow:0 2px 12px rgba(58,124,165,.18)}
+details.qa summary{cursor:pointer;padding:12px 16px;font-weight:600;color:var(--primary-dark);background:var(--lighter);list-style:none;display:flex;align-items:center;gap:10px;font-size:14px}
+details.qa summary::-webkit-details-marker{display:none}
+details.qa summary::before{content:"▶";font-size:10px;color:var(--secondary);transition:transform .2s}
+details.qa[open] summary::before{transform:rotate(90deg)}
+details.qa summary:hover{background:#cfe1ea}
+.qa-body{padding:14px 18px;font-size:14.5px}
+.qa-body .answer{margin-top:8px;padding:10px 14px;background:var(--green-light);border-left:4px solid var(--green);border-radius:6px}
+.qa-body .answer strong{color:#065f46}
+
+.kv-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:10px;margin:14px 0}
+.kv{background:var(--lighter);border:1px solid var(--light);border-radius:8px;padding:10px 14px}
+.kv .k{display:block;font-size:11.5px;text-transform:uppercase;letter-spacing:1px;color:var(--primary);font-weight:700;margin-bottom:3px}
+.kv .v{font-size:14px;color:var(--text)}
+
+strong{color:var(--navy);font-weight:700}
+em{color:var(--primary-mid);font-style:normal;font-weight:600}
+code{background:var(--light);color:var(--navy);padding:1px 6px;border-radius:4px;font-size:.93em;font-family:"SF Mono","Monaco","Consolas",monospace}
+.tag{display:inline-block;padding:1px 8px;background:var(--primary);color:#fff;border-radius:4px;font-size:12px;font-weight:600;margin:0 2px}
+.tag.danger{background:var(--red)}
+.tag.warn{background:var(--amber)}
+.tag.ok{background:var(--green)}
+ul,ol{padding-left:24px}
+li{margin:3px 0}
+hr{border:none;height:1px;background:linear-gradient(90deg,transparent,var(--border),transparent);margin:30px 0}
+
+footer{text-align:center;padding:30px 16px;color:var(--muted);font-size:13px;border-top:1px solid var(--soft-border);margin-top:40px}
+
+@media print{.sidebar{display:none}.wrap{grid-template-columns:1fr;padding:0}.card{box-shadow:none;page-break-inside:avoid;border:1px solid #ccc}.hero{background:#16425b !important;-webkit-print-color-adjust:exact;print-color-adjust:exact}details.qa[open] .qa-body{display:block}details.qa summary::before{display:none}details.qa{page-break-inside:avoid}}
+
+.compare{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin:14px 0}
+.compare>div{background:var(--lighter);border:1px solid var(--light);border-radius:10px;padding:14px 16px}
+.compare h4{margin-top:0;margin-bottom:8px}
+.compare ul{margin:0;padding-left:20px}
+@media (max-width:700px){
+  body{font-size:14.5px;line-height:1.6}
+  .hero{padding:28px 18px 32px}
+  .hero h1{font-size:24px;letter-spacing:-.3px}
+  .hero .subtitle{font-size:13px;margin-bottom:12px}
+  .hero-meta{gap:6px;margin-top:12px}
+  .chip{font-size:11px;padding:4px 9px;gap:4px}
+  .wrap{padding:12px 10px 50px;gap:14px}
+  .sidebar{padding:12px 10px;border-radius:10px;max-height:none;position:static}
+  .sidebar h3{font-size:12px;margin-bottom:8px}
+  .sidebar li{font-size:13px}
+  .sidebar a{padding:6px 8px}
+  .bloque-banner{padding:16px 16px;margin:22px 0 16px;border-radius:10px}
+  .bloque-banner h2{font-size:19px}
+  .bloque-banner .b-sub{font-size:13px}
+  .card{padding:18px 14px;border-radius:10px;margin:0 0 16px}
+  .card h2.section-title{font-size:18px;gap:8px}
+  .card h2.section-title .num{width:28px;height:28px;font-size:13px;border-radius:7px}
+  .card h3{font-size:15.5px;margin:18px 0 8px;padding-left:10px;border-left-width:3px}
+  .card h4{font-size:14.5px;margin:14px 0 6px}
+  .box{padding:12px 14px;margin:10px 0;border-radius:9px;border-left-width:4px}
+  .box-title{font-size:12px;letter-spacing:.6px}
+  .box-title .icon{width:20px;height:20px;font-size:12px}
+  .box ul{padding-left:18px}
+  table{font-size:13px}
+  table th{padding:8px 9px;font-size:12px}
+  table td{padding:8px 9px}
+  details.qa{margin:8px 0;border-radius:8px}
+  details.qa summary{padding:10px 12px;font-size:13.2px;gap:8px}
+  .qa-body{padding:12px 14px;font-size:13.5px}
+  .q{padding:9px 12px;font-size:13.5px}
+  .kv-grid{grid-template-columns:1fr;gap:8px}
+  .kv{padding:9px 12px}
+  .compare{grid-template-columns:1fr;gap:10px}
+  .compare > div{padding:12px 14px}
+  footer{padding:22px 12px;font-size:12.5px;margin-top:24px}
+}
+
+.toc-search{position:relative;margin-bottom:10px}
+.toc-search input{width:100%;padding:8px 10px 8px 30px;border:1px solid var(--border);border-radius:8px;font-size:13px}
+.toc-search::before{content:"🔍";position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:12px;opacity:.6}
+:target{animation:flash 1.2s ease}
+@keyframes flash{0%{background:#fef3c7}100%{background:transparent}}

--- a/jasiu/index.html
+++ b/jasiu/index.html
@@ -1,0 +1,430 @@
+<!DOCTYPE html>
+<html lang="pl" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cześć Jasiu 💙</title>
+    <meta name="description" content="Mały zakątek internetu, tylko dla Jasia.">
+    <meta name="robots" content="noindex, nofollow">
+
+    <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg?v=2">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+
+    <link rel="stylesheet" href="../css/styles.css">
+
+    <style>
+        /* =====================================================================
+           Jasiu landing page — Blue palette override
+           Palette: Baltic Blue · Cerulean · Alabaster · Yale Blue · Sky Blue Light
+           ===================================================================== */
+
+        [data-theme="dark"] {
+            --bg-primary: #0a1f2b;
+            --bg-secondary: #16425b;
+            --bg-tertiary: #1e5577;
+            --accent-primary: #81c3d7;
+            --accent-secondary: #3a7ca5;
+            --accent-tertiary: #2f6690;
+            --text-heading: #ecf2f6;
+            --text-primary: #c5d8e0;
+            --text-secondary: #94adb8;
+            --text-muted: #6d8590;
+            --border: rgba(129, 195, 215, 0.15);
+            --border-hover: rgba(129, 195, 215, 0.4);
+            --shadow-nav: 0 10px 30px -10px rgba(10, 31, 43, 0.7);
+            --shadow-card: 0 10px 30px -15px rgba(0, 0, 0, 0.3);
+            --glow: 0 0 20px rgba(129, 195, 215, 0.3);
+        }
+
+        [data-theme="light"] {
+            --bg-primary: #f3f6f1;
+            --bg-secondary: #ffffff;
+            --bg-tertiary: #e2eaeb;
+            --accent-primary: #2f6690;
+            --accent-secondary: #16425b;
+            --accent-tertiary: #3a7ca5;
+            --text-heading: #0d2230;
+            --text-primary: #1e3a4b;
+            --text-secondary: #3d5664;
+            --text-muted: #6c8390;
+            --border: rgba(47, 102, 144, 0.15);
+            --border-hover: rgba(47, 102, 144, 0.4);
+            --shadow-nav: 0 10px 30px -10px rgba(13, 34, 48, 0.08);
+            --shadow-card: 0 10px 30px -15px rgba(13, 34, 48, 0.12);
+            --glow: 0 0 20px rgba(47, 102, 144, 0.15);
+        }
+
+        :root {
+            --gradient-primary: linear-gradient(135deg, #2f6690, #3a7ca5, #81c3d7);
+            --gradient-accent: linear-gradient(135deg, #3a7ca5, #81c3d7);
+        }
+
+        /* =====================================================================
+           Layout tweaks for the Jasiu hero
+           ===================================================================== */
+
+        .jasiu-hero {
+            min-height: auto;
+            padding: 180px 40px 80px;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+        }
+
+        .jasiu-hero .hero-badge {
+            justify-content: center;
+        }
+
+        .jasiu-hero h1 {
+            font-size: clamp(2.5rem, 6vw, 4.5rem);
+            font-weight: 700;
+            line-height: 1.15;
+            margin-bottom: 1.5rem;
+            color: var(--text-heading);
+        }
+
+        /* Override main stylesheet: keep .name inline (no forced line break) and no gradient */
+        .jasiu-hero h1 .name {
+            display: inline;
+            background: none;
+            -webkit-background-clip: unset;
+            -webkit-text-fill-color: unset;
+            background-clip: unset;
+            color: var(--accent-primary);
+        }
+
+        .jasiu-hero p.hero-description {
+            max-width: 640px;
+            margin: 0 auto;
+        }
+
+        /* Hide the auto "01." numbering on nav links (used on main portfolio only) */
+        .jasiu-nav .nav-links a::before {
+            content: none;
+        }
+
+        /* =====================================================================
+           Card grid
+           ===================================================================== */
+
+        .jasiu-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 1.5rem;
+        }
+
+        .jasiu-card {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            padding: 2rem;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            text-decoration: none;
+            color: inherit;
+            transition: var(--transition);
+            overflow: hidden;
+        }
+
+        .jasiu-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 3px;
+            background: var(--gradient-primary);
+            transform: scaleX(0);
+            transform-origin: left;
+            transition: transform 0.4s ease;
+        }
+
+        .jasiu-card:hover {
+            transform: translateY(-6px);
+            border-color: var(--border-hover);
+            box-shadow: var(--shadow-card);
+        }
+
+        .jasiu-card:hover::before {
+            transform: scaleX(1);
+        }
+
+        .jasiu-card-icon {
+            font-size: 2.5rem;
+            line-height: 1;
+            margin-bottom: 1rem;
+        }
+
+        .jasiu-card-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--text-heading);
+            margin-bottom: 0.5rem;
+            transition: var(--transition);
+        }
+
+        .jasiu-card:hover .jasiu-card-title {
+            color: var(--accent-primary);
+        }
+
+        .jasiu-card-description {
+            font-size: 0.95rem;
+            color: var(--text-secondary);
+            line-height: 1.5;
+            flex-grow: 1;
+        }
+
+        .jasiu-card-meta {
+            margin-top: 1.25rem;
+            font-family: var(--font-mono);
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .jasiu-card-meta .arrow {
+            transition: transform 0.25s ease;
+        }
+
+        .jasiu-card:hover .jasiu-card-meta .arrow {
+            transform: translateX(4px);
+            color: var(--accent-primary);
+        }
+
+        /* =====================================================================
+           Group heading (e.g. "Granada", future groups...)
+           ===================================================================== */
+
+        .jasiu-group {
+            margin-top: 3rem;
+        }
+
+        .jasiu-group:first-of-type {
+            margin-top: 0;
+        }
+
+        .jasiu-group-header {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .jasiu-group-title {
+            font-family: var(--font-mono);
+            font-size: 0.95rem;
+            font-weight: 500;
+            color: var(--accent-primary);
+            text-transform: uppercase;
+            letter-spacing: 0.15em;
+            white-space: nowrap;
+        }
+
+        .jasiu-group-line {
+            flex: 1;
+            height: 1px;
+            background: var(--border);
+        }
+
+        /* =====================================================================
+           Mobile breakpoints
+           ===================================================================== */
+
+        @media (max-width: 768px) {
+            .jasiu-hero {
+                padding: 120px 24px 60px;
+            }
+
+            .jasiu-hero h1 {
+                font-size: clamp(2rem, 9vw, 3rem);
+                margin-bottom: 1rem;
+            }
+
+            .jasiu-hero p.hero-description {
+                font-size: 1rem;
+                line-height: 1.6;
+            }
+
+            .jasiu-group {
+                margin-top: 2.5rem;
+            }
+
+            .jasiu-group-header {
+                margin-bottom: 1.25rem;
+            }
+
+            .jasiu-group-title {
+                font-size: 0.8rem;
+                letter-spacing: 0.12em;
+            }
+
+            .jasiu-grid {
+                grid-template-columns: 1fr;
+                gap: 1rem;
+            }
+
+            .jasiu-card {
+                padding: 1.5rem;
+            }
+
+            .jasiu-card-icon {
+                font-size: 2rem;
+                margin-bottom: 0.75rem;
+            }
+
+            .jasiu-card-title {
+                font-size: 1.1rem;
+            }
+
+            footer {
+                padding: 30px 20px;
+                font-size: 0.85rem;
+            }
+        }
+
+        @media (max-width: 420px) {
+            .jasiu-hero {
+                padding: 100px 18px 48px;
+            }
+
+            .jasiu-card {
+                padding: 1.25rem;
+            }
+        }
+    </style>
+</head>
+
+<body>
+
+    <nav id="navbar" class="jasiu-nav">
+        <div class="nav-container">
+            <a href="#" class="nav-logo">J</a>
+        </div>
+    </nav>
+
+    <section class="hero jasiu-hero">
+        <div class="hero-content">
+            <p class="hero-badge">Mały zakątek internetu</p>
+            <h1>
+                Cześć, <span class="name">Jasiu</span>!
+            </h1>
+            <p class="hero-description">
+                Tutaj znajdziesz wszystko, co dla Ciebie przygotowałem. Kliknij kartę poniżej,
+                żeby otworzyć stronę. Dodaj tę stronę do zakładek i wracaj, kiedy tylko zechcesz. 💙
+            </p>
+        </div>
+    </section>
+
+    <section id="pages">
+        <div class="section-container">
+            <div class="section-header">
+                <h2 class="section-title">Twoje strony</h2>
+            </div>
+
+            <!--
+                =====================================================================
+                JAK DODAĆ NOWĄ STRONĘ
+                =====================================================================
+                1. Wrzuć pliki strony do nowego folderu wewnątrz /jasiu/
+                     np. jasiu/granada/nowy-temat/index.html
+                2. Skopiuj jeden z bloków <a class="jasiu-card"> poniżej i zaktualizuj:
+                       - href     -> ścieżka do folderu (np. "granada/nowy-temat/")
+                       - icon     -> dowolne emoji
+                       - title    -> krótka nazwa
+                       - desc     -> jednolinijkowy opis
+                       - meta     -> rok, uczelnia, data (opcjonalnie)
+                3. Commit & push. GitHub Pages opublikuje stronę w ciągu ~1 minuty.
+                =====================================================================
+            -->
+            <div class="jasiu-group">
+                <div class="jasiu-group-header">
+                    <span class="jasiu-group-title">🇪🇸 Granada</span>
+                    <span class="jasiu-group-line"></span>
+                </div>
+
+                <div class="jasiu-grid">
+
+                    <a href="granada/urinaria-infecciosas/" class="jasiu-card reveal">
+                        <div class="jasiu-card-icon">🩺</div>
+                        <div class="jasiu-card-title">Patología Urinaria y Enf. Infecciosas</div>
+                        <p class="jasiu-card-description">
+                            Urologia, nefrologia i choroby zakaźne — kompletne notatki
+                            z ponad 200 rozwiązanymi pytaniami.
+                        </p>
+                        <div class="jasiu-card-meta">
+                            <span>4. rok · UGR</span>
+                            <span class="arrow">→</span>
+                        </div>
+                    </a>
+
+                    <a href="granada/osteoarticular-sistemicas/" class="jasiu-card reveal">
+                        <div class="jasiu-card-icon">📚</div>
+                        <div class="jasiu-card-title">Patología Osteoarticular y Enf. Sistémicas</div>
+                        <p class="jasiu-card-description">
+                            Choroby układowe, reumatologia i traumatologia — kompletne
+                            notatki z ponad 200 rozwiązanymi pytaniami.
+                        </p>
+                        <div class="jasiu-card-meta">
+                            <span>5. rok · UGR</span>
+                            <span class="arrow">→</span>
+                        </div>
+                    </a>
+
+                    <!--
+                        Szablon karty — skopiuj, wklej i edytuj:
+
+                    <a href="ŚCIEŻKA/" class="jasiu-card reveal">
+                        <div class="jasiu-card-icon">📄</div>
+                        <div class="jasiu-card-title">Tytuł strony</div>
+                        <p class="jasiu-card-description">
+                            Krótki opis tego, co jest w środku.
+                        </p>
+                        <div class="jasiu-card-meta">
+                            <span>otwórz stronę</span>
+                            <span class="arrow">→</span>
+                        </div>
+                    </a>
+                    -->
+
+                </div>
+            </div>
+
+            <!--
+                Aby dodać kolejną grupę (np. inna uczelnia, inny temat), skopiuj
+                cały blok <div class="jasiu-group"> ... </div> powyżej i zmień tytuł.
+            -->
+        </div>
+    </section>
+
+    <footer>
+        <p>
+            Zrobione z 💙 dla Jasia
+        </p>
+    </footer>
+
+    <button class="theme-toggle" id="theme-toggle" aria-label="Zmień motyw">
+        <svg class="sun-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="12" cy="12" r="5" />
+            <path
+                d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+        <svg class="moon-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+    </button>
+
+    <script src="../js/main.js"></script>
+</body>
+
+</html>


### PR DESCRIPTION
- Landing page at /jasiu/ with blue palette (Baltic/Yale/Cerulean), dark/light theme toggle, Polish copy, and responsive card grid
- /jasiu/granada/ groups two Spanish-language med school skrypts (urinaria-infecciosas, osteoarticular-sistemicas) — each with extracted CSS/JS, palette-matched theming, mobile breakpoints, and a TOC sidebar that collapses on small screens
- Hidden from main site, marked noindex via meta robots